### PR TITLE
fix: bug where a string type would be added to anyOf, oneOf, and allOf

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -704,22 +704,52 @@ describe('type', () => {
       });
     });
 
-    it('should repair an invalid schema that has no `type` as just a simple string', () => {
-      const parameters = [
-        {
-          name: 'userId',
-          in: 'query',
-          schema: {
-            description: 'User ID',
+    describe('repair invalid schema that has no `type`', () => {
+      it('should repair an invalid schema that has no `type` as just a simple string', () => {
+        const parameters = [
+          {
+            name: 'userId',
+            in: 'query',
+            schema: {
+              description: 'User ID',
+            },
           },
-        },
-      ];
+        ];
 
-      expect(parametersToJsonSchema({ parameters })[0].schema.properties).toStrictEqual({
-        userId: {
-          description: 'User ID',
-          type: 'string',
-        },
+        expect(parametersToJsonSchema({ parameters })[0].schema.properties).toStrictEqual({
+          userId: {
+            description: 'User ID',
+            type: 'string',
+          },
+        });
+      });
+
+      it.each([['allOf'], ['anyOf'], ['oneOf']])('should not add a missing type on an %s schema', prop => {
+        const parameters = [
+          {
+            description: 'Order creation date',
+            in: 'query',
+            name: 'created',
+            schema: {
+              [prop]: [
+                {
+                  properties: {
+                    gt: {
+                      type: 'integer',
+                    },
+                  },
+                  title: 'range_query_specs',
+                  type: 'object',
+                },
+                {
+                  type: 'integer',
+                },
+              ],
+            },
+          },
+        ];
+
+        expect(parametersToJsonSchema({ parameters })[0].schema.properties.created.type).toBeUndefined();
       });
     });
   });

--- a/packages/tooling/src/lib/parameters-to-json-schema.js
+++ b/packages/tooling/src/lib/parameters-to-json-schema.js
@@ -195,9 +195,9 @@ function getOtherParams(pathOperation, oas) {
       !('type' in data) &&
       !('$ref' in data) &&
       !('allOf' in data) &&
-      !('oneOf' in data) &&
       !('anyOf' in data) &&
-      prevProp !== 'additionalProperties'
+      !('oneOf' in data) &&
+      (!prevProp || (prevProp && prevProp !== 'additionalProperties'))
     ) {
       // If we're processing a schema that has no types, no refs, and is just a lone schema, we should treat it at the
       // bare minimum as a simple string so we make an attempt to generate valid JSON Schema.
@@ -303,9 +303,14 @@ function getOtherParams(pathOperation, oas) {
 
     const properties = parameters.reduce((prev, current) => {
       const schema = {
-        type: 'string',
         ...(current.schema ? constructSchema(current.schema) : {}),
       };
+
+      // If we still don't have a `type` at the highest level of this schema, and it's not a polymorphism/inheritance
+      // model, add a `string` type so the schema will be valid.
+      if (!('type' in schema) && !('allOf' in schema) && !('anyOf' in schema) && !('oneOf' in schema)) {
+        schema.type = 'string';
+      }
 
       if (current.description) {
         schema.description = current.description;


### PR DESCRIPTION
This resolves a bug in our processing of `anyOf`, `oneOf` and `allOf` schemas where in specific cases, we'd add a `type: string` default to it if it were missing a type. This would result in the following broken UI in the API Explorer:

![80650697-54d8ad80-8a29-11ea-9d27-e49836e2a98a](https://user-images.githubusercontent.com/33762/80655915-b2262c00-8a34-11ea-8b0a-06e468bad8f8.png)

Turns out that trying to repair bad OAS schemas is difficult.