### PR TITLE
Add --path parameter

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -28,8 +28,13 @@ exports.findSwagger = function(info, cb) {
   var base = exports.isSwagger(_.last(info.args))
     ? _.last(info.args)
     : undefined;
+  
+  var path = "**/*";
+  if (info.opts.path) {
+    path = info.opts.path.replace(/\/$/, "") + '/*';
+  }
 
-  swaggerInline("**/*", {
+  swaggerInline(path, {
     format: ".json",
     metadata: true,
     base: base


### PR DESCRIPTION
Hi,

This PR is adding optional `--path` parameter to specify which directory SwaggerInline will scan, 
rather than scanning the whole directory, specifying which directory to scan can be way faster sometimes.