### PR TITLE
fix: dedupe security schemes when plucking them out of an oas

### DIFF
--- a/packages/tooling/__tests__/__fixtures__/multiple-securities.json
+++ b/packages/tooling/__tests__/__fixtures__/multiple-securities.json
@@ -171,6 +171,28 @@
         }
       }
     },
+    "/multiple-combo-auths-duped": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        },
+        "security": [
+          {
+            "apiKeyScheme": [],
+            "httpBearer": []
+          },
+          {
+            "apiKeyScheme": [],
+            "apiKeySignature": []
+          }
+        ]
+      }
+    },
     "/unknown-auth-type": {
       "post": {
         "operationId": "unknownAuthType",
@@ -225,9 +247,18 @@
           }
         }
       },
+      "httpBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      },
       "apiKeyScheme": {
         "type": "apiKey",
         "name": "testKey",
+        "in": "header"
+      },
+      "apiKeySignature": {
+        "type": "apiKey",
+        "name": "X-AUTH-SIGNATURE",
         "in": "header"
       },
       "unknownAuthType": {

--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -236,6 +236,13 @@ describe('#prepareSecurity()', () => {
     expect(operation.prepareSecurity().Header).toHaveLength(1);
   });
 
+  it('should dedupe securities in within an && and || situation', () => {
+    const operation = new Oas(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
+
+    expect(operation.prepareSecurity().Bearer).toHaveLength(1);
+    expect(operation.prepareSecurity().Header).toHaveLength(2);
+  });
+
   it.todo('should set a `key` property');
 
   it.todo('should throw if attempting to use a non-existent scheme');

--- a/packages/tooling/src/operation.js
+++ b/packages/tooling/src/operation.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 const findSchemaDefinition = require('./lib/find-schema-definition');
 
 class Operation {
@@ -65,7 +66,6 @@ class Operation {
             return false;
           }
 
-          // eslint-disable-next-line no-underscore-dangle
           security._key = key;
 
           return { type, security };
@@ -76,7 +76,12 @@ class Operation {
           // Remove non-existent schemes
           if (!security) return;
           if (!prev[security.type]) prev[security.type] = [];
-          prev[security.type].push(security.security);
+
+          // Only add schemes we haven't seen yet.
+          const exists = prev[security.type].findIndex(sec => sec._key === security.security._key);
+          if (exists < 0) {
+            prev[security.type].push(security.security);
+          }
         });
         return prev;
       }, {});


### PR DESCRIPTION
This resolves an issue with `operation.prepareSecurity()` where if an operation used the same security scheme multiples within an `||` `security` definition, it would be prepared multiple times, resulting in something that looks like the following within the API Explorer:

![Screen Shot 2020-07-14 at 12 44 17 PM](https://user-images.githubusercontent.com/33762/87469381-0cfd0780-c5d0-11ea-8c35-e454f9d48064.png)

With this fix, it'll now look like:

![Screen Shot 2020-07-14 at 12 44 32 PM](https://user-images.githubusercontent.com/33762/87469398-138b7f00-c5d0-11ea-97de-b3f1b5f47ca7.png)