### PR TITLE
fix: don't set a type on a properties key if that key is a param

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -491,6 +491,39 @@ describe('request bodies', () => {
     });
   });
 
+  it('should handle object property keys that are named "properties"', () => {
+    const schema = parametersToJsonSchema(
+      {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  properties: {
+                    type: 'object',
+                    properties: {
+                      tktk: {
+                        type: 'integer',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {}
+    );
+
+    // What we're testing here is that we don't add a `type: object` adjacent to the `properties`-named object property.
+    expect(Object.keys(schema[0].schema.properties)).toStrictEqual(['name', 'properties']);
+  });
+
   describe('$ref support', () => {
     it('should work for top-level request body $ref', () => {
       expect(

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -28,7 +28,11 @@ function getBodyParam(pathOperation, oas) {
       } else if (typeof obj[prop] === 'object' && !Array.isArray(obj[prop])) {
         // If we have a `properties` object, but no adjacent `type`, we know it's an object so just cast it as one.
         if (prop === 'properties' && !('type' in obj)) {
-          obj.type = 'object';
+          if (prevProp && prevProp === 'properties') {
+            // Only add a type if the previous prop isn't also named `properties`!
+          } else {
+            obj.type = 'object';
+          }
         }
 
         prevProps.push(prop);


### PR DESCRIPTION
Last week I put in a fix to our JSON Schema compilation to add `type: object` on objects if it's missing one and we know that that object has a `properties` object. Problem with this was that this was also being applied to objects that had a properties key named `properties`. This fixes that.

```json
"requestBody": {
  "content": {
    "application/json": {
      "schema": {
        "type": "object",
        "properties": {
          "name": {
            "type": "string"
          },
          "properties": {
            "type": "object",
            "properties": {
              "tktk": {
                "type": "integer"
              }
            }
          }
        }
      }
    }
  }
}
```