### PR TITLE
fix: making adjustments to parameters-to-json-schema for newer RJSF versions

### DIFF
--- a/packages/tooling/.npmignore
+++ b/packages/tooling/.npmignore
@@ -1,1 +1,2 @@
 __tests__/
+coverage/

--- a/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -522,17 +522,15 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -548,20 +546,18 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -577,30 +573,28 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -616,14 +610,12 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/primitiveString",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -646,25 +638,23 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -687,31 +677,29 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -734,51 +722,49 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -801,19 +787,17 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -836,25 +820,23 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -877,31 +859,29 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -924,51 +904,49 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -991,19 +969,17 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -1026,25 +1002,23 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1067,31 +1041,29 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1114,51 +1086,49 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1181,19 +1151,17 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -1285,16 +1253,14 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1310,19 +1276,17 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1338,28 +1302,26 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1375,13 +1337,11 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/primitiveString",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -1404,23 +1364,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1443,29 +1401,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1488,47 +1444,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1551,17 +1505,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": false,
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -1584,23 +1536,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1623,29 +1573,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1668,47 +1616,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1731,17 +1677,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": false,
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -1764,23 +1708,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1803,29 +1745,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1848,47 +1788,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1911,17 +1849,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": false,
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -2089,16 +2025,14 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2114,19 +2048,17 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2142,28 +2074,26 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2179,13 +2109,11 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/primitiveString",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },
@@ -2208,23 +2136,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2247,29 +2173,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2292,47 +2216,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2355,17 +2277,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "default": "example default",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },
@@ -2388,23 +2308,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2427,29 +2345,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2472,47 +2388,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2535,17 +2449,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "default": "example default",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },
@@ -2568,23 +2480,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2607,29 +2517,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2652,47 +2560,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2715,17 +2621,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "default": "example default",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -315,12 +315,10 @@ describe('request bodies', () => {
           label: 'Body Params',
           schema: {
             $ref: '#/components/schemas/Pet',
-            definitions: {
-              components: {
-                schemas: {
-                  Pet: {
-                    type: 'string',
-                  },
+            components: {
+              schemas: {
+                Pet: {
+                  type: 'string',
                 },
               },
             },
@@ -366,9 +364,7 @@ describe('request bodies', () => {
           label: 'Body Params',
           schema: {
             $ref: '#/components/schemas/Pet',
-            definitions: {
-              components: oas.components,
-            },
+            components: oas.components,
           },
         },
       ]);

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -42,7 +42,7 @@ function getBodyParam(pathOperation, oas) {
     type,
     label: types[type],
     schema: oas.components
-      ? { definitions: { components: cleanupSchemaDefaults(oas.components) }, ...cleanupSchemaDefaults(schema.schema) }
+      ? { components: cleanupSchemaDefaults(oas.components), ...cleanupSchemaDefaults(schema.schema) }
       : cleanupSchemaDefaults(schema.schema),
   };
 }


### PR DESCRIPTION
The latest version of RJSF no longer requires component schemas to be nestled inside of a `definitions` object, so we need to make this change so we can continue to use `parameters-to-json-schema` within `@readme/api-explorer`.