### PR TITLE
fix: findOperation issues with "/" paths

### DIFF
--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -217,6 +217,14 @@ describe('#findOperation()', () => {
       slugs: {},
       method: 'GET',
     });
+
+    expect(res.operation).toStrictEqual({
+      responses: {
+        '200': {
+          description: 'OK',
+        },
+      },
+    });
   });
 
   it('should return result if in server variable defaults', () => {

--- a/packages/tooling/__tests__/oas.test.js
+++ b/packages/tooling/__tests__/oas.test.js
@@ -185,6 +185,40 @@ describe('#findOperation()', () => {
     });
   });
 
+  it('should return result if path is slash', () => {
+    const oas = new Oas({
+      openapi: '3.0.0',
+      servers: [
+        {
+          url: 'https://example.com',
+        },
+      ],
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const uri = 'https://example.com';
+    const method = 'get';
+
+    const res = oas.findOperation(uri, method);
+    expect(res.url).toStrictEqual({
+      origin: 'https://example.com',
+      path: '/',
+      nonNormalizedPath: '/',
+      slugs: {},
+      method: 'GET',
+    });
+  });
+
   it('should return result if in server variable defaults', () => {
     const oas = new Oas(serverVariables);
     const uri = 'https://demo.example.com:443/v2/post';

--- a/packages/tooling/src/oas.js
+++ b/packages/tooling/src/oas.js
@@ -167,8 +167,9 @@ class Oas {
     if (!targetServer) return undefined;
     targetServer.url = this.replaceUrl(targetServer.url, targetServer.variables || {});
 
-    const [, pathName] = url.split(targetServer.url);
+    let [, pathName] = url.split(targetServer.url);
     if (pathName === undefined) return undefined;
+    if (pathName === '') pathName = '/';
     const annotatedPaths = generatePathMatches(paths, pathName, targetServer.url);
     if (!annotatedPaths.length) return undefined;
 


### PR DESCRIPTION
For [Paths Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#pathsObject) that only contain `/`, `findOperation()` wasn't handling trailing slashes properly. For example, the ReadMe API has a `/` endpoint but `findOperation()` will return `undefined` for routes like https://dash.readme.com/api/v1 since it'll look for https://dash.readme.com/api/v1/.

Not sure if this is the best approach but I think it should be fine since [the spec dictates](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#user-content-patterned-fields:~:text=The%20field%20name%20MUST%20begin%20with%20a%20forward%20slash%20(%2F).) the following:
> The field name MUST begin with a forward slash (`/`)

meaning that all paths should contain a `/` at the bare minimum.