### PR TITLE
fix: bug where requestBody title and descriptions would come through

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -711,53 +711,84 @@ describe('descriptions', () => {
   });
 
   // This is to resolve a UI quirk with @readme/react-jsonschema-form.
-  it('should remove descriptions on top-level component schemas', () => {
-    const oas = {
-      components: {
-        schemas: {
-          user: {
-            $ref: '#/components/schemas/user',
-          },
-          userBase: {
-            description: 'User object',
-            allOf: [
-              {
-                $ref: '#/components/schemas/userName',
-              },
-            ],
-          },
-          userName: {
-            type: 'object',
-            properties: {
-              firstName: {
-                type: 'string',
-                default: 'tktktk',
-              },
-              lastName: {
-                type: 'string',
-              },
-            },
-          },
-        },
-      },
-    };
-
-    expect(
-      parametersToJsonSchema(
+  describe('@readme/react-jsonschema-form quirks', () => {
+    it('should remove title and descriptions on top-level requestBody schemas', () => {
+      const schema = parametersToJsonSchema(
         {
           requestBody: {
             content: {
               'application/json': {
                 schema: {
-                  $ref: '#/components/schemas/user',
+                  type: 'object',
+                  title: 'User',
+                  required: ['user_id'],
+                  properties: {
+                    user_id: {
+                      type: 'string',
+                      description: 'The users ID',
+                    },
+                  },
+                  description: 'Application user',
                 },
               },
             },
           },
         },
-        oas
-      )[0].schema.components.schemas.userBase.description
-    ).toBeUndefined();
+        {}
+      )[0].schema;
+
+      expect(schema.description).toBeUndefined();
+      expect(schema.title).toBeUndefined();
+    });
+
+    it('should remove descriptions on top-level component schemas', () => {
+      const oas = {
+        components: {
+          schemas: {
+            user: {
+              $ref: '#/components/schemas/user',
+            },
+            userBase: {
+              description: 'User object',
+              allOf: [
+                {
+                  $ref: '#/components/schemas/userName',
+                },
+              ],
+            },
+            userName: {
+              type: 'object',
+              properties: {
+                firstName: {
+                  type: 'string',
+                  default: 'tktktk',
+                },
+                lastName: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expect(
+        parametersToJsonSchema(
+          {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/user',
+                  },
+                },
+              },
+            },
+          },
+          oas
+        )[0].schema.components.schemas.userBase.description
+      ).toBeUndefined();
+    });
   });
 });
 

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -46,14 +46,16 @@ function getBodyParam(pathOperation, oas) {
             break;
 
           case 'description':
-            // If we have a description on a component schema, get rid of it because @readme/react-jsonschema-form will
-            // end up interpreting it as a lone `DescriptionField` element and we don't want that to appear in the
-            // frontend.
+          case 'title':
+            // If we have a description or title on a component or request body schema, get rid of it because
+            // @readme/react-jsonschema-form will end up interpreting it as a lone `DescriptionField` element and we
+            // don't want that to appear in the frontend.
             if (
-              prevProp !== false &&
-              'components' in oas &&
-              'schemas' in oas.components &&
-              prevProp in oas.components.schemas
+              (prevProp !== false &&
+                'components' in oas &&
+                'schemas' in oas.components &&
+                prevProp in oas.components.schemas) ||
+              !prevProp
             ) {
               delete obj[prop];
             }


### PR DESCRIPTION
This fixes a bug in `parameters-to-json-schema` where if a `requestBody` had a `title` or `description` set, we'd carry it through, resulting in orphan text being displayed in the API Explorer:

![Screen Shot 2020-04-14 at 8 43 48 PM](https://user-images.githubusercontent.com/33762/79297034-ccd39f00-7e91-11ea-96fe-d08e94a51fde.png)

This is the same fix as https://github.com/readmeio/oas/pull/153, just for request bodies instead of component schemas.