### PR TITLE
`generate` without colors

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,11 +1,9 @@
-var cardinal = require('cardinal');
-
 exports.swagger = true;
 exports.login = false;
 exports.desc = "Output your Swagger file";
 exports.category = "utility";
 
 exports.run = function(config, info) {
-  console.log(cardinal.highlight(JSON.stringify(info.swagger, undefined, 2)));
+  console.log(JSON.stringify(info.swagger, undefined, 2));
   process.exit();
 };

--- a/lib/print.js
+++ b/lib/print.js
@@ -1,0 +1,11 @@
+var cardinal = require('cardinal');
+
+exports.swagger = true;
+exports.login = false;
+exports.desc = "Output your Swagger file";
+exports.category = "utility";
+
+exports.run = function(config, info) {
+  console.log(cardinal.highlight(JSON.stringify(info.swagger, undefined, 2)));
+  process.exit();
+};


### PR DESCRIPTION
Hello!

I'm using this package and a colorized `generate` breaks my json files. And currently, it is the only way to regenerate a file without running `init` all the time.

So I added a new `print` method to pretty print the output and kept `generate` as simple as possible.

What do you think?