### PR TITLE
fix: trim surrounding whitespace in server URLs

### DIFF
--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -4,6 +4,12 @@ const petstore = require('./__fixtures__/petstore.json');
 const petstoreServerVars = require('./__fixtures__/petstore-server-vars.json');
 const serverVariables = require('./__fixtures__/server-variables.json');
 
+describe('#url()', () => {
+  it('should trim surrounding whitespace from the url', () => {
+    expect(new Oas({ servers: [{ url: '  http://example.com/' }] }).url()).toBe('http://example.com');
+  });
+});
+
 describe('#operation()', () => {
   it('should return an operation object', () => {
     const oas = { paths: { '/path': { get: { a: 1 } } } };

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -123,7 +123,7 @@ class Oas {
       variables = {};
     }
 
-    return this.replaceUrl(url, variables);
+    return this.replaceUrl(url, variables).trim();
   }
 
   replaceUrl(url, variables) {


### PR DESCRIPTION
Server URLs with proceeding whitespace cause HAR validation errors. 🤦 