### PR TITLE
feat: replacing the core parameters-to-json-schema lib

### DIFF
--- a/packages/tooling/__tests__/__fixtures__/lib/json-schema.js
+++ b/packages/tooling/__tests__/__fixtures__/lib/json-schema.js
@@ -79,20 +79,20 @@ function buildSchemaDefault(opts) {
 }
 
 module.exports = {
-  generateRequestBodyDefaults: (complexity, scenario, opts = { default: undefined, allowEmptyValue: undefined }) => {
-    const generateCaseName = (testCase, allowEmptyValue) => {
-      return `${testCase}:default[${opts.default}]allowEmptyValue[${allowEmptyValue}]`;
+  generateRequestBodyDefaults: (complexity, scenario, opts = { default: undefined }) => {
+    const generateCaseName = testCase => {
+      return `${testCase}:default[${opts.default}]`;
     };
 
     const props = buildSchemaDefault(opts);
     const oas = {};
     const requestBody = {
-      description: `Scenario: ${generateCaseName(scenario, opts.allowEmptyValue)}`,
+      description: `Scenario: ${generateCaseName(scenario)}`,
       content: {},
     };
 
     const getScenario = () => {
-      return schemas[scenario](props, opts.allowEmptyValue);
+      return schemas[scenario](props);
     };
 
     if (complexity === 'simple') {

--- a/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -1,78 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`defaults parameters should comply with the \`allowEmptyValue\` declarative when present with normal non-$ref, non-inheritance, non-polymorphism cases 1`] = `
+exports[`defaults parameters should pas through the \`allowEmptyValue\` declarative with normal non-$ref, non-inheritance, non-polymorphism cases 1`] = `
 Array [
   Object {
     "label": "Query Params",
     "schema": Object {
       "properties": Object {
-        "arrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+        "arrayOfPrimitives:allowEmptyValue[false]default[example default]": Object {
           "items": Object {
             "allowEmptyValue": false,
-            "default": "",
+            "default": "example default",
             "type": "string",
           },
           "type": "array",
         },
-        "arrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+        "arrayOfPrimitives:allowEmptyValue[true]default[example default]": Object {
           "items": Object {
             "allowEmptyValue": true,
-            "default": "",
+            "default": "example default",
             "type": "string",
           },
           "type": "array",
         },
-        "arrayOfPrimitives:default[]": Object {
+        "arrayOfPrimitives:default[example default]": Object {
           "items": Object {
-            "default": "",
+            "default": "example default",
             "type": "string",
           },
           "type": "array",
         },
-        "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+        "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[example default]": Object {
           "items": Object {
             "items": Object {
               "allowEmptyValue": false,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "type": "array",
           },
           "type": "array",
         },
-        "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+        "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[example default]": Object {
           "items": Object {
             "items": Object {
               "allowEmptyValue": true,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "type": "array",
           },
           "type": "array",
         },
-        "arrayWithAnArrayOfPrimitives:default[]": Object {
+        "arrayWithAnArrayOfPrimitives:default[example default]": Object {
           "items": Object {
             "items": Object {
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "type": "array",
           },
           "type": "array",
         },
-        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[]": Object {
+        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[example default]": Object {
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": false,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
                   "allowEmptyValue": false,
-                  "default": "",
+                  "default": "example default",
                   "type": "string",
                 },
                 "type": "array",
@@ -82,18 +82,18 @@ Array [
           },
           "type": "object",
         },
-        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[]": Object {
+        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[example default]": Object {
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": true,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
                   "allowEmptyValue": true,
-                  "default": "",
+                  "default": "example default",
                   "type": "string",
                 },
                 "type": "array",
@@ -103,16 +103,16 @@ Array [
           },
           "type": "object",
         },
-        "objectWithPrimitivesAndMixedArrays:default[]": Object {
+        "objectWithPrimitivesAndMixedArrays:default[example default]": Object {
           "properties": Object {
             "param1": Object {
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
-                  "default": "",
+                  "default": "example default",
                   "type": "string",
                 },
                 "type": "array",
@@ -122,18 +122,18 @@ Array [
           },
           "type": "object",
         },
-        "primitiveString:allowEmptyValue[false]default[]": Object {
+        "primitiveString:allowEmptyValue[false]default[example default]": Object {
           "allowEmptyValue": false,
-          "default": "",
+          "default": "example default",
           "type": "string",
         },
-        "primitiveString:allowEmptyValue[true]default[]": Object {
+        "primitiveString:allowEmptyValue[true]default[example default]": Object {
           "allowEmptyValue": true,
-          "default": "",
+          "default": "example default",
           "type": "string",
         },
-        "primitiveString:default[]": Object {
-          "default": "",
+        "primitiveString:default[example default]": Object {
+          "default": "example default",
           "type": "string",
         },
       },
@@ -145,79 +145,79 @@ Array [
 ]
 `;
 
-exports[`defaults parameters should comply with the \`allowEmptyValue\` declarative when present with simple usages of \`$ref\` 1`] = `
+exports[`defaults parameters should pas through the \`allowEmptyValue\` declarative with simple usages of \`$ref\` 1`] = `
 Array [
   Object {
     "label": "Query Params",
     "schema": Object {
       "properties": Object {
-        "arrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+        "arrayOfPrimitives:allowEmptyValue[false]default[example default]": Object {
           "items": Object {
             "allowEmptyValue": false,
-            "default": "",
+            "default": "example default",
             "type": "string",
           },
           "type": "array",
         },
-        "arrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+        "arrayOfPrimitives:allowEmptyValue[true]default[example default]": Object {
           "items": Object {
             "allowEmptyValue": true,
-            "default": "",
+            "default": "example default",
             "type": "string",
           },
           "type": "array",
         },
-        "arrayOfPrimitives:default[]": Object {
+        "arrayOfPrimitives:default[example default]": Object {
           "items": Object {
-            "default": "",
+            "default": "example default",
             "type": "string",
           },
           "type": "array",
         },
-        "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+        "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[example default]": Object {
           "items": Object {
             "items": Object {
               "allowEmptyValue": false,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "type": "array",
           },
           "type": "array",
         },
-        "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+        "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[example default]": Object {
           "items": Object {
             "items": Object {
               "allowEmptyValue": true,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "type": "array",
           },
           "type": "array",
         },
-        "arrayWithAnArrayOfPrimitives:default[]": Object {
+        "arrayWithAnArrayOfPrimitives:default[example default]": Object {
           "items": Object {
             "items": Object {
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "type": "array",
           },
           "type": "array",
         },
-        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[]": Object {
+        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[example default]": Object {
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": false,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
                   "allowEmptyValue": false,
-                  "default": "",
+                  "default": "example default",
                   "type": "string",
                 },
                 "type": "array",
@@ -227,18 +227,18 @@ Array [
           },
           "type": "object",
         },
-        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[]": Object {
+        "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[example default]": Object {
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": true,
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
                   "allowEmptyValue": true,
-                  "default": "",
+                  "default": "example default",
                   "type": "string",
                 },
                 "type": "array",
@@ -248,16 +248,16 @@ Array [
           },
           "type": "object",
         },
-        "objectWithPrimitivesAndMixedArrays:default[]": Object {
+        "objectWithPrimitivesAndMixedArrays:default[example default]": Object {
           "properties": Object {
             "param1": Object {
-              "default": "",
+              "default": "example default",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
-                  "default": "",
+                  "default": "example default",
                   "type": "string",
                 },
                 "type": "array",
@@ -267,18 +267,18 @@ Array [
           },
           "type": "object",
         },
-        "primitiveString:allowEmptyValue[false]default[]": Object {
+        "primitiveString:allowEmptyValue[false]default[example default]": Object {
           "allowEmptyValue": false,
-          "default": "",
+          "default": "example default",
           "type": "string",
         },
-        "primitiveString:allowEmptyValue[true]default[]": Object {
+        "primitiveString:allowEmptyValue[true]default[example default]": Object {
           "allowEmptyValue": true,
-          "default": "",
+          "default": "example default",
           "type": "string",
         },
-        "primitiveString:default[]": Object {
-          "default": "",
+        "primitiveString:default[example default]": Object {
+          "default": "example default",
           "type": "string",
         },
       },

--- a/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -7,13 +7,16 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": false,
+            "default": "",
             "type": "string",
           },
           "type": "array",
         },
         "arrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": true,
             "default": "",
@@ -22,15 +25,19 @@ Array [
           "type": "array",
         },
         "arrayOfPrimitives:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
+            "default": "",
             "type": "string",
           },
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": false,
+              "default": "",
               "type": "string",
             },
             "type": "array",
@@ -38,6 +45,7 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": true,
@@ -49,8 +57,10 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
+              "default": "",
               "type": "string",
             },
             "type": "array",
@@ -58,15 +68,18 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": false,
+              "default": "",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
                   "allowEmptyValue": false,
+                  "default": "",
                   "type": "string",
                 },
                 "type": "array",
@@ -77,6 +90,7 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": true,
@@ -98,13 +112,16 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
+              "default": "",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
+                  "default": "",
                   "type": "string",
                 },
                 "type": "array",
@@ -115,15 +132,20 @@ Array [
           "type": "object",
         },
         "primitiveString:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": false,
+          "default": "",
           "type": "string",
         },
         "primitiveString:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": true,
           "default": "",
           "type": "string",
         },
         "primitiveString:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "default": "",
           "type": "string",
         },
       },
@@ -142,13 +164,16 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": false,
+            "default": "",
             "type": "string",
           },
           "type": "array",
         },
         "arrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": true,
             "default": "",
@@ -157,15 +182,19 @@ Array [
           "type": "array",
         },
         "arrayOfPrimitives:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
+            "default": "",
             "type": "string",
           },
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": false,
+              "default": "",
               "type": "string",
             },
             "type": "array",
@@ -173,6 +202,7 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": true,
@@ -184,8 +214,10 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
+              "default": "",
               "type": "string",
             },
             "type": "array",
@@ -193,15 +225,18 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": false,
+              "default": "",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
                   "allowEmptyValue": false,
+                  "default": "",
                   "type": "string",
                 },
                 "type": "array",
@@ -212,6 +247,7 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": true,
@@ -233,13 +269,16 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
+              "default": "",
               "type": "string",
             },
             "param2": Object {
               "items": Object {
                 "items": Object {
+                  "default": "",
                   "type": "string",
                 },
                 "type": "array",
@@ -250,15 +289,20 @@ Array [
           "type": "object",
         },
         "primitiveString:allowEmptyValue[false]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": false,
+          "default": "",
           "type": "string",
         },
         "primitiveString:allowEmptyValue[true]default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": true,
           "default": "",
           "type": "string",
         },
         "primitiveString:default[]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "default": "",
           "type": "string",
         },
       },
@@ -277,6 +321,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:default[false]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": false,
             "type": "string",
@@ -284,6 +329,7 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[false]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": false,
@@ -294,6 +340,7 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:default[false]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": false,
@@ -313,6 +360,7 @@ Array [
           "type": "object",
         },
         "primitiveString:default[false]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": false,
           "type": "string",
         },
@@ -332,6 +380,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": "example default",
             "type": "string",
@@ -339,6 +388,7 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": "example default",
@@ -349,6 +399,7 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": "example default",
@@ -368,6 +419,7 @@ Array [
           "type": "object",
         },
         "primitiveString:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": "example default",
           "type": "string",
         },
@@ -387,6 +439,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": "example default",
             "type": "string",
@@ -394,6 +447,7 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": "example default",
@@ -404,6 +458,7 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": "example default",
@@ -423,6 +478,7 @@ Array [
           "type": "object",
         },
         "primitiveString:default[example default]": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": "example default",
           "type": "string",
         },
@@ -435,1443 +491,12 @@ Array [
 ]
 `;
 
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: arrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "items": Object {
-        "allowEmptyValue": true,
-        "default": "",
-        "type": "string",
-      },
-      "type": "array",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: arrayWithAnArrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "items": Object {
-        "items": Object {
-          "allowEmptyValue": true,
-          "default": "",
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "type": "array",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: objectWithPrimitivesAndMixedArrays] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "properties": Object {
-        "param1": Object {
-          "allowEmptyValue": true,
-          "default": "",
-          "type": "string",
-        },
-        "param2": Object {
-          "items": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "type": "array",
-        },
-      },
-      "type": "object",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: primitiveString] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allowEmptyValue": true,
-      "default": "",
-      "type": "string",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with simple usages of \`$ref\` [scenario: arrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/arrayOfPrimitives",
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with simple usages of \`$ref\` [scenario: arrayWithAnArrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with simple usages of \`$ref\` [scenario: objectWithPrimitivesAndMixedArrays] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with simple usages of \`$ref\` [scenario: primitiveString] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/primitiveString",
-      "components": Object {
-        "schemas": Object {
-          "primitiveString": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`allOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`anyOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "allowEmptyValue": true,
-              "default": "",
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": true,
-                "default": "",
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": true,
-                    "default": "",
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should comply with the \`allowEmptyValue\` declarative when present with usages of \`oneOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "allowEmptyValue": true,
-            "default": "",
-            "type": "string",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: arrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "items": Object {
-        "allowEmptyValue": false,
-        "type": "string",
-      },
-      "type": "array",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: arrayWithAnArrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "items": Object {
-        "items": Object {
-          "allowEmptyValue": false,
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "type": "array",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: objectWithPrimitivesAndMixedArrays] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "properties": Object {
-        "param1": Object {
-          "allowEmptyValue": false,
-          "type": "string",
-        },
-        "param2": Object {
-          "items": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "type": "array",
-        },
-      },
-      "type": "object",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with normal non-$ref, non-inheritance, non-polymorphism cases [scenario: primitiveString] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allowEmptyValue": false,
-      "type": "string",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with simple usages of \`$ref\` [scenario: arrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/arrayOfPrimitives",
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with simple usages of \`$ref\` [scenario: arrayWithAnArrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with simple usages of \`$ref\` [scenario: objectWithPrimitivesAndMixedArrays] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with simple usages of \`$ref\` [scenario: primitiveString] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "$ref": "#/components/schemas/primitiveString",
-      "components": Object {
-        "schemas": Object {
-          "primitiveString": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`allOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`anyOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "allowEmptyValue": false,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "allowEmptyValue": false,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "allowEmptyValue": false,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`defaults request bodies should not add a default when one is missing with usages of \`oneOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "allowEmptyValue": false,
-            "type": "string",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
 exports[`defaults request bodies should pass through defaults should pass a default of \`false\` [scenario: arrayOfPrimitives] 1`] = `
 Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "default": false,
         "type": "string",
@@ -1888,6 +513,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "items": Object {
           "default": false,
@@ -1907,6 +533,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "param1": Object {
           "default": false,
@@ -1935,6 +562,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "default": false,
       "type": "string",
     },
@@ -1948,6 +576,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "default": "example default",
         "type": "string",
@@ -1964,6 +593,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "items": Object {
           "default": "example default",
@@ -1983,6 +613,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "param1": Object {
           "default": "example default",
@@ -2011,6 +642,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "default": "example default",
       "type": "string",
     },
@@ -2024,8 +656,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$ref": "#/components/schemas/arrayOfPrimitives",
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives": Object {
             "items": Object {
@@ -2036,6 +669,11 @@ Array [
           },
         },
       },
+      "items": Object {
+        "default": "example default",
+        "type": "string",
+      },
+      "type": "array",
     },
     "type": "body",
   },
@@ -2047,8 +685,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives",
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives": Object {
             "items": Object {
@@ -2062,6 +701,14 @@ Array [
           },
         },
       },
+      "items": Object {
+        "items": Object {
+          "default": "example default",
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "type": "array",
     },
     "type": "body",
   },
@@ -2073,8 +720,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays",
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays": Object {
             "properties": Object {
@@ -2097,6 +745,23 @@ Array [
           },
         },
       },
+      "properties": Object {
+        "param1": Object {
+          "default": "example default",
+          "type": "string",
+        },
+        "param2": Object {
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      },
+      "type": "object",
     },
     "type": "body",
   },
@@ -2108,8 +773,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$ref": "#/components/schemas/primitiveString",
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString": Object {
             "default": "example default",
@@ -2117,6 +783,8 @@ Array [
           },
         },
       },
+      "default": "example default",
+      "type": "string",
     },
     "type": "body",
   },
@@ -2128,15 +796,25 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
+          "items": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "type": "array",
         },
         Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
+          "items": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "type": "array",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
             "items": Object {
@@ -2165,15 +843,31 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
         },
         Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
             "items": Object {
@@ -2208,15 +902,49 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
+          "properties": Object {
+            "param1": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "param2": Object {
+              "items": Object {
+                "items": Object {
+                  "default": "example default",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
         },
         Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
+          "properties": Object {
+            "param1": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "param2": Object {
+              "items": Object {
+                "items": Object {
+                  "default": "example default",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
             "properties": Object {
@@ -2269,15 +997,19 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
-          "$ref": "#/components/schemas/primitiveString-1",
+          "default": "example default",
+          "type": "string",
         },
         Object {
-          "$ref": "#/components/schemas/primitiveString-2",
+          "default": "example default",
+          "type": "string",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString-1": Object {
             "default": "example default",
@@ -2300,15 +1032,25 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
+          "items": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "type": "array",
         },
         Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
+          "items": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "type": "array",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
             "items": Object {
@@ -2337,15 +1079,31 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
         },
         Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
             "items": Object {
@@ -2380,15 +1138,49 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
+          "properties": Object {
+            "param1": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "param2": Object {
+              "items": Object {
+                "items": Object {
+                  "default": "example default",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
         },
         Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
+          "properties": Object {
+            "param1": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "param2": Object {
+              "items": Object {
+                "items": Object {
+                  "default": "example default",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
             "properties": Object {
@@ -2441,15 +1233,19 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
-          "$ref": "#/components/schemas/primitiveString-1",
+          "default": "example default",
+          "type": "string",
         },
         Object {
-          "$ref": "#/components/schemas/primitiveString-2",
+          "default": "example default",
+          "type": "string",
         },
       ],
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString-1": Object {
             "default": "example default",
@@ -2472,7 +1268,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
             "items": Object {
@@ -2492,10 +1290,18 @@ Array [
       },
       "oneOf": Array [
         Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
+          "items": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "type": "array",
         },
         Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
+          "items": Object {
+            "default": "example default",
+            "type": "string",
+          },
+          "type": "array",
         },
       ],
     },
@@ -2509,7 +1315,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
             "items": Object {
@@ -2535,10 +1343,24 @@ Array [
       },
       "oneOf": Array [
         Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
         },
         Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
+          "items": Object {
+            "items": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
         },
       ],
     },
@@ -2552,7 +1374,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
             "properties": Object {
@@ -2596,10 +1420,42 @@ Array [
       },
       "oneOf": Array [
         Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
+          "properties": Object {
+            "param1": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "param2": Object {
+              "items": Object {
+                "items": Object {
+                  "default": "example default",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
         },
         Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
+          "properties": Object {
+            "param1": Object {
+              "default": "example default",
+              "type": "string",
+            },
+            "param2": Object {
+              "items": Object {
+                "items": Object {
+                  "default": "example default",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
         },
       ],
     },
@@ -2613,7 +1469,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString-1": Object {
             "default": "example default",
@@ -2627,10 +1485,12 @@ Array [
       },
       "oneOf": Array [
         Object {
-          "$ref": "#/components/schemas/primitiveString-1",
+          "default": "example default",
+          "type": "string",
         },
         Object {
-          "$ref": "#/components/schemas/primitiveString-2",
+          "default": "example default",
+          "type": "string",
         },
       ],
     },
@@ -2646,13 +1506,12 @@ Array [
     "schema": Object {
       "properties": Object {
         "id": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": 12345,
           "type": "integer",
         },
       },
-      "required": Array [
-        "id",
-      ],
+      "required": Array [],
       "type": "object",
     },
     "type": "path",
@@ -2660,8 +1519,9 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$ref": "#/components/schemas/Pet",
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "Pet": Object {
             "example": Object {
@@ -2676,693 +1536,12 @@ Array [
           },
         },
       },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength parameters should pass maxLength and minLength properties 1`] = `
-Array [
-  Object {
-    "label": "Query Params",
-    "schema": Object {
       "properties": Object {
-        "arrayOfPrimitives:maxLength[20]maxLength[5]": Object {
-          "items": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-          "type": "array",
-        },
-        "arrayWithAnArrayOfPrimitives:maxLength[20]maxLength[5]": Object {
-          "items": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "type": "array",
-        },
-        "objectWithPrimitivesAndMixedArrays:maxLength[20]maxLength[5]": Object {
-          "properties": Object {
-            "param1": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "param2": Object {
-              "items": Object {
-                "items": Object {
-                  "maximum": 20,
-                  "minimum": 5,
-                  "type": "string",
-                },
-                "type": "array",
-              },
-              "type": "array",
-            },
-          },
-          "type": "object",
-        },
-        "primitiveString:maxLength[20]maxLength[5]": Object {
-          "maximum": 20,
-          "minimum": 5,
+        "name": Object {
           "type": "string",
-        },
-      },
-      "required": Array [],
-      "type": "object",
-    },
-    "type": "query",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties [scenario: arrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "items": Object {
-        "maximum": 20,
-        "minimum": 5,
-        "type": "string",
-      },
-      "type": "array",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties [scenario: arrayWithAnArrayOfPrimitives] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "items": Object {
-        "items": Object {
-          "maximum": 20,
-          "minimum": 5,
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "type": "array",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties [scenario: objectWithPrimitivesAndMixedArrays] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "properties": Object {
-        "param1": Object {
-          "maximum": 20,
-          "minimum": 5,
-          "type": "string",
-        },
-        "param2": Object {
-          "items": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "type": "array",
         },
       },
       "type": "object",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties [scenario: primitiveString] 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "maximum": 20,
-      "minimum": 5,
-      "type": "string",
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`allOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`allOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`allOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "maximum": 20,
-                    "minimum": 5,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "maximum": 20,
-                    "minimum": 5,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`allOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "allOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`anyOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`anyOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`anyOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "maximum": 20,
-                    "minimum": 5,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "maximum": 20,
-                    "minimum": 5,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`anyOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "anyOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-        },
-      },
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`oneOf\` scenario: arrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "arrayOfPrimitives-1": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "arrayOfPrimitives-2": Object {
-            "items": Object {
-              "maximum": 20,
-              "minimum": 5,
-              "type": "string",
-            },
-            "type": "array",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayOfPrimitives-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`oneOf\` scenario: arrayWithAnArrayOfPrimitives 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "arrayWithAnArrayOfPrimitives-1": Object {
-            "items": Object {
-              "items": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-          "arrayWithAnArrayOfPrimitives-2": Object {
-            "items": Object {
-              "items": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "type": "array",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/arrayWithAnArrayOfPrimitives-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`oneOf\` scenario: objectWithPrimitivesAndMixedArrays 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "objectWithPrimitivesAndMixedArrays-1": Object {
-            "properties": Object {
-              "param1": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "maximum": 20,
-                    "minimum": 5,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-          "objectWithPrimitivesAndMixedArrays-2": Object {
-            "properties": Object {
-              "param1": Object {
-                "maximum": 20,
-                "minimum": 5,
-                "type": "string",
-              },
-              "param2": Object {
-                "items": Object {
-                  "items": Object {
-                    "maximum": 20,
-                    "minimum": 5,
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "type": "array",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/objectWithPrimitivesAndMixedArrays-2",
-        },
-      ],
-    },
-    "type": "body",
-  },
-]
-`;
-
-exports[`minLength / maxLength request bodies should pass maxLength and minLength properties within usages of \`oneOf\` scenario: primitiveString 1`] = `
-Array [
-  Object {
-    "label": "Body Params",
-    "schema": Object {
-      "components": Object {
-        "schemas": Object {
-          "primitiveString-1": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-          "primitiveString-2": Object {
-            "maximum": 20,
-            "minimum": 5,
-            "type": "string",
-          },
-        },
-      },
-      "oneOf": Array [
-        Object {
-          "$ref": "#/components/schemas/primitiveString-1",
-        },
-        Object {
-          "$ref": "#/components/schemas/primitiveString-2",
-        },
-      ],
     },
     "type": "body",
   },
@@ -3376,6 +1555,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "path parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3389,6 +1569,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "query parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3400,6 +1581,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "a": Object {
           "type": "string",
@@ -3414,6 +1596,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "cookie parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3427,6 +1610,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "header parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3445,6 +1629,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "path parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3458,6 +1643,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "query parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3471,6 +1657,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "cookie parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -3482,6 +1669,7 @@ Array [
   Object {
     "label": "Form Data",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "a": Object {
           "type": "string",
@@ -3496,6 +1684,7 @@ Array [
     "schema": Object {
       "properties": Object {
         "header parameter": Object {
+          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },

--- a/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
+++ b/packages/tooling/__tests__/lib/__snapshots__/parameters-to-json-schema.test.js.snap
@@ -7,7 +7,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": false,
             "default": "",
@@ -16,7 +15,6 @@ Array [
           "type": "array",
         },
         "arrayOfPrimitives:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": true,
             "default": "",
@@ -25,7 +23,6 @@ Array [
           "type": "array",
         },
         "arrayOfPrimitives:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": "",
             "type": "string",
@@ -33,7 +30,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": false,
@@ -45,7 +41,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": true,
@@ -57,7 +52,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": "",
@@ -68,7 +62,6 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": false,
@@ -90,7 +83,6 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": true,
@@ -112,7 +104,6 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": "",
@@ -132,19 +123,16 @@ Array [
           "type": "object",
         },
         "primitiveString:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": false,
           "default": "",
           "type": "string",
         },
         "primitiveString:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": true,
           "default": "",
           "type": "string",
         },
         "primitiveString:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": "",
           "type": "string",
         },
@@ -164,7 +152,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": false,
             "default": "",
@@ -173,7 +160,6 @@ Array [
           "type": "array",
         },
         "arrayOfPrimitives:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "allowEmptyValue": true,
             "default": "",
@@ -182,7 +168,6 @@ Array [
           "type": "array",
         },
         "arrayOfPrimitives:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": "",
             "type": "string",
@@ -190,7 +175,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": false,
@@ -202,7 +186,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "allowEmptyValue": true,
@@ -214,7 +197,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": "",
@@ -225,7 +207,6 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": false,
@@ -247,7 +228,6 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "allowEmptyValue": true,
@@ -269,7 +249,6 @@ Array [
           "type": "object",
         },
         "objectWithPrimitivesAndMixedArrays:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": "",
@@ -289,19 +268,16 @@ Array [
           "type": "object",
         },
         "primitiveString:allowEmptyValue[false]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": false,
           "default": "",
           "type": "string",
         },
         "primitiveString:allowEmptyValue[true]default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "allowEmptyValue": true,
           "default": "",
           "type": "string",
         },
         "primitiveString:default[]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": "",
           "type": "string",
         },
@@ -321,7 +297,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:default[false]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": false,
             "type": "string",
@@ -329,7 +304,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[false]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": false,
@@ -340,7 +314,6 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:default[false]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": false,
@@ -360,7 +333,6 @@ Array [
           "type": "object",
         },
         "primitiveString:default[false]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": false,
           "type": "string",
         },
@@ -380,7 +352,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": "example default",
             "type": "string",
@@ -388,7 +359,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": "example default",
@@ -399,7 +369,6 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": "example default",
@@ -419,7 +388,6 @@ Array [
           "type": "object",
         },
         "primitiveString:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": "example default",
           "type": "string",
         },
@@ -439,7 +407,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "arrayOfPrimitives:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "default": "example default",
             "type": "string",
@@ -447,7 +414,6 @@ Array [
           "type": "array",
         },
         "arrayWithAnArrayOfPrimitives:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "items": Object {
             "items": Object {
               "default": "example default",
@@ -458,7 +424,6 @@ Array [
           "type": "array",
         },
         "objectWithPrimitivesAndMixedArrays:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "properties": Object {
             "param1": Object {
               "default": "example default",
@@ -478,7 +443,6 @@ Array [
           "type": "object",
         },
         "primitiveString:default[example default]": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": "example default",
           "type": "string",
         },
@@ -496,7 +460,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "default": false,
         "type": "string",
@@ -513,7 +476,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "items": Object {
           "default": false,
@@ -533,7 +495,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "param1": Object {
           "default": false,
@@ -562,7 +523,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "default": false,
       "type": "string",
     },
@@ -576,7 +536,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "default": "example default",
         "type": "string",
@@ -593,7 +552,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "items": Object {
         "items": Object {
           "default": "example default",
@@ -613,7 +571,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "param1": Object {
           "default": "example default",
@@ -642,7 +599,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "default": "example default",
       "type": "string",
     },
@@ -656,9 +612,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives": Object {
             "items": Object {
@@ -685,9 +639,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives": Object {
             "items": Object {
@@ -720,9 +672,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays": Object {
             "properties": Object {
@@ -773,9 +723,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString": Object {
             "default": "example default",
@@ -796,7 +744,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
           "items": Object {
@@ -814,7 +761,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
             "items": Object {
@@ -843,7 +789,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
           "items": Object {
@@ -867,7 +812,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
             "items": Object {
@@ -902,7 +846,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
           "properties": Object {
@@ -944,7 +887,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
             "properties": Object {
@@ -997,7 +939,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
           "default": "example default",
@@ -1009,7 +950,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString-1": Object {
             "default": "example default",
@@ -1032,7 +972,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
           "items": Object {
@@ -1050,7 +989,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
             "items": Object {
@@ -1079,7 +1017,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
           "items": Object {
@@ -1103,7 +1040,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
             "items": Object {
@@ -1138,7 +1074,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
           "properties": Object {
@@ -1180,7 +1115,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
             "properties": Object {
@@ -1233,7 +1167,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "anyOf": Array [
         Object {
           "default": "example default",
@@ -1245,7 +1178,6 @@ Array [
         },
       ],
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString-1": Object {
             "default": "example default",
@@ -1268,9 +1200,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayOfPrimitives-1": Object {
             "items": Object {
@@ -1315,9 +1245,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "arrayWithAnArrayOfPrimitives-1": Object {
             "items": Object {
@@ -1374,9 +1302,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "objectWithPrimitivesAndMixedArrays-1": Object {
             "properties": Object {
@@ -1469,9 +1395,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "primitiveString-1": Object {
             "default": "example default",
@@ -1506,7 +1430,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "id": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "default": 12345,
           "type": "integer",
         },
@@ -1519,9 +1442,7 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
-        "$schema": "http://json-schema.org/draft-04/schema#",
         "schemas": Object {
           "Pet": Object {
             "example": Object {
@@ -1555,7 +1476,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "path parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1569,7 +1489,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "query parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1581,7 +1500,6 @@ Array [
   Object {
     "label": "Body Params",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "a": Object {
           "type": "string",
@@ -1596,7 +1514,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "cookie parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1610,7 +1527,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "header parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1629,7 +1545,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "path parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1643,7 +1558,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "query parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1657,7 +1571,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "cookie parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },
@@ -1669,7 +1582,6 @@ Array [
   Object {
     "label": "Form Data",
     "schema": Object {
-      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "a": Object {
           "type": "string",
@@ -1684,7 +1596,6 @@ Array [
     "schema": Object {
       "properties": Object {
         "header parameter": Object {
-          "$schema": "http://json-schema.org/draft-04/schema#",
           "type": "string",
         },
       },

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -4,10 +4,6 @@ const fixtures = require('../__fixtures__/lib/json-schema');
 
 const polymorphismScenarios = ['oneOf', 'allOf', 'anyOf'];
 
-const schemaDraftVersion = {
-  $schema: 'http://json-schema.org/draft-04/schema#',
-};
-
 test('it should return with null if there are no parameters', async () => {
   expect(await parametersToJsonSchema({ parameters: [] })).toBeNull();
   expect(await parametersToJsonSchema({})).toBeNull();
@@ -98,10 +94,7 @@ describe('parameters', () => {
             oas
           )
         )[0].schema.properties.param
-      ).toStrictEqual({
-        ...oas.components.parameters.Param.schema,
-        ...schemaDraftVersion,
-      });
+      ).toStrictEqual(oas.components.parameters.Param.schema);
     });
 
     it('should fetch parameters that have a child $ref', async () => {
@@ -166,7 +159,6 @@ describe('parameters', () => {
       ).toStrictEqual({
         param: {
           type: 'string',
-          ...schemaDraftVersion,
         },
       });
     });
@@ -306,7 +298,6 @@ describe('request bodies', () => {
         label: 'Body Params',
         type: 'body',
         schema: {
-          ...schemaDraftVersion,
           type: 'object',
           properties: {
             a: { type: 'string' },
@@ -339,7 +330,6 @@ describe('request bodies', () => {
         label: 'Form Data',
         type: 'formData',
         schema: {
-          ...schemaDraftVersion,
           type: 'object',
           properties: {
             a: { type: 'string' },
@@ -404,12 +394,8 @@ describe('request bodies', () => {
           type: 'body',
           label: 'Body Params',
           schema: {
-            ...schemaDraftVersion,
             ...oas.components.schemas.Pet,
-            components: {
-              ...schemaDraftVersion,
-              ...oas.components,
-            },
+            components: oas.components,
           },
         },
       ]);
@@ -433,7 +419,6 @@ describe('type', () => {
       expect((await parametersToJsonSchema({ parameters }))[0].schema).toStrictEqual({
         properties: {
           param: {
-            ...schemaDraftVersion,
             items: {},
             type: 'array',
           },
@@ -509,7 +494,6 @@ describe('enums', () => {
           type: 'object',
           properties: {
             Accept: {
-              ...schemaDraftVersion,
               type: 'string',
               enum: ['application/json', 'application/xml'],
             },
@@ -569,7 +553,6 @@ describe('descriptions', () => {
           type: 'object',
           properties: {
             Accept: {
-              ...schemaDraftVersion,
               description: 'Expected response format.',
               type: 'string',
             },

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -731,15 +731,22 @@ describe('defaults', () => {
       it.todo('with usages of `anyOf` cases');
     });
 
-    // @todo rework this logic to just test that allowemptyvalue gets passed through
-    describe('should comply with the `allowEmptyValue` declarative when present', () => {
+    describe('should pas through the `allowEmptyValue` declarative', () => {
       it('with normal non-$ref, non-inheritance, non-polymorphism cases', async () => {
-        const { parameters } = fixtures.generateParameterDefaults('simple', { default: '', allowEmptyValue: true });
+        const { parameters } = fixtures.generateParameterDefaults('simple', {
+          default: 'example default',
+          allowEmptyValue: true,
+        });
+
         expect(await parametersToJsonSchema({ parameters })).toMatchSnapshot();
       });
 
       it('with simple usages of `$ref`', async () => {
-        const { parameters, oas } = fixtures.generateParameterDefaults('$ref', { default: '', allowEmptyValue: true });
+        const { parameters, oas } = fixtures.generateParameterDefaults('$ref', {
+          default: 'example default',
+          allowEmptyValue: true,
+        });
+
         expect(await parametersToJsonSchema({ parameters }, oas)).toMatchSnapshot();
       });
 

--- a/packages/tooling/package-lock.json
+++ b/packages/tooling/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
+      "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.0",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -794,6 +804,19 @@
         }
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
+      "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
+    },
+    "@openapi-contrib/openapi-schema-to-json-schema": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.0.0.tgz",
+      "integrity": "sha512-nM0Xn6lCwk1nt/fCWwiLBT1SbH4TlX099bWfz4h5lleW7yeu3SHGDP3knFBDHXPCLwywo5qqOOTVvjTTGf/7lA==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "@readme/eslint-config": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-2.0.1.tgz",
@@ -813,6 +836,12 @@
         "eslint-plugin-sonarjs": "^0.5.0",
         "eslint-plugin-unicorn": "^17.0.1"
       }
+    },
+    "@readme/oas-examples": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.0.0.tgz",
+      "integrity": "sha512-8icVZrS+V8DxdFLbErNSxqw6rqXBTa/i6YeNiLdVkqCh2veZ13lvmbgmzg9U3mzINosenqpAeT1bpC41SZ4goQ==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.7.1",
@@ -1058,7 +1087,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1431,6 +1459,11 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1716,6 +1749,19 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1726,7 +1772,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1847,7 +1892,6 @@
       "version": "1.17.4",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
       "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -1866,7 +1910,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -2387,8 +2430,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.1.0",
@@ -2760,8 +2802,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2896,7 +2937,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -2910,8 +2950,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3184,6 +3223,11 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3199,8 +3243,7 @@
     "is-callable": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-      "dev": true
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -3234,8 +3277,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3314,7 +3356,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -3335,7 +3376,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -5007,7 +5047,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5524,14 +5563,17 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5546,7 +5588,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -5987,7 +6028,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -6631,8 +6671,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -6734,7 +6773,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -6744,7 +6782,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -30,6 +30,8 @@
     "test": "jest --coverage"
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^8.0.0",
+    "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0",
     "jsonpointer": "^4.0.1",
     "path-to-regexp": "^6.1.0"
   },

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -7,6 +7,7 @@ const toJsonSchema = require('@openapi-contrib/openapi-schema-to-json-schema');
 const toJsonSchemaFromParameter = require('@openapi-contrib/openapi-schema-to-json-schema').fromParameter;
 
 const toJsonSchemaOptions = {
+  // Since we support custom formats in `@readme/api-explorer`, we want to preserve unsupported formats.
   keepNotSupported: ['format'],
 };
 

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -42,7 +42,8 @@ function getBodyParam(pathOperation, oas) {
           obj.items = {};
         }
       } else if (prop === '$schema') {
-        // @todo delete $schema because we don't really need it right now
+        // Delete the JSON Schema draft version from the schema because we don't really need it.
+        delete obj.$schema;
       }
     });
 
@@ -57,7 +58,7 @@ function getBodyParam(pathOperation, oas) {
     : cleanedSchema;
 
   // If there's not actually any data within this schema, don't bother returning it.
-  if (Object.keys(cleanedSchema).length <= 1) {
+  if (Object.keys(constructedSchema).length <= 1) {
     return null;
   }
 
@@ -108,7 +109,10 @@ function getOtherParams(pathOperation) {
         schema.items = {};
       }
 
-      // @tood delete schema.$schema right now because we don't really need it
+      // Delete the JSON Schema draft version from the schema because we don't really need it.
+      if ('$schema' in schema) {
+        delete schema.$schema;
+      }
 
       prev[current.name] = schema;
 


### PR DESCRIPTION
## 🧰 What's being changed?
Since the release of `@readme/api-explorer` v6 we've been running into a truckload of JSON Schema issues with unsupported keywords like `example`. Instead of trying to put these fires out as they crop up, I'm swapping our our code OpenAPI parameter/request body -> JSON Schema conversion library with two packages:

* [@apidevtools/json-schema-ref-parser](https://www.npmjs.com/package/@apidevtools/json-schema-ref-parser)
* [@openapi-contrib/openapi-schema-to-json-schema](https://www.npmjs.com/package/@openapi-contrib/openapi-schema-to-json-schema)

With these two packages we can:

1. Dereference schemas before we process, eliminating the need to recur and resolve `$ref`'s as we go with our `find-schema-definition` library.
2. Remove a whole bunch of custom OpenAPI to JSON Schema conversion code that's handled much more gracefully, and with better test and spec coverage.