### PR TITLE
fix: regression of common parameters support in JSON Schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <small>6.1.1 (2020-12-16)</small>
+
+* fix: resolving a regression of common parameters support in jsonschema generation ([88f2a13](https://github.com/readmeio/oas/commit/88f2a13))
+
+
+
 ## 6.1.0 (2020-11-12)
 
 * feat: adding some new methods to the operation class (#311) ([c7b6fbc](https://github.com/readmeio/oas/commit/c7b6fbc)), closes [#311](https://github.com/readmeio/oas/issues/311)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Working with Swagger and OpenAPI definitions is hard. This makes it easier.",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (http://readme.io)",

--- a/tooling/operation.js
+++ b/tooling/operation.js
@@ -227,7 +227,7 @@ class Operation {
    * @return {array}
    */
   getParametersAsJsonSchema() {
-    return getParametersAsJsonSchema(this.schema, this.oas);
+    return getParametersAsJsonSchema(this.path, this.schema, this.oas);
   }
 
   /**


### PR DESCRIPTION
## 🧰 What's being changed?

This resolves a regression that was introduced in https://github.com/readmeio/oas/pull/301 that affected how we were able to construct common parameters when using `getParametersAsJsonSchema`. The problem it turns out is that by changing how we were storing operation schema data to a `schema` property in the `Operation` class, we were no longer supplying `getParametersAsJsonSchema` with the current `path` needed to find common parameters in the OAS.

This issue was also compounded by us having tests for common parameters that were generating false positives by supplying the `oas` in the wrong part of the schema it should have been in.

To resolve this, I've rewritten a couple things:

* [x] `Operation.getParametersToJsonSchema` now supplies the underlying `getParametersAsJsonSchema` library with three parameters: path, operation schema (this includes parameters, request bodies, responses, etc.), and the full OAS.
* [x] Every unit test for this underlying library to now uses the flow through `Operation.getParametersAsJsonSchema` instead of directly testing the `getParametersAsJsonSchema` library. This should ensure that we have more resilient tests. With this every test there is also now directly handling an OAS definition instead of fragments of one. This should hopefully make the currently messy test suite a bit more maintainable.