### PR TITLE
fix: catch jsonpointer errors when looking for jsonschema examples

### DIFF
--- a/tooling/operation/get-parameters-as-json-schema.js
+++ b/tooling/operation/get-parameters-as-json-schema.js
@@ -120,7 +120,13 @@ function searchForExampleByPointer(pointer, examples = []) {
         schema = schema.examples[Object.keys(schema.examples).shift()].value;
       }
 
-      example = jsonpointer.get(schema, pointers[i]);
+      try {
+        example = jsonpointer.get(schema, pointers[i]);
+      } catch (err) {
+        // If the schema we're looking at is `{obj: null}` and our pointer if `/obj/propertyName` jsonpointer will throw
+        // an error. If that happens, we should silently catch and toss it and return no example.
+      }
+
       if (example !== undefined) {
         break;
       }


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Implements some try-catch around our [jsonpointer](https://npm.im/jsonpointer) when we're constructing and looking for JSON Schema examples.

## 🧪 Testing

Check the added unit test.