### PR TITLE
feat: look in request/response content when retrieving headers

### DIFF
--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -404,7 +404,7 @@ describe('class.operation', () => {
       });
     });
 
-    it('should return an object containing content-type response header if media types exist in response', () => {
+    it('should return an object containing accept and content-type headers if media types exist in response', () => {
       const oas = new Oas(petstore);
       const uri = `http://petstore.swagger.io/v2/pet/findByStatus`;
       const method = 'GET';
@@ -413,7 +413,7 @@ describe('class.operation', () => {
       const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
       expect(operation.getHeaders(true)).toMatchObject({
-        request: [],
+        request: ['Accept'],
         response: ['Content-Type'],
       });
     });

--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -390,6 +390,34 @@ describe('class.operation', () => {
       });
     });
 
+    it('should return an object containing content-type request header if media types exist in request body', () => {
+      const oas = new Oas(petstore);
+      const uri = `http://petstore.swagger.io/v2/pet`;
+      const method = 'POST';
+
+      const logOperation = oas.findOperation(uri, method);
+      const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+
+      expect(operation.getHeaders(true)).toMatchObject({
+        request: ['Content-Type'],
+        response: [],
+      });
+    });
+
+    it('should return an object containing content-type response header if media types exist in response', () => {
+      const oas = new Oas(petstore);
+      const uri = `http://petstore.swagger.io/v2/pet/findByStatus`;
+      const method = 'GET';
+
+      const logOperation = oas.findOperation(uri, method);
+      const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+
+      expect(operation.getHeaders(true)).toMatchObject({
+        request: [],
+        response: ['Content-Type'],
+      });
+    });
+
     it('should return an object containing request headers if security exists', () => {
       const oas = new Oas(multipleSecurities);
       const uri = 'http://example.com/multiple-combo-auths';

--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -441,8 +441,8 @@ describe('class.operation', () => {
       const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
       expect(operation.getHeaders()).toMatchObject({
-        request: ['Cookie', 'Authorization'],
-        response: [],
+        request: ['Cookie', 'Authorization', 'Accept'],
+        response: ['Content-Type'],
       });
     });
 
@@ -454,8 +454,8 @@ describe('class.operation', () => {
       const logOperation = oas.findOperation(uri, method);
       const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
       expect(operation.getHeaders()).toMatchObject({
-        request: ['hostname'],
-        response: [],
+        request: ['hostname', 'Accept'],
+        response: ['Content-Type'],
       });
     });
   });

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -114,6 +114,7 @@ class Operation {
       } else if (this.requestBody.content && Object.keys(this.requestBody.content))
         this.headers.request.push('Content-Type');
     }
+
     // This is a similar approach, but in this case if we check the response content
     // and prioritize the 'accept' request header and 'content-type' request header
     if (this.responses) {

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -117,9 +117,11 @@ class Operation {
       }
       // This is a similar approach, but in this case if we check the response content
       // and prioritize the 'accept' request header and 'content-type' request header
-      if (!this.headers.response.includes('Content-Type') && this.responses) {
-        if (Object.keys(this.responses).some(response => !!this.responses[response].content))
-          this.headers.response.push('Content-Type');
+      if (this.responses) {
+        if (Object.keys(this.responses).some(response => !!this.responses[response].content)) {
+          if (!this.headers.request.includes('Accept')) this.headers.request.push('Accept');
+          if (!this.headers.response.includes('Content-Type')) this.headers.response.push('Content-Type');
+        }
       }
     }
 

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -67,7 +67,7 @@ class Operation {
       }, {});
   }
 
-  getHeaders() {
+  getHeaders(includeContent = false) {
     this.headers = {
       request: [],
       response: [],
@@ -103,6 +103,25 @@ class Operation {
       .filter(r => this.responses[r].headers)
       .map(r => Object.keys(this.responses[r].headers))
       .reduce((a, b) => a.concat(b), []);
+
+    if (includeContent) {
+      // If the operation doesn't already specify a 'content-type' request header,
+      // we check if the path operation request body contains content, which implies that
+      // we should also include the 'content-type' header.
+      if (!this.headers.request.includes('Content-Type') && this.requestBody) {
+        if (this.requestBody.$ref) {
+          const ref = findSchemaDefinition(this.requestBody.$ref, this.oas);
+          if (ref.content && Object.keys(ref.content)) this.headers.request.push('Content-Type');
+        } else if (this.requestBody.content && Object.keys(this.requestBody.content))
+          this.headers.request.push('Content-Type');
+      }
+      // This is a similar approach, but in this case if we check the response content
+      // and prioritize the 'accept' request header and 'content-type' request header
+      if (!this.headers.response.includes('Content-Type') && this.responses) {
+        if (Object.keys(this.responses).some(response => !!this.responses[response].content))
+          this.headers.response.push('Content-Type');
+      }
+    }
 
     return this.headers;
   }

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -67,7 +67,7 @@ class Operation {
       }, {});
   }
 
-  getHeaders(includeContent = false) {
+  getHeaders() {
     this.headers = {
       request: [],
       response: [],
@@ -104,24 +104,22 @@ class Operation {
       .map(r => Object.keys(this.responses[r].headers))
       .reduce((a, b) => a.concat(b), []);
 
-    if (includeContent) {
-      // If the operation doesn't already specify a 'content-type' request header,
-      // we check if the path operation request body contains content, which implies that
-      // we should also include the 'content-type' header.
-      if (!this.headers.request.includes('Content-Type') && this.requestBody) {
-        if (this.requestBody.$ref) {
-          const ref = findSchemaDefinition(this.requestBody.$ref, this.oas);
-          if (ref.content && Object.keys(ref.content)) this.headers.request.push('Content-Type');
-        } else if (this.requestBody.content && Object.keys(this.requestBody.content))
-          this.headers.request.push('Content-Type');
-      }
-      // This is a similar approach, but in this case if we check the response content
-      // and prioritize the 'accept' request header and 'content-type' request header
-      if (this.responses) {
-        if (Object.keys(this.responses).some(response => !!this.responses[response].content)) {
-          if (!this.headers.request.includes('Accept')) this.headers.request.push('Accept');
-          if (!this.headers.response.includes('Content-Type')) this.headers.response.push('Content-Type');
-        }
+    // If the operation doesn't already specify a 'content-type' request header,
+    // we check if the path operation request body contains content, which implies that
+    // we should also include the 'content-type' header.
+    if (!this.headers.request.includes('Content-Type') && this.requestBody) {
+      if (this.requestBody.$ref) {
+        const ref = findSchemaDefinition(this.requestBody.$ref, this.oas);
+        if (ref.content && Object.keys(ref.content)) this.headers.request.push('Content-Type');
+      } else if (this.requestBody.content && Object.keys(this.requestBody.content))
+        this.headers.request.push('Content-Type');
+    }
+    // This is a similar approach, but in this case if we check the response content
+    // and prioritize the 'accept' request header and 'content-type' request header
+    if (this.responses) {
+      if (Object.keys(this.responses).some(response => !!this.responses[response].content)) {
+        if (!this.headers.request.includes('Accept')) this.headers.request.push('Accept');
+        if (!this.headers.response.includes('Content-Type')) this.headers.response.push('Content-Type');
       }
     }
 


### PR DESCRIPTION
Partially inspired by [`api-explorer`](https://github.com/readmeio/api-explorer/blob/d1df9260c6a7d9d106aa277716fb95d56e5a50fb/packages/oas-to-har/src/index.js#L244-L253).

In the `getHeaders()` function, I'm adding logic to also look in the [`requestBody`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#request-body-object) and [`response`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#responseObject) objects to see if there are `content` fields that contain [media type objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject). If these exist, we can infer `Content-Type` and `Accept` headers and add them to the result.