### PR TITLE
feat: properly handle cookie auth

### DIFF
--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -238,9 +238,6 @@ describe('#prepareSecurity()', () => {
 
   it.todo('should set a `key` property');
 
-  // TODO We dont currently support cookies?
-  it.todo('apiKey/cookie: should return with a type of Cookie');
-
   it.todo('should throw if attempting to use a non-existent scheme');
 
   it('should return empty object if no security', () => {

--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -197,6 +197,20 @@ describe('#prepareSecurity()', () => {
     });
   });
 
+  it('apiKey/cookie: should return with a type of Cookie', () => {
+    const oas = createSecurityOas({
+      securityScheme: {
+        type: 'apiKey',
+        in: 'cookie',
+      },
+    });
+    const operation = oas.operation(path, method);
+
+    expect(operation.prepareSecurity()).toStrictEqual({
+      Cookie: [oas.components.securitySchemes.securityScheme],
+    });
+  });
+
   it('should work for petstore', () => {
     const operation = new Oas(petstore).operation('/pet', 'post');
 
@@ -311,7 +325,7 @@ describe('#getHeaders()', () => {
     const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
     expect(operation.getHeaders()).toMatchObject({
-      request: ['Cookie', 'Authorization', 'Accept'],
+      request: ['Authorization', 'Cookie', 'Accept'],
       response: ['Content-Type'],
     });
   });

--- a/packages/tooling/src/operation.js
+++ b/packages/tooling/src/operation.js
@@ -59,7 +59,8 @@ class Operation {
             type = 'OAuth2';
           } else if (security.type === 'apiKey') {
             if (security.in === 'query') type = 'Query';
-            else if (security.in === 'header' || security.in === 'cookie') type = 'Header';
+            else if (security.in === 'header') type = 'Header';
+            else if (security.in === 'cookie') type = 'Cookie';
           } else {
             return false;
           }
@@ -90,13 +91,16 @@ class Operation {
     const security = this.prepareSecurity();
     if (security.Header) {
       this.headers.request = security.Header.map(h => {
-        if (h.in === 'cookie') return 'Cookie';
         return h.name;
       });
     }
 
     if (security.Bearer || security.Basic) {
       this.headers.request.push('Authorization');
+    }
+
+    if (security.Cookie) {
+      this.headers.request.push('Cookie');
     }
 
     if (this.parameters) {


### PR DESCRIPTION
This adds formal support for handling [cookie auth](https://swagger.io/docs/specification/authentication/cookie-authentication/) in `@readme/oas-tooling`.