### PR TITLE
fix: operation being set to undefined if not found

### DIFF
--- a/__tests__/tooling/index.test.js
+++ b/__tests__/tooling/index.test.js
@@ -61,6 +61,11 @@ describe('#operation()', () => {
     const operation = new Oas(petstore).operation('/pet', 'put');
     expect(operation.getSecurity()).toStrictEqual([{ petstore_auth: ['write:pets', 'read:pets'] }]);
   });
+
+  it("should still return an operation object if the operation isn't found", () => {
+    const operation = new Oas(petstore).operation('/pet', 'patch');
+    expect(operation.schema).not.toBeUndefined();
+  });
 });
 
 describe('#findOperation()', () => {

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -152,7 +152,11 @@ class Oas {
 
   operation(path, method) {
     const operation = getPathOperation(this, { swagger: { path }, api: { method } });
-    return new Operation(this, path, method, operation);
+
+    // If `getPathOperation` wasn't able to find the operation in the API definition, we should still set an empty
+    // schema on the operation in the `Operation` class because if we don't trying to use any of the accessors on that
+    // class are going to fail as `schema` will be `undefined`.
+    return new Operation(this, path, method, operation || {});
   }
 
   findOperationMatches(url) {


### PR DESCRIPTION
## 🧰 What's being changed?

If you do `oas.operation(path, method)` and that path+method combination isn't found in the attached OAS, we still return an empty `Operation` class. Problem though is that we aren't prefilling the `schema` property on that class with anything so if you try to use any of the accessors on that class, like `Operation.getResponseBody()`, they'll fail because `schema` is `undefined`.
