### PR TITLE
feat: implementing blocking on `oas.dereference` to prevent multiple executions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
   "root": true,
   "rules": {
     "no-console": "off",
-    "no-param-reassign": "off"
+    "no-param-reassign": "off",
+
+    "no-underscore-dangle": ["error", {
+      "allow": ["_dereferencing", "_promises"]
+    }]
   }
 }

--- a/__tests__/tooling/__snapshots__/index.test.js.snap
+++ b/__tests__/tooling/__snapshots__/index.test.js.snap
@@ -5,6 +5,11 @@ Operation {
   "contentType": undefined,
   "method": "get",
   "oas": Oas {
+    "_dereferencing": Object {
+      "complete": false,
+      "processing": false,
+    },
+    "_promises": Array [],
     "user": Object {},
   },
   "path": "/unknown",


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Implements some Promise blocking on `Oas.dereference()` to prevent multiple calls of `oas.dereference()` that are happening at the same time from running on top of each other.
* [x] Adds some state handling into the `Oas` class so it has awareness if `oas.dereference()` has been run and if `oas.dereference()` is called again it won't re-run the process.
