### PR TITLE
fix: edge case where component would sometimes be marked a string

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -834,35 +834,77 @@ describe('type', () => {
       });
     });
 
-    it('should repair an invalid schema that has no `type` as just a simple string', () => {
-      const schema = parametersToJsonSchema(
-        {
-          requestBody: {
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    host: {
-                      description: 'Host name to check validity of.',
+    describe('repair invalid schema that has no `type`', () => {
+      it('should repair an invalid schema that has no `type` as just a simple string', () => {
+        const schema = parametersToJsonSchema(
+          {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      host: {
+                        description: 'Host name to check validity of.',
+                      },
                     },
                   },
                 },
               },
             },
           },
-        },
-        {}
-      );
+          {}
+        );
 
-      expect(schema[0].schema).toStrictEqual({
-        properties: {
-          host: {
-            description: 'Host name to check validity of.',
-            type: 'string',
+        expect(schema[0].schema).toStrictEqual({
+          properties: {
+            host: {
+              description: 'Host name to check validity of.',
+              type: 'string',
+            },
           },
-        },
-        type: 'object',
+          type: 'object',
+        });
+      });
+
+      it('should not add a string type on a ref and component schema that are clearly objects', () => {
+        const schema = parametersToJsonSchema(
+          {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/NewUser',
+                  },
+                },
+              },
+            },
+          },
+          {
+            components: {
+              schemas: {
+                ErrorResponse: {
+                  properties: {
+                    message: {
+                      type: 'string',
+                    },
+                  },
+                },
+                NewUser: {
+                  required: ['user_id'],
+                  properties: {
+                    user_id: {
+                      type: 'integer',
+                    },
+                  },
+                },
+              },
+            },
+          }
+        );
+
+        expect(schema[0].schema.components.schemas.ErrorResponse.type).toBe('object');
+        expect(schema[0].schema.components.schemas.NewUser.type).toBe('object');
       });
     });
   });


### PR DESCRIPTION
| [🎟 Asana](https://app.asana.com/0/681252538274980/1173503272587186/f) |
| :---  |

## 🆘 Problem

This resolves an edge case that was introduced in some logic I added to repair schemas without a `type` that was sometimes marking the schema object as a `string`.  This would result in the following "broken" UI:
 
![Screen Shot 2020-04-29 at 10 42 36 PM](https://user-images.githubusercontent.com/33762/80676038-be2ce080-8a6a-11ea-949c-87fb2b898556.png)

You can see it in action here:  http://bin.readme.com/s/5eaa651315dd18002423bd32

Now if we remove the `InputErrorResponse`, we'll see that it's resolved:

![Screen Shot 2020-04-29 at 10 43 08 PM](https://user-images.githubusercontent.com/33762/80676090-dc92dc00-8a6a-11ea-9852-bd48ef2ee144.png)

Now what if you move the `InputErrorResponse` schema below `NewPreauthorization`?

![Screen Shot 2020-04-29 at 10 46 16 PM](https://user-images.githubusercontent.com/33762/80676265-4317fa00-8a6b-11ea-9126-a81a72fb80b3.png)

😬 

## 🚧 Resolution
So the reason this was happening was that since our `cleanupSchemaDefaults` method for `requestBody` and component schema objects is recursive, and we were invoking it against the `components` object, and not individual schemas, it was difficult for us to ascertain when we were **first** processing a component schema and when we should add a missing `type` at the top level of a schema if it didn't have one.

For this specific case, what was tripping up our logic was a few things:

* Both `InputErrorResponse` and `NewPreauthorization` schemas didn't have a defined `type`.
* Our code would correctly identify `InputErrorResponse` as an object because we hadn't seen a top-level `properties` property yet until that point, and when we did we immediately knew that we were processing an object, and could mark it as such.
* Once we hit the `NewPreauthorization` schema, and after we had already processed `InputErrorResponse`, we had the following data in our internal recursive `prevProps` memory state:

```
[
  "schemas", 
  "InputErrorResponse", 
  "properties", 
  "code", 
  "message", 
  "NewPreauthorization"
]
```

Since we retained knowledge of parsing `properties`, our code misinterpreted this as having already seen this schema before, is it not parsing properties again for it and since it's missing a `type` to add `string` so it's still valid JSON Schema. 

![source](https://user-images.githubusercontent.com/33762/80677618-11ecf900-8a6e-11ea-9396-a2191271cfbb.gif)

Resolving this involved a couple things:

* [x] Shift our recursive processing of component schemas to start at the schema itself, not the `components` level. This way we'll know exactly when we're **first** seeing a component schema.
* [x] Update our internal `prevProps` memory state to clean itself out if we don't have a `prevProp`. This will resolve the issue of `prevProps` retaining data from previously processed schemas.