### PR TITLE
fix: include server variables in `findOperation`

### DIFF
--- a/packages/tooling/__tests__/__fixtures__/server-variables.json
+++ b/packages/tooling/__tests__/__fixtures__/server-variables.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://{name}.example.com:{port}/{basePath}",
+      "variables": {
+        "name": {
+          "default": "demo"
+        },
+        "port": {
+          "default": "443"
+        },
+        "basePath": {
+          "default": "v2"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": "1.0.0",
+    "title": "Server variables"
+  },
+  "paths": {
+    "/post": {
+      "post": {
+        "summary": "Should fetch variables from defaults and user values",
+        "description": "",
+        "parameters": [],
+        "responses": {}
+      }
+    }
+  },
+  "x-explorer-enabled": true,
+  "x-samples-enabled": true,
+  "x-samples-languages": ["curl", "node", "ruby", "javascript", "python"]
+}

--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -3,6 +3,7 @@ const { Operation } = require('../src/oas');
 const petstore = require('./__fixtures__/petstore.json');
 const multipleSecurities = require('./__fixtures__/multiple-securities.json');
 const referenceSpec = require('./__fixtures__/local-link.json');
+const serverVariables = require('./__fixtures__/server-variables.json');
 
 describe('class.Oas', () => {
   describe('operation()', () => {
@@ -191,6 +192,29 @@ describe('class.Oas', () => {
           path: '/pet/findByStatus',
           slugs: {},
           method: 'GET',
+        },
+      });
+    });
+
+    it('should return result if in server variable defaults', () => {
+      const oas = new Oas(serverVariables);
+      const uri = `https://demo.example.com:443/v2/post`;
+      const method = 'POST';
+
+      const res = oas.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'https://demo.example.com:443/v2',
+          path: '/post',
+          nonNormalizedPath: '/post',
+          slugs: {},
+          method: 'POST',
+        },
+        operation: {
+          summary: 'Should fetch variables from defaults and user values',
+          description: '',
+          parameters: [],
+          responses: {},
         },
       });
     });

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -243,6 +243,7 @@ class Oas {
     const { origin } = new URL(url);
     const originRegExp = new RegExp(origin);
     const { servers, paths } = this;
+    servers.push({ url: this.url() });
 
     if (!servers || !servers.length) return undefined;
     const targetServer = servers.find(s => originRegExp.exec(s.url));


### PR DESCRIPTION
`findOperation()` currently just searches through all of the server URLs, without doing any replacements for server variables.

This fixes that by also including the output of the `url()` function in the list of URLs to search. Not sure if this is the best approach but it seems like the most straightforward.