### PR TITLE
fix: add support for $ref when pulling content types

### DIFF
--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -95,7 +95,7 @@ describe('#getContentType', () => {
         },
       },
       '/body',
-      'get',
+      'post',
       {
         requestBody: {
           $ref: '#/components/requestBodies/payload',

--- a/packages/tooling/__tests__/operation.test.js
+++ b/packages/tooling/__tests__/operation.test.js
@@ -66,6 +66,45 @@ describe('#getContentType', () => {
       }).getContentType()
     ).toBe('text/xml');
   });
+
+  it('should handle cases where the requestBody is a $ref', () => {
+    const op = new Operation(
+      {
+        ...petstore,
+        ...{
+          components: {
+            requestBodies: {
+              payload: {
+                required: true,
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        'Document file': {
+                          type: 'string',
+                          format: 'binary',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/body',
+      'get',
+      {
+        requestBody: {
+          $ref: '#/components/requestBodies/payload',
+        },
+      }
+    );
+
+    expect(op.getContentType()).toBe('multipart/form-data');
+  });
 });
 
 describe('#getSecurity()', () => {

--- a/packages/tooling/src/operation.js
+++ b/packages/tooling/src/operation.js
@@ -10,7 +10,16 @@ class Operation {
   }
 
   getContentType() {
-    const types = (this.requestBody && this.requestBody.content && Object.keys(this.requestBody.content)) || [];
+    let types = [];
+    if (this.requestBody) {
+      if ('$ref' in this.requestBody) {
+        this.requestBody = findSchemaDefinition(this.requestBody.$ref, this.oas);
+      }
+
+      if ('content' in this.requestBody) {
+        types = Object.keys(this.requestBody.content);
+      }
+    }
 
     let type = 'application/json';
     if (types && types.length) {


### PR DESCRIPTION
This adds support for resolving `$ref` pointers in `requestBody` when attempting to discover the `Content-Type` header of an operation.

Resolves https://app.asana.com/0/1177947654981875/1175486497688586/f