### PR TITLE
feat: adding a new hasOperationId accessor on the operation class

### DIFF
--- a/__tests__/tooling/operation.test.js
+++ b/__tests__/tooling/operation.test.js
@@ -508,6 +508,18 @@ describe('#getHeaders()', () => {
   });
 });
 
+describe('#hasOperationId()', () => {
+  it('should return true if one exists', () => {
+    const operation = new Oas(petstore).operation('/pet/{petId}', 'delete');
+    expect(operation.hasOperationId()).toBe(true);
+  });
+
+  it('should return false if one does not exist', () => {
+    const operation = new Oas(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
+    expect(operation.hasOperationId()).toBe(false);
+  });
+});
+
 describe('#getOperationId()', () => {
   it('should return an operation id if one exists', () => {
     const operation = new Oas(petstore).operation('/pet/{petId}', 'delete');

--- a/tooling/operation.js
+++ b/tooling/operation.js
@@ -199,6 +199,15 @@ class Operation {
   }
 
   /**
+   * Determine if the operation has an operation present in its schema.
+   *
+   * @return {boolean}
+   */
+  hasOperationId() {
+    return 'operationId' in this.schema;
+  }
+
+  /**
    * Get an operationId for this operation. If one is not present (it's not required by the spec!) a hash of the path
    * and method will be returned instead.
    *
@@ -215,6 +224,7 @@ class Operation {
   /**
    * Return the parameters (non-request body) on the operation.
    *
+   * @todo This should also pull in common params.
    * @return {array}
    */
   getParameters() {


### PR DESCRIPTION
## 🧰 What's being changed?

Adds a new `hasOperationId` accessor on the `Operation` class for determining if an `operationId` is present in the operation schema or not.