### PR TITLE
fix: removing descriptions from top-level component schemas

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -666,6 +666,56 @@ describe('descriptions', () => {
       },
     ]);
   });
+
+  // This is to resolve a UI quirk with @readme/react-jsonschema-form.
+  it('should remove descriptions on top-level component schemas', () => {
+    const oas = {
+      components: {
+        schemas: {
+          user: {
+            $ref: '#/components/schemas/user',
+          },
+          userBase: {
+            description: 'User object',
+            allOf: [
+              {
+                $ref: '#/components/schemas/userName',
+              },
+            ],
+          },
+          userName: {
+            type: 'object',
+            properties: {
+              firstName: {
+                type: 'string',
+                default: 'tktktk',
+              },
+              lastName: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      parametersToJsonSchema(
+        {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/user',
+                },
+              },
+            },
+          },
+        },
+        oas
+      )[0].schema.components.schemas.userBase.description
+    ).toBeUndefined();
+  });
 });
 
 describe('required', () => {


### PR DESCRIPTION
This resolves a quick with how we're using `parameters-to-json-schema` in `@readme/api-explorer` where if a component schema has a `description`, we'd render it as a `DescriptionField`, resulting in orphaned text that makes the parameters section in our API Explorer confusing.

See:

![Screen Shot 2020-04-08 at 12 27 30 PM](https://user-images.githubusercontent.com/33762/78825184-6253c800-7994-11ea-8e67-e343a1df44c8.png)
