### PR TITLE
fix: add missing `type` property if missing but has `properties`

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -411,6 +411,37 @@ describe('request bodies', () => {
     ).toStrictEqual([]);
   });
 
+  it('should add a missing `type` property if missing, but `properties` is present', () => {
+    expect(
+      parametersToJsonSchema(
+        {
+          requestBody: {
+            description: 'Body description',
+            content: {
+              'application/json': {
+                schema: {
+                  properties: {
+                    name: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {}
+      )[0].schema
+    ).toStrictEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+      },
+    });
+  });
+
   describe('$ref support', () => {
     it('should work for top-level request body $ref', () => {
       expect(

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -26,6 +26,11 @@ function getBodyParam(pathOperation, oas) {
         // `typeof null` equates to `object` for "legacy reasons" apparently.
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null
       } else if (typeof obj[prop] === 'object' && !Array.isArray(obj[prop])) {
+        // If we have a `properties` object, but no adjacent `type`, we know it's an object so just cast it as one.
+        if (prop === 'properties' && !('type' in obj)) {
+          obj.type = 'object';
+        }
+
         prevProps.push(prop);
         cleanupSchemaDefaults(obj[prop], prop, prevProps);
       } else {


### PR DESCRIPTION
This'll resolve some funky OAS/Swagger documents that we've got in our database right now where a `requestBody` schema has a `properties` object, but no adjacent `type`. Since we can infer that it's an object, we should just cast it as one so as to not break JSON Schema parsing that happens on the resulting constructed schema.