### PR TITLE
fix: prevent us from crashing if `examples` is an empty object

### DIFF
--- a/__tests__/tooling/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/tooling/operation/get-parameters-as-json-schema.test.js
@@ -1664,4 +1664,33 @@ describe('example support', () => {
       },
     });
   });
+
+  it('should not bug out if `examples` is an empty object', () => {
+    const oas = new Oas({
+      paths: {
+        '/': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      limit: {
+                        type: 'integer',
+                      },
+                    },
+                  },
+                  examples: {},
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const schema = oas.operation('/', 'post').getParametersAsJsonSchema();
+    expect(schema[0].schema).toStrictEqual({ type: 'object', properties: { limit: { type: 'integer' } } });
+  });
 });

--- a/tooling/operation/get-parameters-as-json-schema.js
+++ b/tooling/operation/get-parameters-as-json-schema.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-continue */
 // This library is built to translate OpenAPI schemas into schemas compatible with `@readme/oas-form`, and should
 // not at this time be used for general purpose consumption.
 const jsonpointer = require('jsonpointer');
@@ -117,7 +118,20 @@ function searchForExampleByPointer(pointer, examples = []) {
       if ('example' in schema) {
         schema = schema.example;
       } else {
-        schema = schema.examples[Object.keys(schema.examples).shift()].value;
+        const keys = Object.keys(schema.examples);
+        if (!keys.length) {
+          continue;
+        }
+
+        // Prevent us from crashing if `examples` is a completely empty object.
+        const ex = schema.examples[keys.shift()];
+        if (typeof ex !== 'object' || Array.isArray(ex)) {
+          continue;
+        } else if (!('value' in ex)) {
+          continue;
+        }
+
+        schema = ex.value;
       }
 
       try {


### PR DESCRIPTION
## 🧰 What's being changed?

Fixes a bug in our examples lookup work where if `examples: {}` was present we'd crash because we're expecting `value` to be inside one of the keyed properties of it.
