### PR TITLE
fix: exception that would be thrown when trying to access a null example

### DIFF
--- a/__tests__/tooling/operation/get-response-examples.test.js
+++ b/__tests__/tooling/operation/get-response-examples.test.js
@@ -273,6 +273,52 @@ describe('defined within response `content`', () => {
       ]);
     });
 
+    it('should not fail if the example is null', () => {
+      const spec = new Oas({
+        paths: {
+          '/': {
+            get: {
+              responses: {
+                500: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'string',
+                      },
+                    },
+                    data: { examples: { response: { value: null } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(spec.operation('/', 'get').getResponseExamples()).toStrictEqual([
+        {
+          languages: [
+            {
+              code: 'string',
+              language: 'application/json',
+              multipleExamples: false,
+            },
+            {
+              code: null,
+              language: 'data',
+              multipleExamples: [
+                {
+                  code: 'null',
+                  label: 'response',
+                },
+              ],
+            },
+          ],
+          status: '500',
+        },
+      ]);
+    });
+
     it('should not fail if the example is an array', async () => {
       const operation = oas.operation('/single-media-type-single-example-in-examples-prop-that-are-arrays', 'post');
 

--- a/tooling/lib/get-mediatype-examples.js
+++ b/tooling/lib/get-mediatype-examples.js
@@ -29,7 +29,7 @@ module.exports = {
         if (example !== null && typeof example === 'object') {
           if ('value' in example) {
             // If we have a $ref here then it's a circular schema and we should ignore it.
-            if (typeof example.value === 'object' && '$ref' in example.value) {
+            if (example.value !== null && typeof example.value === 'object' && '$ref' in example.value) {
               return false;
             }
 
@@ -69,7 +69,7 @@ module.exports = {
       if (example !== null && typeof example === 'object') {
         if ('value' in example) {
           // If we have a $ref here then it's a circular reference and we should ignore it.
-          if (typeof example.value === 'object' && '$ref' in example.value) {
+          if (example.value !== null && typeof example.value === 'object' && '$ref' in example.value) {
             example = undefined;
           } else {
             example = example.value;


### PR DESCRIPTION
## 🧰 What's being changed?

Fixes a bug where if a media type in a response had a `value: null` we'd throw an exception while trying to look for a `$ref` in it.