### PR TITLE
feat: better support for polymorphism

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,274 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
+    "@commitlint/cli": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-8.3.5.tgz",
+      "integrity": "sha512-6+L0vbw55UEdht71pgWOE55SRgb+8OHcEwGDB234VlIBFGK9P2QOBU7MHiYJ5cjdjCQ0rReNrGjOHmJ99jwf0w==",
+      "dev": true,
+      "requires": {
+        "@commitlint/format": "^8.3.4",
+        "@commitlint/lint": "^8.3.5",
+        "@commitlint/load": "^8.3.5",
+        "@commitlint/read": "^8.3.4",
+        "babel-polyfill": "6.26.0",
+        "chalk": "2.4.2",
+        "get-stdin": "7.0.0",
+        "lodash": "4.17.15",
+        "meow": "5.0.0",
+        "resolve-from": "5.0.0",
+        "resolve-global": "1.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@commitlint/config-conventional": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-8.3.4.tgz",
+      "integrity": "sha512-w0Yc5+aVAjZgjYqx29igBOnVCj8O22gy3Vo6Fyp7PwoS7+AYS1x3sN7IBq6i7Ae15Mv5P+rEx1pkxXo5zOMe4g==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "4.2.1"
+      }
+    },
+    "@commitlint/ensure": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-8.3.4.tgz",
+      "integrity": "sha512-8NW77VxviLhD16O3EUd02lApMFnrHexq10YS4F4NftNoErKbKaJ0YYedktk2boKrtNRf/gQHY/Qf65edPx4ipw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.15"
+      }
+    },
+    "@commitlint/execute-rule": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-8.3.4.tgz",
+      "integrity": "sha512-f4HigYjeIBn9f7OuNv5zh2y5vWaAhNFrfeul8CRJDy82l3Y+09lxOTGxfF3uMXKrZq4LmuK6qvvRCZ8mUrVvzQ==",
+      "dev": true
+    },
+    "@commitlint/format": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-8.3.4.tgz",
+      "integrity": "sha512-809wlQ/ND6CLZON+w2Rb3YM2TLNDfU2xyyqpZeqzf2reJNpySMSUAeaO/fNDJSOKIsOsR3bI01rGu6hv28k+Nw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "@commitlint/is-ignored": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-8.3.5.tgz",
+      "integrity": "sha512-Zo+8a6gJLFDTqyNRx53wQi/XTiz8mncvmWf/4oRG+6WRcBfjSSHY7KPVj5Y6UaLy2EgZ0WQ2Tt6RdTDeQiQplA==",
+      "dev": true,
+      "requires": {
+        "semver": "6.3.0"
+      }
+    },
+    "@commitlint/lint": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-8.3.5.tgz",
+      "integrity": "sha512-02AkI0a6PU6rzqUvuDkSi6rDQ2hUgkq9GpmdJqfai5bDbxx2939mK4ZO+7apbIh4H6Pae7EpYi7ffxuJgm+3hQ==",
+      "dev": true,
+      "requires": {
+        "@commitlint/is-ignored": "^8.3.5",
+        "@commitlint/parse": "^8.3.4",
+        "@commitlint/rules": "^8.3.4",
+        "babel-runtime": "^6.23.0",
+        "lodash": "4.17.15"
+      }
+    },
+    "@commitlint/load": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-8.3.5.tgz",
+      "integrity": "sha512-poF7R1CtQvIXRmVIe63FjSQmN9KDqjRtU5A6hxqXBga87yB2VUJzic85TV6PcQc+wStk52cjrMI+g0zFx+Zxrw==",
+      "dev": true,
+      "requires": {
+        "@commitlint/execute-rule": "^8.3.4",
+        "@commitlint/resolve-extends": "^8.3.5",
+        "babel-runtime": "^6.23.0",
+        "chalk": "2.4.2",
+        "cosmiconfig": "^5.2.0",
+        "lodash": "4.17.15",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@commitlint/message": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-8.3.4.tgz",
+      "integrity": "sha512-nEj5tknoOKXqBsaQtCtgPcsAaf5VCg3+fWhss4Vmtq40633xLq0irkdDdMEsYIx8rGR0XPBTukqzln9kAWCkcA==",
+      "dev": true
+    },
+    "@commitlint/parse": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-8.3.4.tgz",
+      "integrity": "sha512-b3uQvpUQWC20EBfKSfMRnyx5Wc4Cn778bVeVOFErF/cXQK725L1bYFvPnEjQO/GT8yGVzq2wtLaoEqjm1NJ/Bw==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^1.3.3",
+        "conventional-commits-parser": "^3.0.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "conventional-changelog-angular": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+          "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+          "dev": true,
+          "requires": {
+            "compare-func": "^1.3.1",
+            "q": "^1.5.1"
+          }
+        }
+      }
+    },
+    "@commitlint/read": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-8.3.4.tgz",
+      "integrity": "sha512-FKv1kHPrvcAG5j+OSbd41IWexsbLhfIXpxVC/YwQZO+FR0EHmygxQNYs66r+GnhD1EfYJYM4WQIqd5bJRx6OIw==",
+      "dev": true,
+      "requires": {
+        "@commitlint/top-level": "^8.3.4",
+        "@marionebl/sander": "^0.6.0",
+        "babel-runtime": "^6.23.0",
+        "git-raw-commits": "^2.0.0"
+      }
+    },
+    "@commitlint/resolve-extends": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-8.3.5.tgz",
+      "integrity": "sha512-nHhFAK29qiXNe6oH6uG5wqBnCR+BQnxlBW/q5fjtxIaQALgfoNLHwLS9exzbIRFqwJckpR6yMCfgMbmbAOtklQ==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^3.0.0",
+        "lodash": "4.17.15",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
+      },
+      "dependencies": {
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+              "dev": true
+            }
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@commitlint/rules": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-8.3.4.tgz",
+      "integrity": "sha512-xuC9dlqD5xgAoDFgnbs578cJySvwOSkMLQyZADb1xD5n7BNcUJfP8WjT9W1Aw8K3Wf8+Ym/ysr9FZHXInLeaRg==",
+      "dev": true,
+      "requires": {
+        "@commitlint/ensure": "^8.3.4",
+        "@commitlint/message": "^8.3.4",
+        "@commitlint/to-lines": "^8.3.4",
+        "babel-runtime": "^6.23.0"
+      }
+    },
+    "@commitlint/to-lines": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-8.3.4.tgz",
+      "integrity": "sha512-5AvcdwRsMIVq0lrzXTwpbbG5fKRTWcHkhn/hCXJJ9pm1JidsnidS1y0RGkb3O50TEHGewhXwNoavxW9VToscUA==",
+      "dev": true
+    },
+    "@commitlint/top-level": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-8.3.4.tgz",
+      "integrity": "sha512-nOaeLBbAqSZNpKgEtO6NAxmui1G8ZvLG+0wb4rvv6mWhPDzK1GNZkCd8FUZPahCoJ1iHDoatw7F8BbJLg4nDjg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -963,6 +1231,17 @@
         "write-file-atomic": "^2.3.0"
       }
     },
+    "@marionebl/sander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
+      "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1162,6 +1441,12 @@
         "eslint-plugin-unicorn": "^16.0.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1201,6 +1486,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {
@@ -1553,6 +1844,55 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
       "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
       "dev": true
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -2002,6 +2342,12 @@
         "dot-prop": "^3.0.0"
       }
     },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -2061,6 +2407,17 @@
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.2.1.tgz",
+      "integrity": "sha512-vC02KucnkNNap+foDKFm7BVUSDAXktXrUJqGszUuYnt6T0J2azsbYz/w9TDc3VsrW2v6JOtiQWVcgZnporHr4Q==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "lodash": "^4.2.1",
         "q": "^1.5.1"
       }
     },
@@ -3729,6 +4086,15 @@
         "locate-path": "^2.0.0"
       }
     },
+    "find-versions": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "dev": true,
+      "requires": {
+        "semver-regex": "^2.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -4254,6 +4620,15 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
     },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
     "globals": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
@@ -4438,6 +4813,181 @@
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
+      }
+    },
+    "husky": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.3.tgz",
+      "integrity": "sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.5.1",
+        "cosmiconfig": "^6.0.0",
+        "find-versions": "^3.2.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -5907,6 +6457,12 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -6242,6 +6798,15 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         }
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "posix-character-classes": {
@@ -6674,6 +7239,15 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.1"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -6763,6 +7337,18 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
       "dev": true
     },
     "set-blocking": {
@@ -7819,6 +8405,12 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
+    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -8001,6 +8593,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.3"
+      }
     },
     "yargs": {
       "version": "14.2.2",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,18 @@
     "version": "auto-changelog --template compact -v $(node -e \"console.log('v' + require('./lerna.json').version)\") && git add CHANGELOG.md"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.3.5",
+    "@commitlint/config-conventional": "^8.3.4",
     "@readme/eslint-config": "^1.14.0",
     "auto-changelog": "^1.16.2",
     "eslint": "^6.8.0",
+    "husky": "^4.2.3",
     "lerna": "^3.20.2",
     "prettier": "^1.19.1"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   }
 }

--- a/packages/tooling/.npmignore
+++ b/packages/tooling/.npmignore
@@ -1,1 +1,2 @@
 __tests__/
+coverage/

--- a/packages/tooling/__tests__/__fixtures__/lib/json-schema.js
+++ b/packages/tooling/__tests__/__fixtures__/lib/json-schema.js
@@ -107,7 +107,7 @@ module.exports = {
           [scenario]: getScenario(),
         },
       };
-    } else if (complexity === '$oneOf' || complexity === '$allOf' || complexity === '$anyOf') {
+    } else if (complexity === 'oneOf' || complexity === 'allOf' || complexity === 'anyOf') {
       requestBody.content = {
         'application/json': {
           schema: {

--- a/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -522,17 +522,15 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -548,20 +546,18 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -577,30 +573,28 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -616,14 +610,12 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/primitiveString",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -646,25 +638,23 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -687,31 +677,29 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -734,51 +722,49 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -801,19 +787,17 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -836,25 +820,23 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -877,31 +859,29 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -924,51 +904,49 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -991,19 +969,17 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -1026,25 +1002,23 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": true,
+              "default": "",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1067,31 +1041,29 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1114,51 +1086,49 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": true,
-                  "default": "",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": true,
+                "default": "",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": true,
-                      "default": "",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": true,
+                    "default": "",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1181,19 +1151,17 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": true,
+            "default": "",
+            "type": "string",
           },
         },
       },
@@ -1285,16 +1253,14 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1310,19 +1276,17 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1338,28 +1302,26 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1375,13 +1337,11 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/primitiveString",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -1404,23 +1364,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1443,29 +1401,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1488,47 +1444,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1551,17 +1505,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": false,
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -1584,23 +1536,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1623,29 +1573,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1668,47 +1616,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1731,17 +1677,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": false,
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -1764,23 +1708,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "allowEmptyValue": false,
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -1803,29 +1745,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "type": "array",
+                "allowEmptyValue": false,
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -1848,47 +1788,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "allowEmptyValue": false,
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "allowEmptyValue": false,
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "allowEmptyValue": false,
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "allowEmptyValue": false,
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -1911,17 +1849,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "allowEmptyValue": false,
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "allowEmptyValue": false,
+            "type": "string",
           },
         },
       },
@@ -2089,16 +2025,14 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2114,19 +2048,17 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2142,28 +2074,26 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2179,13 +2109,11 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/primitiveString",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },
@@ -2208,23 +2136,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2247,29 +2173,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2292,47 +2216,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2355,17 +2277,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "default": "example default",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },
@@ -2388,23 +2308,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2427,29 +2345,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2472,47 +2388,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2535,17 +2449,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "default": "example default",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },
@@ -2568,23 +2480,21 @@ Array [
           "$ref": "#/components/schemas/arrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayOfPrimitives-1": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+      "components": Object {
+        "schemas": Object {
+          "arrayOfPrimitives-1": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
-            "arrayOfPrimitives-2": Object {
-              "items": Object {
-                "default": "example default",
-                "type": "string",
-              },
-              "type": "array",
+            "type": "array",
+          },
+          "arrayOfPrimitives-2": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
             },
+            "type": "array",
           },
         },
       },
@@ -2607,29 +2517,27 @@ Array [
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "arrayWithAnArrayOfPrimitives-1": Object {
+      "components": Object {
+        "schemas": Object {
+          "arrayWithAnArrayOfPrimitives-1": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
-            "arrayWithAnArrayOfPrimitives-2": Object {
+            "type": "array",
+          },
+          "arrayWithAnArrayOfPrimitives-2": Object {
+            "items": Object {
               "items": Object {
-                "items": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "type": "array",
+                "default": "example default",
+                "type": "string",
               },
               "type": "array",
             },
+            "type": "array",
           },
         },
       },
@@ -2652,47 +2560,45 @@ Array [
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "objectWithPrimitivesAndMixedArrays-1": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+      "components": Object {
+        "schemas": Object {
+          "objectWithPrimitivesAndMixedArrays-1": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
-            "objectWithPrimitivesAndMixedArrays-2": Object {
-              "properties": Object {
-                "param1": Object {
-                  "default": "example default",
-                  "type": "string",
-                },
-                "param2": Object {
+            "type": "object",
+          },
+          "objectWithPrimitivesAndMixedArrays-2": Object {
+            "properties": Object {
+              "param1": Object {
+                "default": "example default",
+                "type": "string",
+              },
+              "param2": Object {
+                "items": Object {
                   "items": Object {
-                    "items": Object {
-                      "default": "example default",
-                      "type": "string",
-                    },
-                    "type": "array",
+                    "default": "example default",
+                    "type": "string",
                   },
                   "type": "array",
                 },
+                "type": "array",
               },
-              "type": "object",
             },
+            "type": "object",
           },
         },
       },
@@ -2715,17 +2621,15 @@ Array [
           "$ref": "#/components/schemas/primitiveString-2",
         },
       ],
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "primitiveString-1": Object {
-              "default": "example default",
-              "type": "string",
-            },
-            "primitiveString-2": Object {
-              "default": "example default",
-              "type": "string",
-            },
+      "components": Object {
+        "schemas": Object {
+          "primitiveString-1": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "primitiveString-2": Object {
+            "default": "example default",
+            "type": "string",
           },
         },
       },

--- a/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -625,12 +625,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$allOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayOfPrimitives-1",
         },
@@ -664,12 +664,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
         },
@@ -709,12 +709,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
         },
@@ -774,12 +774,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$allOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/primitiveString-1",
         },
@@ -807,12 +807,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$anyOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayOfPrimitives-1",
         },
@@ -846,12 +846,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
         },
@@ -891,12 +891,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
         },
@@ -956,12 +956,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$anyOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/primitiveString-1",
         },
@@ -989,19 +989,11 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$oneOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
@@ -1022,25 +1014,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/arrayOfPrimitives-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/arrayOfPrimitives-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
@@ -1067,25 +1059,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
@@ -1132,25 +1124,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`$oneOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "primitiveString-1": Object {
@@ -1165,6 +1157,14 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/primitiveString-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/primitiveString-2",
+        },
+      ],
     },
     "type": "body",
   },
@@ -1351,12 +1351,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$allOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayOfPrimitives-1",
         },
@@ -1388,12 +1388,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
         },
@@ -1431,12 +1431,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
         },
@@ -1492,12 +1492,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$allOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/primitiveString-1",
         },
@@ -1523,12 +1523,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$anyOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayOfPrimitives-1",
         },
@@ -1560,12 +1560,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
         },
@@ -1603,12 +1603,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
         },
@@ -1664,12 +1664,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$anyOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/primitiveString-1",
         },
@@ -1695,19 +1695,11 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$oneOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
@@ -1726,25 +1718,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/arrayOfPrimitives-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/arrayOfPrimitives-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
@@ -1769,25 +1761,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
@@ -1830,25 +1822,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should not add a default when one is missing with usages of \`$oneOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "primitiveString-1": Object {
@@ -1861,6 +1853,14 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/primitiveString-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/primitiveString-2",
+        },
+      ],
     },
     "type": "body",
   },
@@ -2123,12 +2123,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$allOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`allOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayOfPrimitives-1",
         },
@@ -2160,12 +2160,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
         },
@@ -2203,12 +2203,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
         },
@@ -2264,12 +2264,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$allOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`allOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$allOf": Array [
+      "allOf": Array [
         Object {
           "$ref": "#/components/schemas/primitiveString-1",
         },
@@ -2295,12 +2295,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$anyOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`anyOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayOfPrimitives-1",
         },
@@ -2332,12 +2332,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
         },
@@ -2375,12 +2375,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
         },
@@ -2436,12 +2436,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$anyOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`anyOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$anyOf": Array [
+      "anyOf": Array [
         Object {
           "$ref": "#/components/schemas/primitiveString-1",
         },
@@ -2467,19 +2467,11 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$oneOf\` scenario: arrayOfPrimitives 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`oneOf\` scenario: arrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
@@ -2498,25 +2490,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/arrayOfPrimitives-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/arrayOfPrimitives-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
@@ -2541,25 +2533,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
@@ -2602,25 +2594,25 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
+        },
+      ],
     },
     "type": "body",
   },
 ]
 `;
 
-exports[`defaults request bodies should pass through defaults with usages of \`$oneOf\` scenario: primitiveString 1`] = `
+exports[`defaults request bodies should pass through defaults with usages of \`oneOf\` scenario: primitiveString 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
       "components": Object {
         "schemas": Object {
           "primitiveString-1": Object {
@@ -2633,6 +2625,14 @@ Array [
           },
         },
       },
+      "oneOf": Array [
+        Object {
+          "$ref": "#/components/schemas/primitiveString-1",
+        },
+        Object {
+          "$ref": "#/components/schemas/primitiveString-2",
+        },
+      ],
     },
     "type": "body",
   },
@@ -2661,20 +2661,18 @@ Array [
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/Pet",
-      "definitions": Object {
-        "components": Object {
-          "schemas": Object {
-            "Pet": Object {
-              "example": Object {
-                "name": null,
-              },
-              "properties": Object {
-                "name": Object {
-                  "type": "string",
-                },
-              },
-              "type": "object",
+      "components": Object {
+        "schemas": Object {
+          "Pet": Object {
+            "example": Object {
+              "name": null,
             },
+            "properties": Object {
+              "name": Object {
+                "type": "string",
+              },
+            },
+            "type": "object",
           },
         },
       },

--- a/packages/tooling/__tests__/lib/find-schema-definition.test.js
+++ b/packages/tooling/__tests__/lib/find-schema-definition.test.js
@@ -1,4 +1,21 @@
+const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
 const findSchemaDefinition = require('../../src/lib/find-schema-definition');
+
+test('should return a definition for a given ref', () => {
+  expect(findSchemaDefinition('#/components/schemas/Pet', petstore)).toStrictEqual(petstore.components.schemas.Pet);
+});
+
+test('should return a definition for a given ref that is escaped', () => {
+  expect(
+    findSchemaDefinition('#/components/schemas/Pet~1Error', {
+      components: {
+        schemas: {
+          'Pet/Error': petstore.components.schemas.Error,
+        },
+      },
+    })
+  ).toStrictEqual(petstore.components.schemas.Error);
+});
 
 test('should throw an error if there is an invalid ref', () => {
   expect(() => findSchemaDefinition('some-other-ref', {})).toThrow(/Could not find a definition for/);
@@ -6,4 +23,17 @@ test('should throw an error if there is an invalid ref', () => {
 
 test('should throw an error if there is a missing ref', () => {
   expect(() => findSchemaDefinition('#/components/schemas/user', {})).toThrow(/Could not find a definition for/);
+});
+
+test("should throw an error if an escaped ref isn't present its non-escaped format", () => {
+  expect(() => {
+    findSchemaDefinition('#/components/schemas/Pet~1Error', {
+      components: {
+        schemas: {
+          // This should be written in the schema as `Pet/Error`.
+          'Pet~1Error': {},
+        },
+      },
+    });
+  }).toThrow(/Could not find a definition for/);
 });

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -315,12 +315,10 @@ describe('request bodies', () => {
           label: 'Body Params',
           schema: {
             $ref: '#/components/schemas/Pet',
-            definitions: {
-              components: {
-                schemas: {
-                  Pet: {
-                    type: 'string',
-                  },
+            components: {
+              schemas: {
+                Pet: {
+                  type: 'string',
                 },
               },
             },
@@ -366,9 +364,7 @@ describe('request bodies', () => {
           label: 'Body Params',
           schema: {
             $ref: '#/components/schemas/Pet',
-            definitions: {
-              components: oas.components,
-            },
+            components: oas.components,
           },
         },
       ]);

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -473,7 +473,7 @@ describe('required', () => {
 });
 
 describe('defaults', () => {
-  const polymorphismScenarios = ['$oneOf', '$allOf', '$anyOf'];
+  const polymorphismScenarios = ['oneOf', 'allOf', 'anyOf'];
 
   it('should not attempt to recur on `null` data', () => {
     const oas = {

--- a/packages/tooling/package-lock.json
+++ b/packages/tooling/package-lock.json
@@ -5091,6 +5091,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",

--- a/packages/tooling/package-lock.json
+++ b/packages/tooling/package-lock.json
@@ -804,6 +804,12 @@
         "eslint-plugin-unicorn": "^16.0.0"
       }
     },
+    "@readme/oas-examples": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-2.1.1.tgz",
+      "integrity": "sha512-MdEOEvYAWnrKv7aeJPHjnbsevfq+fm6/0AswRznpxeqasV7vDmi/AVbmKZVnPI19zwkC5QOJiI2y6c0rx4XZuw==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@readme/eslint-config": "^1.11.0",
+    "@readme/oas-examples": "^2.1.1",
     "eslint": "^6.6.0",
     "jest": "^25.1.0",
     "prettier": "1.19.1"

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -30,6 +30,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
+    "jsonpointer": "^4.0.1",
     "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {

--- a/packages/tooling/src/lib/find-schema-definition.js
+++ b/packages/tooling/src/lib/find-schema-definition.js
@@ -1,35 +1,21 @@
-// Nabbed from react-jsonschema-form. This is to resolve down one level of $refs
-// if it looks like the schema is in `requestBodies`. This is because
-// react-jsonschema-form does not know how to resolve objects that look like the following
-// to get their actual $ref:
-//
-// { content: { 'application/json': { schema: { $ref: '#/components/schemas/Thing' } } } }
-//
-// Out of this we want to get `'#/components/schemas/Thing'`
-//
-// TODO this should probably be extracted into an npm module
-// https://github.com/mozilla-services/react-jsonschema-form/blob/e0192b75d24024370d52a43293931c8ddd769752/src/utils.js#L384-L404
+// Nabbed from react-jsonschema-form, but this should probably be extracted into a slim NPM module.
+const jsonpointer = require('jsonpointer');
+
 function findSchemaDefinition($ref, definitions = {}) {
-  // Extract and use the referenced definition if we have it.
-  const match = /^#\/(.*)$/.exec($ref);
-  if (match && match[0]) {
-    const parts = match[1].split('/');
-    let current = definitions;
-
-    parts.forEach(part => {
-      if (Object.prototype.hasOwnProperty.call(current, part)) {
-        current = current[part];
-      } else {
-        // No matching definition found, that's an error (bogus schema?)
-        throw new Error(`Could not find a definition for ${$ref}.`);
-      }
-    });
-
-    return current;
+  const origRef = $ref;
+  if ($ref.startsWith('#')) {
+    // Decode URI fragment representation.
+    $ref = decodeURIComponent($ref.substring(1));
+  } else {
+    throw new Error(`Could not find a definition for ${origRef}.`);
   }
 
-  // No matching definition found, that's an error (bogus schema?)
-  throw new Error(`Could not find a definition for ${$ref}.`);
+  const current = jsonpointer.get(definitions, $ref);
+  if (current === undefined) {
+    throw new Error(`Could not find a definition for ${origRef}.`);
+  }
+
+  return current;
 }
 
 module.exports = findSchemaDefinition;

--- a/packages/tooling/src/lib/flatten-schema.js
+++ b/packages/tooling/src/lib/flatten-schema.js
@@ -11,86 +11,88 @@ const getName = (parent, prop) => {
 
 const capitalizeFirstLetter = (string = '') => string.charAt(0).toUpperCase() + string.slice(1);
 
-function flattenObject(obj, parent, level, oas) {
-  return flattenArray(
-    Object.keys(obj.properties).map(prop => {
-      let value = obj.properties[prop];
-      const array = [];
-      if (value.$ref) {
-        value = findSchemaDefinition(value.$ref, oas);
-      }
-
-      // If `value` doesn't have an explicit `type` declaration, but has `properties` present, then
-      // it's an object and should be treated as one.
-      if (!('type' in value) && value.properties) {
-        value.type = 'object';
-      }
-
-      if (value.type === 'object') {
-        array.push(flattenSchema(value, oas, getName(parent, prop), level + 1));
-      }
-
-      if (value.type === 'array' && value.items) {
-        let { items } = value;
-        if (items.$ref) {
-          items = findSchemaDefinition(items.$ref, oas);
+module.exports = (schema, oas) => {
+  function flattenObject(obj, parent, level) {
+    return flattenArray(
+      Object.keys(obj.properties).map(prop => {
+        let value = obj.properties[prop];
+        const array = [];
+        if (value.$ref) {
+          value = findSchemaDefinition(value.$ref, oas);
         }
 
-        // If `value` doesn't have an explicit `type` declaration, but has `properties` present,
-        // then it's an object and should be treated as one.
-        if (!('type' in items) && items.properties) {
-          items.type = 'object';
+        // If `value` doesn't have an explicit `type` declaration, but has `properties` present, then
+        // it's an object and should be treated as one.
+        if (!('type' in value) && value.properties) {
+          value.type = 'object';
         }
 
-        if (items.type) {
-          array.push({
-            name: getName(parent, prop),
-            type: `[${capitalizeFirstLetter(items.type)}]`,
-            description: value.description,
-          });
+        if (value.type === 'object') {
+          array.push(flattenSchema(value, getName(parent, prop), level + 1));
         }
 
-        const newParent = parent ? `${parent}.` : '';
-        if (items.type === 'object') {
-          array.push(flattenSchema(items, oas, `${newParent}${prop}[]`, level + 1));
+        if (value.type === 'array' && value.items) {
+          let { items } = value;
+          if (items.$ref) {
+            items = findSchemaDefinition(items.$ref, oas);
+          }
+
+          // If `value` doesn't have an explicit `type` declaration, but has `properties` present,
+          // then it's an object and should be treated as one.
+          if (!('type' in items) && items.properties) {
+            items.type = 'object';
+          }
+
+          if (items.type) {
+            array.push({
+              name: getName(parent, prop),
+              type: `[${capitalizeFirstLetter(items.type)}]`,
+              description: value.description,
+            });
+          }
+
+          const newParent = parent ? `${parent}.` : '';
+          if (items.type === 'object') {
+            array.push(flattenSchema(items, `${newParent}${prop}[]`, level + 1));
+          }
+
+          return array;
         }
+
+        array.unshift({
+          name: getName(parent, prop),
+          type: capitalizeFirstLetter(value.type),
+          description: value.description,
+        });
 
         return array;
-      }
-
-      array.unshift({
-        name: getName(parent, prop),
-        type: capitalizeFirstLetter(value.type),
-        description: value.description,
-      });
-
-      return array;
-    })
-  );
-}
-
-function flattenSchema(obj, oas, parent = '', level = 0) {
-  if (level > 2) {
-    return [];
+      })
+    );
   }
 
-  let newParent;
-  // top level array
-  if (obj.type === 'array' && obj.items) {
-    if (obj.items.$ref) {
-      const value = findSchemaDefinition(obj.items.$ref, oas);
-      return flattenSchema(value, oas);
+  function flattenSchema(obj, parent = '', level = 0) {
+    if (level > 2) {
+      return [];
     }
 
-    newParent = parent ? `${parent}.[]` : '';
-    return flattenSchema(obj.items, oas, `${newParent}`, level + 1);
+    let newParent;
+    // top level array
+    if (obj.type === 'array' && obj.items) {
+      if (obj.items.$ref) {
+        const value = findSchemaDefinition(obj.items.$ref, oas);
+        return flattenSchema(value);
+      }
+
+      newParent = parent ? `${parent}.[]` : '';
+      return flattenSchema(obj.items, `${newParent}`, level + 1);
+    }
+
+    if (obj && !obj.properties) {
+      return [];
+    }
+
+    return flattenObject(obj, parent, level);
   }
 
-  if (obj && !obj.properties) {
-    return [];
-  }
-
-  return flattenObject(obj, parent, level, oas);
-}
-
-module.exports = flattenSchema;
+  return flattenSchema(schema);
+};

--- a/packages/tooling/src/lib/flatten-schema.js
+++ b/packages/tooling/src/lib/flatten-schema.js
@@ -82,13 +82,21 @@ module.exports = (schema, oas) => {
       });
 
       return allof;
-    } else if ('oneOf' in obj) {
-      // We can't merge flatten objects in a `oneOf` representation into a single structure because that wouldn't
-      // validate against one of the objects, so let's just pick the first one present and flatten only that one.
-      return flattenSchema(obj.oneOf.shift());
-    } else if ('anyOf' in obj) {
-      // We can't merge flatten objects in an `anyOf` representation into a single structure because that wouldn't
-      // validate against one of the objects, so let's just pick the first one present and flatten only that one.
+    } else if ('oneOf' in obj || 'anyOf' in obj) {
+      // Since we can't merge flatten objects in a `oneOf` or `anyOf` representation into a single structure, because
+      // that  wouldn't validate against the defined schema, we're instead just pick the first one present and
+      // flattening only that one.
+      //
+      // This work will be somewhat resolved when we start to render response schemas in an improved, non-flattened list
+      // in a future API Explorer redesign, but until then we have no other option other than to have partial
+      // documentation data loss in the frontend.
+      //
+      // See https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/ for full documentation on how
+      // these polymorphism traits work and why we need to have these quirks.
+      if ('oneOf' in obj) {
+        return flattenSchema(obj.oneOf.shift());
+      }
+
       return flattenSchema(obj.anyOf.shift());
     } else if ('$ref' in obj) {
       const value = findSchemaDefinition(obj.$ref, oas);

--- a/packages/tooling/src/lib/flatten-schema.js
+++ b/packages/tooling/src/lib/flatten-schema.js
@@ -84,7 +84,7 @@ module.exports = (schema, oas) => {
       return allof;
     } else if ('oneOf' in obj || 'anyOf' in obj) {
       // Since we can't merge flatten objects in a `oneOf` or `anyOf` representation into a single structure, because
-      // that  wouldn't validate against the defined schema, we're instead just pick the first one present and
+      // that wouldn't validate against the defined schema, we're instead just pick the first one present and
       // flattening only that one.
       //
       // This work will be somewhat resolved when we start to render response schemas in an improved, non-flattened list

--- a/packages/tooling/src/lib/flatten-schema.js
+++ b/packages/tooling/src/lib/flatten-schema.js
@@ -75,6 +75,14 @@ module.exports = (schema, oas) => {
       return [];
     }
 
+    // If we don't actually have an object here, don't try to treat it as one.
+    //
+    // This might happen in the event of a $ref being improperly written as the value of a non-$ref object property.
+    // For example: `"schema": "~paths~/pet~post~requestBody~content~application/json~schema"`.
+    if (obj === null || typeof obj !== 'object') {
+      return [];
+    }
+
     if ('allOf' in obj) {
       let allof = [];
       obj.allOf.forEach(item => {

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -42,7 +42,7 @@ function getBodyParam(pathOperation, oas) {
     type,
     label: types[type],
     schema: oas.components
-      ? { definitions: { components: cleanupSchemaDefaults(oas.components) }, ...cleanupSchemaDefaults(schema.schema) }
+      ? { components: cleanupSchemaDefaults(oas.components), ...cleanupSchemaDefaults(schema.schema) }
       : cleanupSchemaDefaults(schema.schema),
   };
 }


### PR DESCRIPTION
### find-schema-definition
* [x]  Slightly rewriting the tool so it can handle `$ref` pointers that are escaped with `~1` by just using the great [jsonpointer](https://www.npmjs.com/package/jsonpointer) library. 
  * This is mostly the same code that RJSF uses, just without the recursion to call `find-schema-definition` if we find a nested `$ref`. We handle that case in the code that handles `find-schema-definition` in the Explorer, and though they're probably ripe for a rewrite it's fine for now.

### flatten-schema
* [x] Added support for flattening a schema that contains `oneOf`, `allOf`, and `anyOf` polymorphism cases.
  * For `oneOf` and `anyOf` cases, since we can't really flatten down every option defined in those arrays into a single schema that would validate against the document, I'm choosing to just select the first defined object in the set and flatten that out.
* [x] Making a minor adjustment to only attempt to flatten an object if it's actually an object. Previously, we'd throw up a fatal exception on a schema that looks like this:

```json
"application/xml": {
  "schema": "~paths~/pet~post~requestBody~content~application/json~schema"
}
```

### parameters-to-json-schema
* [x] Made updates to stop storing our component schemas inside of a `definitions` object as a recent push to RJSF made this no longer a requirement.