### PR TITLE
fix: adding support for parameter `content` schemas

### DIFF
--- a/tooling/operation/get-parameters-as-json-schema.js
+++ b/tooling/operation/get-parameters-as-json-schema.js
@@ -3,6 +3,7 @@
 // not at this time be used for general purpose consumption.
 const jsonpointer = require('jsonpointer');
 const getSchema = require('../lib/get-schema');
+const matchesMimeType = require('../lib/matches-mimetype');
 
 // The order of this object determines how they will be sorted in the compiled JSON Schema
 // representation.
@@ -432,13 +433,49 @@ function getParameters(path, operation, oas) {
     }
 
     const properties = parameters.reduce((prev, current) => {
-      const schema = {
-        ...(current.schema ? constructSchema(current.schema) : {}),
-      };
+      let schema = {};
+      if ('schema' in current) {
+        schema = {
+          ...(current.schema ? constructSchema(current.schema) : {}),
+        };
+      } else if ('content' in current && typeof current.content === 'object') {
+        const contentKeys = Object.keys(current.content);
+        if (contentKeys.length) {
+          let contentType;
+          if (contentKeys.length === 1) {
+            contentType = contentKeys[0];
+          } else {
+            // We should always try to prioritize `application/json` over any other possible content that might be present
+            // on this schema.
+            const jsonLikeContentTypes = contentKeys.filter(k => matchesMimeType.json(k));
+            if (jsonLikeContentTypes.length) {
+              contentType = jsonLikeContentTypes[0];
+            } else {
+              contentType = contentKeys[0];
+            }
+          }
+
+          if (typeof current.content[contentType] === 'object' && 'schema' in current.content[contentType]) {
+            schema = {
+              ...(current.content[contentType].schema ? constructSchema(current.content[contentType].schema) : {}),
+            };
+          }
+        }
+      }
 
       // Parameter descriptions don't exist in `current.schem` so `constructSchema` will never have access to it.
       if (current.description) {
         schema.description = current.description;
+      }
+
+      // If for whatever reason we were unable to ascertain a type for the schema (maybe `schema` and `content` aren't
+      // present, or they're not in the shape they should be), set it to a string so we can at least make an attempt at
+      // returning *something* for it.
+      if (!('type' in schema)) {
+        // Only add a missing type if this schema isn't a polymorphismified schema.
+        if (!('allOf' in schema) && !('oneOf' in schema) && !('anyOf' in schema)) {
+          schema.type = 'string';
+        }
       }
 
       prev[current.name] = schema;


### PR DESCRIPTION
## 🧰 What's being changed?

With the rewrite of `getParametersAsJsonSchema()` #358 we lost support for parameter `content` schemas, something we never actually officially supported or had tests for.

* [x] Adds support for `content` within parameters
* [x] Fixes an edge case where if a `type` couldn't be determined for a schema (maybe `schema` or `content` aren't present for whatever reason, or aren't in the right shape), then we'll default to treating the schema as a `string`.

```json
{
  "name": "groupId",
  "description": "Filter the data by groupId",
  "in": "query",
  "required": false,
  "content": { "application/json": { "schema": { "type": "string" } } }
}
```

Fixes [RM-311](https://linear.app/readme-io/issue/RM-311/we-are-trying-to-render-params-we-dont-understand)

## 🧪 Testing

I've added in a bunch of different test cases, but the ways we support this and pick up schemas within `content` are as follows:

* If there is just a single content type in `content` we'll pick that up and use the schema inside it.
* If there are two non-`application/json` content types in `content` we'll use the first in the list.
* If there are two content types in `content`, and one of them is JSON-like (`application/json`, `text/json`, `application/vnd.something+json`) we'll use that over the other.