### PR TITLE
fix: adding some handling to repair malformed OAS arrays

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -394,7 +394,25 @@ describe('request bodies', () => {
 
 describe('type', () => {
   describe('parameters', () => {
-    it('should adjust an object that is typod as an array [README-6R]', () => {
+    it('should repair a malformed array that is missing items [README-8E]', () => {
+      const parameters = [
+        {
+          name: 'param',
+          in: 'query',
+          schema: {
+            type: 'array',
+          },
+        },
+      ];
+
+      expect(parametersToJsonSchema({ parameters })[0].schema).toStrictEqual({
+        properties: { param: { items: {}, type: 'array' } },
+        required: [],
+        type: 'object',
+      });
+    });
+
+    it('should repair a malformed object that is typod as an array [README-6R]', () => {
       const parameters = [
         {
           name: 'param',
@@ -408,26 +426,52 @@ describe('type', () => {
         },
       ];
 
-      expect(parametersToJsonSchema({ parameters })).toStrictEqual([
-        {
-          label: 'Query Params',
-          schema: {
-            properties: {
-              param: {
-                type: 'array',
-              },
-            },
-            required: [],
-            type: 'object',
-          },
-          type: 'query',
-        },
-      ]);
+      expect(parametersToJsonSchema({ parameters })[0].schema).toStrictEqual({
+        properties: { param: { type: 'array' } },
+        required: [],
+        type: 'object',
+      });
     });
   });
 
   describe('request bodies', () => {
-    it('should adjust an object that is typod as an array [README-6R]', () => {
+    it('should repair a malformed array that is missing items [README-8E]', () => {
+      const oas = {
+        components: {
+          schemas: {
+            updatePets: {
+              type: 'array',
+            },
+          },
+        },
+      };
+
+      const schema = parametersToJsonSchema(
+        {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/updatePets',
+                  },
+                  description: '',
+                },
+              },
+            },
+          },
+        },
+        oas
+      );
+
+      expect(schema[0].schema.components.schemas.updatePets).toStrictEqual({
+        items: {},
+        type: 'array',
+      });
+    });
+
+    it('should repair a malformed object that is typod as an array [README-6R]', () => {
       const oas = {
         components: {
           schemas: {

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "pretest": "npm run prettier && npm run lint",
+    "pretest": "npm run lint && npm run prettier",
     "prettier": "prettier --list-different --write \"./**/**.js\"",
     "test": "jest --coverage"
   },


### PR DESCRIPTION
This adds some handling for us to be able to repair potentially malformed `array` schemas that we missing an `items` property. Schemas of this kind don't validate OAS, but we have a number of them in our database as it is and they're causing rendering problems.

https://sentry.io/organizations/readme/issues/1574096195/