### PR TITLE
feat: adding a `getOperation` method into the OAS class

### DIFF
--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -192,6 +192,30 @@ describe('#findOperation()', () => {
   });
 });
 
+// Since this is just a wrapper for findOperation, we don't need to re-test everything that the tests for that does. All
+// we need to know is that if findOperation fails this fails, as well as the reverse.
+describe('#getOperation()', () => {
+  it('should return undefined if #findOperation returns undefined', () => {
+    const oas = new Oas(petstore);
+    const uri = `http://localhost:3000/pet/1`;
+    const method = 'DELETE';
+
+    expect(oas.getOperation(uri, method)).toBeUndefined();
+  });
+
+  it('should return a result if found', () => {
+    const oas = new Oas(petstore);
+    const uri = `http://petstore.swagger.io/v2/pet/1`;
+    const method = 'DELETE';
+
+    const res = oas.getOperation(uri, method);
+    expect(res).toBeInstanceOf(Operation);
+
+    expect(res.path).toBe('/pet/:petId');
+    expect(res.method).toBe('DELETE');
+  });
+});
+
 describe('server variables', () => {
   it('should use defaults', () => {
     expect(

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -138,6 +138,15 @@ class Oas {
     return new Operation(this, path, method, operation);
   }
 
+  /**
+   * Discover an operation in an OAS from a fully-formed URL and HTTP method. Will return an object containing a `url`
+   * object and another one for `operation`. This differs from `getOperation()` in that it does not return an instance
+   * of the `Operation` class.
+   *
+   * @param {String} url
+   * @param {String} method
+   * @return {(Object|undefined)}
+   */
   findOperation(url, method) {
     const { origin } = new URL(url);
     const originRegExp = new RegExp(origin);
@@ -157,6 +166,23 @@ class Oas {
     if (!includesMethod.length) return undefined;
 
     return findTargetPath(includesMethod);
+  }
+
+  /**
+   * Retrieve an operation in an OAS from a fully-formed URL and HTTP method. Differs from `findOperation` in that while
+   * this method will return an `Operation` instance, `findOperation()` does not.
+   *
+   * @param {String} url
+   * @param {String} method
+   * @return {(Operation|undefined)}
+   */
+  getOperation(url, method) {
+    const op = this.findOperation(url, method);
+    if (op === undefined) {
+      return undefined;
+    }
+
+    return this.operation(op.url.path, op.url.method);
   }
 }
 


### PR DESCRIPTION
This adds a new `getOperation` method into the `OAS` class that differs from `findOperation` in that `getOperation` will transform the results from `findOperation` into an instance of the `Operation` class.

Adding this because I need an `Operation` instance to work with for some fixes in https://github.com/readmeio/api/issues/71.