### PR TITLE
fix: bug where a nested allOf/anyOf/oneOf parameter wasn't compiled

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -358,7 +358,7 @@ describe('parameters', () => {
         ],
       });
 
-      expect(schema[0].schema.properties.nestedParam.properties.nesdtedParamProp).toStrictEqual({
+      expect(schema[0].schema.properties.nestedParam.properties.nestedParamProp).toStrictEqual({
         [prop]: [
           {
             type: 'object',

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -336,7 +336,7 @@ describe('parameters', () => {
             name: 'nestedParam',
             schema: {
               properties: {
-                nesdtedParamProp: {
+                nestedParamProp: {
                   [prop]: [
                     {
                       properties: {

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -363,7 +363,7 @@ describe('parameters', () => {
           {
             type: 'object',
             properties: {
-              nesdtedNum: {
+              nestedNum: {
                 type: 'integer',
               },
             },

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -326,6 +326,55 @@ describe('parameters', () => {
       )[0].schema.properties.petId.description
     ).toBe(oas.components.parameters.petId.description);
   });
+
+  describe('polymorphism / inheritance', () => {
+    it.each([['allOf'], ['anyOf'], ['oneOf']])('should support nested %s', prop => {
+      const schema = parametersToJsonSchema({
+        parameters: [
+          {
+            in: 'query',
+            name: 'nestedParam',
+            schema: {
+              properties: {
+                nesdtedParamProp: {
+                  [prop]: [
+                    {
+                      properties: {
+                        nesdtedNum: {
+                          type: 'integer',
+                        },
+                      },
+                      type: 'object',
+                    },
+                    {
+                      type: 'integer',
+                    },
+                  ],
+                },
+              },
+              type: 'object',
+            },
+          },
+        ],
+      });
+
+      expect(schema[0].schema.properties.nestedParam.properties.nesdtedParamProp).toStrictEqual({
+        [prop]: [
+          {
+            type: 'object',
+            properties: {
+              nesdtedNum: {
+                type: 'integer',
+              },
+            },
+          },
+          {
+            type: 'integer',
+          },
+        ],
+      });
+    });
+  });
 });
 
 describe('request bodies', () => {
@@ -520,6 +569,63 @@ describe('request bodies', () => {
           },
         },
       ]);
+    });
+  });
+
+  describe('polymorphism / inheritance', () => {
+    it.each([['allOf'], ['anyOf'], ['oneOf']])('should support nested %s', prop => {
+      const schema = parametersToJsonSchema(
+        {
+          requestBody: {
+            description: 'Body description',
+            content: {
+              'application/json': {
+                schema: {
+                  properties: {
+                    nestedParam: {
+                      properties: {
+                        nestedParamProp: {
+                          [prop]: [
+                            {
+                              properties: {
+                                nestedNum: {
+                                  type: 'integer',
+                                },
+                              },
+                              type: 'object',
+                            },
+                            {
+                              type: 'integer',
+                            },
+                          ],
+                        },
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {}
+      );
+
+      expect(schema[0].schema.properties.nestedParam.properties.nestedParamProp).toStrictEqual({
+        [prop]: [
+          {
+            properties: {
+              nestedNum: {
+                type: 'integer',
+              },
+            },
+            type: 'object',
+          },
+          {
+            type: 'integer',
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -340,7 +340,7 @@ describe('parameters', () => {
                   [prop]: [
                     {
                       properties: {
-                        nesdtedNum: {
+                        nestedNum: {
                           type: 'integer',
                         },
                       },

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -243,6 +243,26 @@ function getOtherParams(pathOperation, oas) {
       }
     } else if ('type' in data) {
       schema.type = data.type;
+    } else {
+      // If we don't have a set type, but are dealing with an anyOf, oneOf, or allOf representation let's run through
+      // them and make sure they're good.
+      // eslint-disable-next-line no-lonely-if
+      if ('allOf' in data && Array.isArray(data.allOf)) {
+        schema.allOf = data.allOf;
+        schema.allOf.forEach((item, idx) => {
+          schema.allOf[idx] = constructSchema(item);
+        });
+      } else if ('anyOf' in data && Array.isArray(data.anyOf)) {
+        schema.anyOf = data.anyOf;
+        schema.anyOf.forEach((item, idx) => {
+          schema.anyOf[idx] = constructSchema(item);
+        });
+      } else if ('oneOf' in data && Array.isArray(data.oneOf)) {
+        schema.oneOf = data.oneOf;
+        schema.oneOf.forEach((item, idx) => {
+          schema.oneOf[idx] = constructSchema(item);
+        });
+      }
     }
 
     if ('allowEmptyValue' in data) {


### PR DESCRIPTION
This resolves an edge case on parameters where if a parameter contained a nested `allOf`, `anyOf`, or `oneOf` array, we wouldn't add that to the compiled JSON Schema representation, which would result in the parameter not validating.