### PR TITLE
fix: issue where flattened array descriptions wouldn't be retained

### DIFF
--- a/__tests__/tooling/lib/flatten-schema.test.js
+++ b/__tests__/tooling/lib/flatten-schema.test.js
@@ -523,3 +523,57 @@ describe('polymorphism cases', () => {
     });
   });
 });
+
+test('should retain descriptions on objects', () => {
+  const schema = {
+    type: 'object',
+    properties: {
+      products: {
+        type: 'array',
+        items: {
+          description: 'product schema description',
+          type: 'object',
+          properties: {
+            cash: {
+              description: 'cash schema description',
+              type: 'object',
+              properties: {
+                accounts: {
+                  type: 'array',
+                  items: {
+                    description: 'account schema description',
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        description: 'account id',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  expect(flattenSchema(schema)).toStrictEqual([
+    {
+      name: 'products',
+      type: '[Object]',
+      description: 'product schema description',
+    },
+    {
+      name: 'products[].cash',
+      type: 'Object',
+      description: 'cash schema description',
+    },
+    {
+      name: 'products[].cash.accounts',
+      type: '[Object]',
+      description: 'account schema description',
+    },
+  ]);
+});

--- a/tooling/lib/flatten-schema.js
+++ b/tooling/lib/flatten-schema.js
@@ -57,7 +57,7 @@ module.exports = schema => {
             array.push({
               name: getName(parent, prop),
               type: `[${capitalizeFirstLetter(items.type)}]`,
-              description: value.description,
+              description: value.description || items.description,
             });
 
             if (items.type === 'object') {


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a bug in our `flattenSchema` library where if an array description was located inside of the `items` object, we wouldn't retain it.

Fixes RM-232

## 🧪 Testing

```js
{
  type: 'object',
  properties: {
    products: {
      type: 'array',
      items: {
        description: 'product schema description', // This description wouldn't be retained and `products` 
                                                   // would be set with an `undefined` description.
        type: 'object',
        properties: {
          cash: {
            description: 'cash schema description',
            type: 'object',
            properties: {
              accounts: {
                type: 'array',
                items: {
                  description: 'account schema description',
                  type: 'object',
                  properties: {
                    id: {
                      type: 'string',
                      description: 'account id',
                    },
                  },
                },
              },
            },
          },
        },
      },
    },
  },
}
```