### PR TITLE
fix: if a requestBody schema prop has no type, attempt to add one

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -664,6 +664,38 @@ describe('type', () => {
         type: 'object',
       });
     });
+
+    it('should repair an invalid schema that has no `type` as just a simple string', () => {
+      const schema = parametersToJsonSchema(
+        {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    host: {
+                      description: 'Host name to check validity of.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {}
+      );
+
+      expect(schema[0].schema).toStrictEqual({
+        properties: {
+          host: {
+            description: 'Host name to check validity of.',
+            type: 'string',
+          },
+        },
+        type: 'object',
+      });
+    });
   });
 });
 

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -34,6 +34,20 @@ function getBodyParam(pathOperation, oas) {
         prevProps.push(prop);
         cleanupSchemaDefaults(obj[prop], prop, prevProps);
       } else {
+        if (
+          prevProps.includes('properties') &&
+          !('type' in obj) &&
+          !('$ref' in obj) &&
+          !('allOf' in obj) &&
+          !('oneOf' in obj) &&
+          !('anyOf' in obj) &&
+          prevProp !== 'additionalProperties'
+        ) {
+          // If we're processing a schema that has no types, no refs, and is just a lone schema, we should treat it at
+          // the bare minimum as a simple string so we make an attempt to generate valid JSON Schema.
+          obj.type = 'string';
+        }
+
         switch (prop) {
           case 'additionalProperties':
             // If it's set to `false`, don't bother adding it.


### PR DESCRIPTION
This is a companion part of https://github.com/readmeio/oas/pull/167, but instead of attempting to fix invalid parameter JSO Schema objects, this works on request body and component schemas.