### PR TITLE
fix: edge case in findOperation

### DIFF
--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -116,6 +116,15 @@ describe('class.Oas', () => {
       expect(res).toBeUndefined();
     });
 
+    it('should return undefined if origin is correct but unable to extract path', () => {
+      const oas = new Oas(petstore);
+      const uri = `http://petstore.swagger.io/`;
+      const method = 'GET';
+
+      const res = oas.findOperation(uri, method);
+      expect(res).toBeUndefined();
+    });
+
     it('should return undefined if no path matches found', () => {
       const oas = new Oas(petstore);
       const uri = `http://petstore.swagger.io/v2/search`;

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -249,6 +249,7 @@ class Oas {
     if (!targetServer) return undefined;
 
     const [, pathName] = url.split(targetServer.url);
+    if (pathName === undefined) return undefined;
     const annotatedPaths = generatePathMatches(paths, pathName, targetServer.url);
     if (!annotatedPaths.length) return undefined;
 


### PR DESCRIPTION
If the origin URL is the same as the server URL defined in the OpenAPI file, but the path cannot be extracted, it would throw an error in `generatePathMatches()` [here](https://github.com/readmeio/oas/blob/6b58e58bb9ea9928389444421edb0c286d7d2fff/packages/tooling/src/oas.js#L150) since `pathName` is undefined. This fixes that case.