### PR TITLE
feat: adding some new methods to the operation class

### DIFF
--- a/__tests__/tooling/lib/matches-mimetype.test.js
+++ b/__tests__/tooling/lib/matches-mimetype.test.js
@@ -27,6 +27,12 @@ describe('#multipart', () => {
   );
 });
 
+describe('#wildcard', () => {
+  it('should recognize `*/*`', () => {
+    expect(matchesMimeType.wildcard('*/*')).toBe(true);
+  });
+});
+
 describe('#xml', () => {
   it.each([
     ['application/xml'],

--- a/__tests__/tooling/operation.test.js
+++ b/__tests__/tooling/operation.test.js
@@ -508,6 +508,38 @@ describe('#getHeaders()', () => {
   });
 });
 
+describe('#getOperationId()', () => {
+  it('should return an operation id if one exists', () => {
+    const operation = new Oas(petstore).operation('/pet/{petId}', 'delete');
+    expect(operation.getOperationId()).toBe('deletePet');
+  });
+
+  it('should create one if one does not exist', () => {
+    const operation = new Oas(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
+    expect(operation.getOperationId()).toBe('getmultiplecomboauthsduped');
+  });
+});
+
+describe('#getParameters()', () => {
+  it('should return parameters', () => {
+    const operation = new Oas(petstore).operation('/pet/{petId}', 'delete');
+    expect(operation.getParameters()).toHaveLength(2);
+  });
+
+  it('should return an empty array if there are none', () => {
+    const operation = new Oas(petstore).operation('/pet', 'put');
+    expect(operation.getParameters()).toHaveLength(0);
+  });
+});
+
+describe('#getParametersAsJsonSchema()', () => {
+  it('should return json schema', () => {
+    const operation = new Oas(petstore).operation('/pet', 'put');
+
+    expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+  });
+});
+
 describe('#hasRequestBody()', () => {
   it('should return true on an operation with a requestBody', () => {
     const operation = new Oas(petstore).operation('/pet', 'put');
@@ -520,10 +552,34 @@ describe('#hasRequestBody()', () => {
   });
 });
 
-describe('#getParametersAsJsonSchema()', () => {
-  it('should return json schema', () => {
-    const operation = new Oas(petstore).operation('/pet', 'put');
+describe('#getResponseByStatusCode()', () => {
+  it('should return false if the status code doesnt exist', () => {
+    const operation = new Oas(petstore).operation('/pet/findByStatus', 'get');
+    expect(operation.getResponseByStatusCode(202)).toBe(false);
+  });
 
-    expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+  it('should return the response', () => {
+    const operation = new Oas(petstore).operation('/pet/findByStatus', 'get');
+    expect(operation.getResponseByStatusCode(200)).toStrictEqual({
+      content: {
+        'application/json': {
+          schema: {
+            items: {
+              $ref: '#/components/schemas/Pet',
+            },
+            type: 'array',
+          },
+        },
+        'application/xml': {
+          schema: {
+            items: {
+              $ref: '#/components/schemas/Pet',
+            },
+            type: 'array',
+          },
+        },
+      },
+      description: 'successful operation',
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9086,6 +9086,11 @@
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jsonfile": "^6.0.0",
     "jsonpointer": "^4.1.0",
     "lodash": "^4.17.11",
+    "lodash.kebabcase": "^4.1.1",
     "minimist": "^1.2.0",
     "node-status": "^1.0.0",
     "oas-normalize": "2.3.1",

--- a/tooling/lib/matches-mimetype.js
+++ b/tooling/lib/matches-mimetype.js
@@ -23,6 +23,10 @@ module.exports = {
     );
   },
 
+  wildcard: contentType => {
+    return contentType === '*/*';
+  },
+
   xml: contentType => {
     return matchesMimeType(
       [

--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -3,6 +3,7 @@ const flattenArray = require('./lib/flatten-array');
 const flattenSchema = require('./lib/flatten-schema');
 const getPath = require('./lib/get-path');
 const getSchema = require('./lib/get-schema');
+const matchesMimeType = require('./lib/matches-mimetype');
 
 module.exports = {
   findSchemaDefinition,
@@ -10,4 +11,5 @@ module.exports = {
   flattenSchema,
   getPath,
   getSchema,
+  matchesMimeType,
 };


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Adds some new methods to the `Operation` class:
  * `getOperationId`
  * `getParameters`
  * `getResponseByStatusCode`
* [x] Adds a new `wildcard` method to `matches-mimetype` to match against `*/*`. Also exposes this library through `oas/tooling/utils`.