### PR TITLE
fix: magically resolving objects that are typod as arrays

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -392,6 +392,86 @@ describe('request bodies', () => {
   });
 });
 
+describe('type', () => {
+  describe('parameters', () => {
+    it('should adjust an object that is typod as an array [README-6R]', () => {
+      const parameters = [
+        {
+          name: 'param',
+          in: 'query',
+          schema: {
+            type: 'array',
+            properties: {
+              type: 'string',
+            },
+          },
+        },
+      ];
+
+      expect(parametersToJsonSchema({ parameters })).toStrictEqual([
+        {
+          label: 'Query Params',
+          schema: {
+            properties: {
+              param: {
+                type: 'array',
+              },
+            },
+            required: [],
+            type: 'object',
+          },
+          type: 'query',
+        },
+      ]);
+    });
+  });
+
+  describe('request bodies', () => {
+    it('should adjust an object that is typod as an array [README-6R]', () => {
+      const oas = {
+        components: {
+          schemas: {
+            updatePets: {
+              required: ['name'],
+              type: 'array',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const schema = parametersToJsonSchema(
+        {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/updatePets',
+                  },
+                  description: '',
+                },
+              },
+            },
+          },
+        },
+        oas
+      );
+
+      expect(schema[0].schema.components.schemas.updatePets).toStrictEqual({
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+        type: 'object',
+      });
+    });
+  });
+});
+
 describe('enums', () => {
   it.todo('should pass through enum on requestBody');
 


### PR DESCRIPTION
Since launching v6 of the Explorer, we've gotten a number of reports come through Sentry of OAS documents being used rendered that have `type: array` when they should be `type: object`. It's no fault of ours, but since we can see that they intended for it to be `type: object` as `properties` and not `items` is present on that schema, we can infer and shape the data into what they intended it to be and avoid any fatal rendering errors.

Resolves README-6R in Sentry.