### PR TITLE
fix: flattenSchema not properly flattening allOf/oneOf/anyOf schemas

### DIFF
--- a/packages/tooling/__tests__/__fixtures__/nested-allof-flattening.json
+++ b/packages/tooling/__tests__/__fixtures__/nested-allof-flattening.json
@@ -1,0 +1,112 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "nested allOf flattening"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json;charset=UTF-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/extendedAttribute"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "extendedAttribute": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "createdOn": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "lastModifiedOn": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "application": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/link"
+              }
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "linkBase": {
+        "type": "object",
+        "required": [
+          "href",
+          "rel"
+        ],
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string",
+            "readOnly": true
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/metadata"
+          }
+        }
+      },
+      "link": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/linkBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "$ref": "#/components/schemas/linkBase"
+              }
+            }
+          }
+        ]
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "createdOn": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "lastModifiedOn": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/tooling/__tests__/lib/flatten-schema.test.js
+++ b/packages/tooling/__tests__/lib/flatten-schema.test.js
@@ -215,6 +215,27 @@ describe('polymorphism cases', () => {
       ]);
     });
 
+    it("should be able to handle an allOf that's nested a level down", () => {
+      // eslint-disable-next-line global-require
+      const oas = require('../__fixtures__/nested-allof-flattening.json');
+      const schema = oas.components.schemas.extendedAttribute;
+
+      expect(flattenSchema(schema, oas)).toStrictEqual([
+        { name: 'createdOn', type: 'String', description: undefined },
+        { name: 'lastModifiedOn', type: 'String', description: undefined },
+        { name: 'application.href', type: 'String', description: undefined },
+        { name: 'application.title', type: 'String', description: undefined },
+        { name: 'application.metadata', type: 'Object', description: undefined },
+        { name: 'application.metadata.createdOn', type: 'String', description: undefined },
+        { name: 'application.metadata.lastModifiedOn', type: 'String', description: undefined },
+        { name: 'application.source', type: 'Object', description: undefined },
+        { name: 'application.source.href', type: 'String', description: undefined },
+        { name: 'application.source.title', type: 'String', description: undefined },
+        { name: 'application.source.metadata', type: 'Object', description: undefined },
+        { name: 'value', type: 'String', description: undefined },
+      ]);
+    });
+
     it('should be able to handle an allOf that contains deep $refs', () => {
       const schema = {
         allOf: [

--- a/packages/tooling/src/lib/flatten-schema.js
+++ b/packages/tooling/src/lib/flatten-schema.js
@@ -29,9 +29,7 @@ module.exports = (schema, oas) => {
 
         if (value.type === 'object') {
           array.push(flattenSchema(value, getName(parent, prop), level + 1));
-        }
-
-        if (value.type === 'array' && value.items) {
+        } else if (value.type === 'array' && value.items) {
           let { items } = value;
           if (items.$ref) {
             items = findSchemaDefinition(items.$ref, oas);
@@ -59,6 +57,9 @@ module.exports = (schema, oas) => {
             array = array.concat(flattenSchema(items, newParent, level));
           }
 
+          return array;
+        } else if ('allOf' in value || 'oneOf' in value || 'anyOf' in value) {
+          array = array.concat(flattenSchema(value, getName(parent, prop), level + 1));
           return array;
         }
 


### PR DESCRIPTION
This fixes a case where `flattenSchema` wouldn't handle `allOf`, `anyOf`, and `oneOf` cases, resulting in a flattened schema that'd look like:

![unnamed](https://user-images.githubusercontent.com/33762/96048397-6a049580-0e2b-11eb-9c3d-02186db2ab63.png)
