### PR TITLE
feat: adding a getContentType method into the OAS Operation class

### DIFF
--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -4,10 +4,16 @@ const petstore = require('./__fixtures__/petstore.json');
 const multipleSecurities = require('./__fixtures__/multiple-securities.json');
 const referenceSpec = require('./__fixtures__/local-link.json');
 
+describe('#getContentType', () => {
+  it('should return the content type on an operation', () => {
+    expect(new Oas(petstore).operation('/pet', 'post').getContentType()).toBe('application/json');
+  });
+});
+
 describe('#getSecurity()', () => {
   const security = [{ auth: [] }];
 
-  it('should return the security on this endpoint', () => {
+  it('should return the security on this operation', () => {
     expect(
       new Oas({
         info: { version: '1.0' },

--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -8,6 +8,64 @@ describe('#getContentType', () => {
   it('should return the content type on an operation', () => {
     expect(new Oas(petstore).operation('/pet', 'post').getContentType()).toBe('application/json');
   });
+
+  it('should prioritise json if it exists', () => {
+    expect(
+      new Operation(petstore, '/body', 'get', {
+        requestBody: {
+          content: {
+            'text/xml': {
+              schema: {
+                type: 'string',
+                required: ['a'],
+                properties: {
+                  a: {
+                    type: 'string',
+                  },
+                },
+              },
+              example: { a: 'value' },
+            },
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['a'],
+                properties: {
+                  a: {
+                    type: 'string',
+                  },
+                },
+              },
+              example: { a: 'value' },
+            },
+          },
+        },
+      }).getContentType()
+    ).toBe('application/json');
+  });
+
+  it('should fetch the type from the first requestBody if it is not JSON-like', () => {
+    expect(
+      new Operation(petstore, '/body', 'get', {
+        requestBody: {
+          content: {
+            'text/xml': {
+              schema: {
+                type: 'object',
+                required: ['a'],
+                properties: {
+                  a: {
+                    type: 'string',
+                  },
+                },
+              },
+              example: { a: 'value' },
+            },
+          },
+        },
+      }).getContentType()
+    ).toBe('text/xml');
+  });
 });
 
 describe('#getSecurity()', () => {

--- a/packages/tooling/package-lock.json
+++ b/packages/tooling/package-lock.json
@@ -996,12 +996,6 @@
         "eslint-plugin-unicorn": "^19.0.1"
       }
     },
-    "@readme/oas-examples": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-3.0.0.tgz",
-      "integrity": "sha512-8icVZrS+V8DxdFLbErNSxqw6rqXBTa/i6YeNiLdVkqCh2veZ13lvmbgmzg9U3mzINosenqpAeT1bpC41SZ4goQ==",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",

--- a/packages/tooling/src/operation.js
+++ b/packages/tooling/src/operation.js
@@ -8,6 +8,24 @@ class Operation {
     this.method = method;
   }
 
+  getContentType() {
+    const types = (this.requestBody && this.requestBody.content && Object.keys(this.requestBody.content)) || [];
+
+    let type = 'application/json';
+    if (types && types.length) {
+      type = types[0];
+    }
+
+    // Favor JSON if it exists
+    types.forEach(t => {
+      if (t.match(/json/)) {
+        type = t;
+      }
+    });
+
+    return type;
+  }
+
   getSecurity() {
     return this.security || this.oas.security || [];
   }
@@ -76,6 +94,7 @@ class Operation {
         return h.name;
       });
     }
+
     if (security.Bearer || security.Basic) {
       this.headers.request.push('Authorization');
     }


### PR DESCRIPTION
This method exists currently in `@readme/oas-to-har` but it makes more sense for it to live here.

https://github.com/readmeio/api-explorer/blob/master/packages/oas-to-har/src/index.js#L32-L53