### PR TITLE
feat: adding support for creating example schemas on allOf schemas

### DIFF
--- a/__tests__/tooling/__datasets__/operation-examples.json
+++ b/__tests__/tooling/__datasets__/operation-examples.json
@@ -462,6 +462,37 @@
           }
         }
       }
+    },
+    "/wildcard-media-type": {
+      "post": {
+        "description": "This operation handles a single media type that returns a wildcard `*/*`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "*/*": {
+              "example": {
+                "id": 12343354,
+                "email": "test@example.com",
+                "name": "Test user name"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "example": {
+                  "id": 12343354,
+                  "email": "test@example.com",
+                  "name": "Test user name"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/__tests__/tooling/operation/get-requestbody-examples.test.js
+++ b/__tests__/tooling/operation/get-requestbody-examples.test.js
@@ -11,6 +11,21 @@ test('should return early if there is no request body', async () => {
   expect(await operation.getRequestBodyExamples()).toStrictEqual([]);
 });
 
+test('should support */* media types', async () => {
+  const operation = oas.operation('/wildcard-media-type', 'post');
+  expect(await operation.getRequestBodyExamples()).toStrictEqual([
+    {
+      code: cleanStringify({
+        id: 12343354,
+        email: 'test@example.com',
+        name: 'Test user name',
+      }),
+      mediaType: '*/*',
+      multipleExamples: false,
+    },
+  ]);
+});
+
 describe('no curated examples present', () => {
   it('should not generate an example if there is no schema and an empty example', async () => {
     const operation = oas.operation('/emptyexample', 'post');

--- a/__tests__/tooling/operation/get-response-examples.test.js
+++ b/__tests__/tooling/operation/get-response-examples.test.js
@@ -11,6 +11,26 @@ test('should return early if there is no response', async () => {
   expect(await operation.getResponseExamples()).toStrictEqual([]);
 });
 
+test('should support */* media types', async () => {
+  const operation = oas.operation('/wildcard-media-type', 'post');
+  expect(await operation.getResponseExamples()).toStrictEqual([
+    {
+      languages: [
+        {
+          code: cleanStringify({
+            id: 12343354,
+            email: 'test@example.com',
+            name: 'Test user name',
+          }),
+          language: '*/*',
+          multipleExamples: false,
+        },
+      ],
+      status: '200',
+    },
+  ]);
+});
+
 describe('no curated examples present', () => {
   it('should not generate an example if there is no schema and an empty example', async () => {
     const operation = oas.operation('/emptyexample', 'post');

--- a/__tests__/tooling/samples/index.test.js
+++ b/__tests__/tooling/samples/index.test.js
@@ -753,4 +753,41 @@ describe('sampleFromSchema', () => {
       expect(sampleFromSchema(definition)).toStrictEqual(expected);
     });
   });
+
+  describe('polymorphism', () => {
+    it('should handle an allOf schema', () => {
+      const definition = {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              tag: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              id: {
+                type: 'integer',
+                format: 'int64',
+              },
+            },
+          },
+        ],
+      };
+
+      const expected = {
+        name: 'string',
+        tag: 'string',
+        id: 0,
+      };
+
+      expect(sampleFromSchema(definition)).toStrictEqual(expected);
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3876,6 +3876,27 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compute-gcd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
+      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
+      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
+      "requires": {
+        "compute-gcd": "^1.2.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8135,6 +8156,24 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.7.0.tgz",
+      "integrity": "sha512-kvsuSVnl1n5xnNEu5ed4o8r8ujSA4/IgRtHmpgfMfa7FOMIRAzN4F9qbuklouTn5J8bi83y6MQ11n+ERMMTXZg==",
+      "requires": {
+        "compute-lcm": "^1.1.0",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -12297,6 +12336,38 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
     },
     "validator": {
       "version": "12.2.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "figures": "^3.0.0",
     "glob": "^7.1.2",
     "inquirer": "^7.0.1",
+    "json-schema-merge-allof": "^0.7.0",
     "json2yaml": "^1.1.0",
     "jsonfile": "^6.0.0",
     "jsonpointer": "^4.1.0",

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -6,6 +6,7 @@
  */
 
 const { objectify, isFunc, normalizeArray, deeplyStripKey } = require('./utils');
+const mergeAllOf = require('json-schema-merge-allof');
 
 const primitives = {
   string: () => 'string',
@@ -56,6 +57,21 @@ const sampleFromSchema = (schema, config = {}) => {
     } else if (items) {
       type = 'array';
     } else {
+      if ('allOf' in objectifySchema) {
+        try {
+          return sampleFromSchema(
+            mergeAllOf(objectifySchema, {
+              resolvers: {
+                // Ignore any unrecognized OAS-specific keywords that might be present on the schema (like `xml`).
+                defaultResolver: mergeAllOf.options.resolvers.title,
+              },
+            })
+          );
+        } catch (e) {
+          // Unable to merge the schema for whatever reason so let's just ignore it and do a no-op here.
+        }
+      }
+
       return undefined;
     }
   }


### PR DESCRIPTION
## 🧰 What's being changed?

Adds support for being able to handle generating an example from a schema that has an `allOf`.
