### PR TITLE
Properly sorting generated JSON Schema representations

### DIFF
--- a/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parameter type support and sorting should return with a json schema for each parameter type (body instead of formData) 1`] = `
+Array [
+  Object {
+    "label": "Path Params",
+    "schema": Object {
+      "properties": Object {
+        "path parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "path",
+  },
+  Object {
+    "label": "Query Params",
+    "schema": Object {
+      "properties": Object {
+        "query parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "query",
+  },
+  Object {
+    "label": "Body Params",
+    "schema": Object {
+      "properties": Object {
+        "a": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "type": "body",
+  },
+  Object {
+    "label": "Cookie Params",
+    "schema": Object {
+      "properties": Object {
+        "cookie parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "cookie",
+  },
+  Object {
+    "label": "Headers",
+    "schema": Object {
+      "properties": Object {
+        "header parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "header",
+  },
+]
+`;
+
+exports[`parameter type support and sorting should return with a json schema for each parameter type (formData instead of body) 1`] = `
+Array [
+  Object {
+    "label": "Path Params",
+    "schema": Object {
+      "properties": Object {
+        "path parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "path",
+  },
+  Object {
+    "label": "Query Params",
+    "schema": Object {
+      "properties": Object {
+        "query parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "query",
+  },
+  Object {
+    "label": "Cookie Params",
+    "schema": Object {
+      "properties": Object {
+        "cookie parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "cookie",
+  },
+  Object {
+    "label": "Form Data",
+    "schema": Object {
+      "properties": Object {
+        "a": Object {
+          "type": "string",
+        },
+      },
+      "type": "object",
+    },
+    "type": "formData",
+  },
+  Object {
+    "label": "Headers",
+    "schema": Object {
+      "properties": Object {
+        "header parameter": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [],
+      "type": "object",
+    },
+    "type": "header",
+  },
+]
+`;

--- a/src/lib/parameters-to-json-schema.js
+++ b/src/lib/parameters-to-json-schema.js
@@ -1,6 +1,8 @@
 const getSchema = require('./get-schema');
 const findSchemaDefinition = require('./find-schema-definition');
 
+// The order of this object determines how they will be sorted in the compiled JSON Schema
+// representation.
 // https://github.com/OAI/OpenAPI-Specification/blob/4875e02d97048d030de3060185471b9f9443296c/versions/3.0.md#parameterObject
 const types = {
   path: 'Path Params',
@@ -112,9 +114,13 @@ module.exports = (pathOperation, oas) => {
   const hasParameters = !!(pathOperation.parameters && pathOperation.parameters.length !== 0);
   if (!hasParameters && !hasRequestBody && !hasCommonParameters(pathOperation)) return null;
 
+  const typeKeys = Object.keys(types);
   return [getBodyParam(pathOperation, oas)]
     .concat(...getOtherParams(pathOperation, oas))
-    .filter(Boolean);
+    .filter(Boolean)
+    .sort((a, b) => {
+      return typeKeys.indexOf(a.type) - typeKeys.indexOf(b.type);
+    });
 };
 
 // Exported for use in oas-to-har for default values object


### PR DESCRIPTION
This resolves a bug in our parameter to JSON Schema compilation where body params would always be at the top of the stack instead of the intended ordering of: `path`, `query`, `body`, `cookie`, `formData`, and `header`