### PR TITLE
fix: resolve issue where a freeform object couldn't be jsonschema

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -474,6 +474,107 @@ describe('required', () => {
   it.todo('should make things required correctly for request bodies');
 });
 
+describe('additionalProperties', () => {
+  describe('parameters', () => {
+    const parameters = [
+      {
+        name: 'param',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+        },
+      },
+    ];
+
+    it('when set to `true`', () => {
+      parameters[0].schema.items.additionalProperties = true;
+
+      expect(parametersToJsonSchema({ parameters })[0].schema.properties.param.items).toStrictEqual({
+        additionalProperties: true,
+        type: 'object',
+      });
+    });
+
+    it('when set to an empty object', () => {
+      parameters[0].schema.items.additionalProperties = {};
+
+      expect(parametersToJsonSchema({ parameters })[0].schema.properties.param.items).toStrictEqual({
+        additionalProperties: {},
+        type: 'object',
+      });
+    });
+
+    it('when set to an object', () => {
+      parameters[0].schema.items.additionalProperties = {
+        type: 'string',
+      };
+
+      expect(parametersToJsonSchema({ parameters })[0].schema.properties.param.items).toStrictEqual({
+        additionalProperties: {
+          type: 'string',
+        },
+        type: 'object',
+      });
+    });
+
+    it('should be ignored when set to `false`', () => {
+      parameters[0].schema.items.additionalProperties = false;
+
+      expect(parametersToJsonSchema({ parameters })[0].schema.properties.param.items).toStrictEqual({
+        type: 'object',
+      });
+    });
+  });
+
+  describe('request bodies', () => {
+    const requestBody = {
+      description: 'Scenario: arrayOfPrimitives:default[undefined]allowEmptyValue[undefined]',
+      content: {
+        'application/json': { schema: { type: 'array', items: { type: 'object' } } },
+      },
+    };
+
+    it('when set to `true`', () => {
+      requestBody.content['application/json'].schema.items.additionalProperties = true;
+      expect(parametersToJsonSchema({ requestBody }, {})[0].schema.items).toStrictEqual({
+        additionalProperties: true,
+        type: 'object',
+      });
+    });
+
+    it('when set to an empty object', () => {
+      requestBody.content['application/json'].schema.items.additionalProperties = {};
+      expect(parametersToJsonSchema({ requestBody }, {})[0].schema.items).toStrictEqual({
+        additionalProperties: {},
+        type: 'object',
+      });
+    });
+
+    it('when set to an object', () => {
+      requestBody.content['application/json'].schema.items.additionalProperties = {
+        type: 'string',
+      };
+
+      expect(parametersToJsonSchema({ requestBody }, {})[0].schema.items).toStrictEqual({
+        additionalProperties: {
+          type: 'string',
+        },
+        type: 'object',
+      });
+    });
+
+    it('should be ignored when set to `false`', () => {
+      requestBody.content['application/json'].schema.items.additionalProperties = false;
+      expect(parametersToJsonSchema({ requestBody }, {})[0].schema.items).toStrictEqual({
+        type: 'object',
+      });
+    });
+  });
+});
+
 describe('defaults', () => {
   it('should not attempt to recur on `null` data', () => {
     const oas = {

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -40,6 +40,11 @@ function getBodyParam(pathOperation, oas) {
       } else if (prop === 'minLength') {
         obj.minimum = obj[prop];
         delete obj[prop];
+      } else if (prop === 'additionalProperties') {
+        // If it's set to `false`, don't bother adding it.
+        if (obj[prop] === false) {
+          delete obj[prop];
+        }
       }
     });
 
@@ -101,12 +106,24 @@ function getOtherParams(pathOperation, oas) {
       schema.items = constructSchema(schema.items);
     } else if (data.type === 'object') {
       schema.type = 'object';
-      schema.properties = {};
 
-      Object.keys(data.properties).map(prop => {
-        schema.properties[prop] = constructSchema(data.properties[prop]);
-        return true;
-      });
+      if ('properties' in data) {
+        schema.properties = {};
+
+        Object.keys(data.properties).map(prop => {
+          schema.properties[prop] = constructSchema(data.properties[prop]);
+          return true;
+        });
+      }
+
+      if ('additionalProperties' in data) {
+        if (typeof data.additionalProperties === 'object' && data.additionalProperties !== null) {
+          schema.additionalProperties = constructSchema(data.additionalProperties);
+        } else if (data.additionalProperties !== false) {
+          // If it's set to `false`, don't bother adding it.
+          schema.additionalProperties = data.additionalProperties;
+        }
+      }
     }
 
     if ('allowEmptyValue' in data) {


### PR DESCRIPTION
If we had an object like the following, `lib/parameters-to-json-schema` would error out because there was no `properties` object set with the object.

```json
{
  "name": "identities",
  "in": "query",
  "schema": {
    "type": "array",
    "items": {
    "type": "object",
    "additionalProperties": true
  }
}
```