### PR TITLE
fix: case where titles in polymorphism schemas would be removed

### DIFF
--- a/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
+++ b/packages/tooling/__tests__/lib/parameters-to-json-schema.test.js
@@ -968,6 +968,56 @@ describe('format', () => {
   });
 });
 
+describe('titles', () => {
+  it('should pass through titles on polymorphism refs', () => {
+    const schema = parametersToJsonSchema(
+      {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  {
+                    $ref: '#/components/schemas/Dog',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      {
+        components: {
+          schemas: {
+            Dog: {
+              title: 'Dog',
+              allOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    breed: {
+                      type: 'string',
+                      enum: ['Dingo', 'Husky', 'Retriever', 'Shepherd'],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      }
+    );
+
+    expect(schema[0].schema.components.schemas.Dog.title).toBe('Dog');
+    expect(schema[0].schema.oneOf).toStrictEqual([
+      {
+        $ref: '#/components/schemas/Dog',
+        title: 'Dog',
+      },
+    ]);
+  });
+});
+
 describe('descriptions', () => {
   it.todo('should pass through description on requestBody');
 


### PR DESCRIPTION
This fixes a case where under certain circumstances, `title` properties in polymorphism schemas (`oneOf`, `anyOf`, and `oneOf`) would sometimes be deleted.

This also introduces a workaround for a bug in https://github.com/rjsf-team/react-jsonschema-form where if a `title` property on a `$ref` within one of the aforementioned schemas isn't at the same level as the `$ref`, it's not used when constructing a dropdown picker, resulting in a placeholder that looks like "Option 1".