### PR TITLE
feat: add scope support to `oas generate` command

### DIFF
--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -25,17 +25,28 @@ exports.config = function (env) {
 
 exports.findSwagger = function (info, cb) {
   const base = exports.isSwagger(_.last(info.args)) ? _.last(info.args) : undefined;
-  const scope = info.opts.scope ? info.opts.scope : undefined;
 
   swaggerInline('**/*', {
     format: '.json',
     metadata: true,
+    scope: info.opts.scope,
     base,
-    scope
   }).then(generatedSwaggerString => {
     const oas = new OAS(generatedSwaggerString);
 
     oas.bundle(function (err, schema) {
+      // Log as much of the error as possible for more helpful debugging.
+      if (err) {
+        const { code, message, source, stack } = err;
+
+        console.log(code);
+        console.log(message);
+        console.log(source);
+        console.log(stack);
+
+        process.exit(1);
+      }
+
       if (!schema['x-si-base']) {
         console.log("We couldn't find a Swagger file.".red);
         console.log(`Don't worry, it's easy to get started! Run ${'oas init'.yellow} to get started.`);

--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -25,8 +25,6 @@ exports.config = function (env) {
 
 exports.findSwagger = function (info, cb) {
   const base = exports.isSwagger(_.last(info.args)) ? _.last(info.args) : undefined;
-  console.log('%%%%%%%%%%%%');
-  console.log(info);
   const scope = info.opts.scope ? info.opts.scope : undefined;
 
   swaggerInline('**/*', {

--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -25,6 +25,8 @@ exports.config = function (env) {
 
 exports.findSwagger = function (info, cb) {
   const base = exports.isSwagger(_.last(info.args)) ? _.last(info.args) : undefined;
+  console.log('%%%%%%%%%%%%');
+  console.log(info);
   const scope = info.opts.scope ? info.opts.scope : undefined;
 
   swaggerInline('**/*', {


### PR DESCRIPTION
## What's being changed?

This PR passes in the `scope` argument to `swagger-inline` so that generated swagger files can be properly scoped.

As per https://github.com/readmeio/swagger-inline#available-options, swagger files can be generated by matching the scope field declared.

## Usage of scope
No scope
`oas generate VetStore.yaml`

With scope
`oas generate VetStore.yaml --scope public`


## Testing
Please see repo for example:
https://github.com/kschiu/oas_test


In the `src/` directory,  ran: `oas generate VetStore.yaml > ../no_scope.json`, which generated:
https://github.com/kschiu/oas_test/blob/master/no_scope.json

In the `src/` directory,  ran: `oas generate VetStore.yaml --scope public > ../public_scope.json`, which generated:
https://github.com/kschiu/oas_test/blob/master/public_scope.json