### PR TITLE
fix: being more leanient with how we're constructing types

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -544,7 +544,7 @@ describe('type', () => {
       });
     });
 
-    it('should repair a malformed object that is typod as an array [README-6R]', () => {
+    it('should discard a malformed object that is typod as an array and treat it as a string [README-6R]', () => {
       const parameters = [
         {
           name: 'param',
@@ -559,9 +559,28 @@ describe('type', () => {
       ];
 
       expect(parametersToJsonSchema({ parameters })[0].schema).toStrictEqual({
-        properties: { param: { type: 'array' } },
+        properties: { param: { type: 'string' } },
         required: [],
         type: 'object',
+      });
+    });
+
+    it('should repair an invalid schema that has no `type` as just a simple string', () => {
+      const parameters = [
+        {
+          name: 'userId',
+          in: 'query',
+          schema: {
+            description: 'User ID',
+          },
+        },
+      ];
+
+      expect(parametersToJsonSchema({ parameters })[0].schema.properties).toStrictEqual({
+        userId: {
+          description: 'User ID',
+          type: 'string',
+        },
       });
     });
   });

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -544,7 +544,7 @@ describe('type', () => {
       });
     });
 
-    it('should discard a malformed object that is typod as an array and treat it as a string [README-6R]', () => {
+    it('should repair a malformed object that is typod as an array [README-6R]', () => {
       const parameters = [
         {
           name: 'param',
@@ -559,7 +559,7 @@ describe('type', () => {
       ];
 
       expect(parametersToJsonSchema({ parameters })[0].schema).toStrictEqual({
-        properties: { param: { type: 'string' } },
+        properties: { param: { type: 'object' } },
         required: [],
         type: 'object',
       });

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -197,9 +197,11 @@ function getOtherParams(pathOperation, oas) {
         // Run through the arrays contents and clean them up.
         schema.items = constructSchema(schema.items);
       } else if ('properties' in data || 'additionalProperties' in data) {
-        // If this is a malformed array/object hybrid, discard it as there's no easy way we can make an attempt to
-        // repair it to anything that functions as what it was intended to describe.
-        return {};
+        // This is a fix to handle cases where someone may have typod `items` as `properties` on an array. Since
+        // throwing a complete failure isn't ideal, we can see that they meant for the type to be `object`, so we can do
+        // our best to shape the data into what they were intending it to be.
+        // README-6R
+        schema.type = 'object';
       } else {
         // This is a fix to handle cases where we have a malformed array with no `items` property present.
         // README-8E


### PR DESCRIPTION
If a schema doesn't have a defined `type`, instead of accepting that, we should attempt to do our best to give it a type so it's still valid JSON Schema.