### PR TITLE
Bug Fix - Query Params

### DIFF
--- a/__tests__/oas.test.js
+++ b/__tests__/oas.test.js
@@ -169,6 +169,22 @@ describe('class.Oas', () => {
         },
       });
     });
+
+    it('should return object if query string is included', () => {
+      const oas = new Oas(petstore);
+      const uri = `http://petstore.swagger.io/v2/pet/findByStatus?test=2`;
+      const method = 'GET';
+
+      const res = oas.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'http://petstore.swagger.io/v2',
+          path: '/pet/findByStatus',
+          slugs: {},
+          method: 'GET',
+        },
+      });
+    });
   });
 });
 
@@ -386,7 +402,7 @@ describe('class.operation', () => {
 
       const logOperation = oas.findOperation(uri, method);
       const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
-      console.log(operation.getHeaders());
+
       expect(operation.getHeaders()).toMatchObject({
         request: ['Cookie', 'Authorization'],
         response: [],

--- a/src/oas.js
+++ b/src/oas.js
@@ -147,11 +147,12 @@ function normalizePath(path) {
 }
 
 function generatePathMatches(paths, pathName, origin) {
+  const prunedPathName = pathName.split('?')[0];
   return Object.keys(paths)
     .map(path => {
       const cleanedPath = normalizePath(path);
       const matchStatement = match(cleanedPath, { decode: decodeURIComponent });
-      const matchResult = matchStatement(pathName);
+      const matchResult = matchStatement(prunedPathName);
       const slugs = {};
 
       if (matchResult && Object.keys(matchResult.params).length) {


### PR DESCRIPTION
Query params were incorrectly being used to generate path match regex. Query strings are now being properly pruned for matching purposes