### PR TITLE
feat: addition of a new `getAuth` method on the OAS class

### DIFF
--- a/__tests__/tooling/__fixtures__/multiple-securities.json
+++ b/__tests__/tooling/__fixtures__/multiple-securities.json
@@ -261,6 +261,11 @@
         "name": "X-AUTH-SIGNATURE",
         "in": "header"
       },
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "in": "header"
+      },
       "unknownAuthType": {
         "type": "demigorgon",
         "name": "eleven",

--- a/__tests__/tooling/lib/get-auth.test.js
+++ b/__tests__/tooling/lib/get-auth.test.js
@@ -1,0 +1,122 @@
+const Oas = require('../../../tooling');
+const { getByScheme } = require('../../../tooling/lib/get-auth');
+
+const multipleSecurities = require('../__fixtures__/multiple-securities.json');
+
+const oas = new Oas(multipleSecurities);
+
+test('should fetch all auths from the OAS files', () => {
+  expect(oas.getAuth({ oauthScheme: 'oauth', apiKeyScheme: 'apikey' })).toStrictEqual({
+    apiKeyScheme: 'apikey',
+    apiKeySignature: '',
+    basicAuth: {
+      pass: '',
+      user: '',
+    },
+    httpBearer: '',
+    oauthDiff: '',
+    oauthScheme: 'oauth',
+    unknownAuthType: '',
+  });
+});
+
+test('should fetch auths from selected app', () => {
+  const user = {
+    keys: [
+      { oauthScheme: '111', name: 'app-1' },
+      { oauthScheme: '222', name: 'app-2' },
+    ],
+  };
+
+  expect(oas.getAuth(user, 'app-2').oauthScheme).toBe('222');
+});
+
+test('should not error if oas.components is not set', () => {
+  const user = { oauthScheme: 'oauth', apiKeyScheme: 'apikey' };
+
+  expect(() => {
+    new Oas().getAuth(user);
+  }).not.toThrow();
+
+  expect(() => {
+    new Oas({ components: {} }).getAuth(user);
+  }).not.toThrow();
+
+  expect(() => {
+    new Oas({ components: { schemas: {} } }).getAuth(user);
+  }).not.toThrow();
+});
+
+describe('#getByScheme', () => {
+  const topLevelUser = { apiKey: '123456', user: 'user', pass: 'pass' };
+  const keysUser = {
+    keys: [
+      { apiKey: '123456', name: 'app-1' },
+      { apiKey: '7890', name: 'app-2' },
+    ],
+  };
+
+  const topLevelSchemeUser = { schemeName: 'scheme-key' };
+  const keysSchemeUser = {
+    keys: [
+      { schemeName: 'scheme-key-1', name: 'app-1' },
+      { schemeName: 'scheme-key-2', name: 'app-2' },
+      { schemeName: { user: 'user', pass: 'pass' }, name: 'app-3' },
+    ],
+  };
+
+  it('should return apiKey property for oauth', () => {
+    expect(getByScheme(topLevelUser, { type: 'oauth2' })).toBe('123456');
+  });
+
+  it('should return apiKey property for apiKey', () => {
+    expect(getByScheme(topLevelUser, { type: 'oauth2' })).toBe('123456');
+  });
+
+  it('should return a default value if scheme is sec0 and default auth provided', () => {
+    expect(getByScheme({}, { type: 'apiKey', _key: 'sec0', 'x-default': 'default' })).toBe('default');
+  });
+
+  it('should return apiKey property for bearer', () => {
+    expect(getByScheme(topLevelUser, { type: 'http', scheme: 'bearer' })).toBe('123456');
+  });
+
+  it('should return user/pass properties for basic auth', () => {
+    expect(getByScheme(topLevelUser, { type: 'http', scheme: 'basic' })).toStrictEqual({
+      user: 'user',
+      pass: 'pass',
+    });
+  });
+
+  it('should return first item from keys array if no app selected', () => {
+    expect(getByScheme(keysUser, { type: 'oauth2' })).toBe('123456');
+  });
+
+  it('should return selected app from keys array if app provided', () => {
+    expect(getByScheme(keysUser, { type: 'oauth2' }, 'app-2')).toBe('7890');
+  });
+
+  it('should return item by scheme name if no apiKey/user/pass', () => {
+    expect(getByScheme(topLevelSchemeUser, { type: 'oauth2', _key: 'schemeName' })).toBe('scheme-key');
+    expect(getByScheme(topLevelSchemeUser, { type: 'http', scheme: 'bearer', _key: 'schemeName' })).toBe('scheme-key');
+    expect(getByScheme(keysSchemeUser, { type: 'oauth2', _key: 'schemeName' })).toBe('scheme-key-1');
+    expect(getByScheme(keysSchemeUser, { type: 'oauth2', _key: 'schemeName' }, 'app-2')).toBe('scheme-key-2');
+    expect(getByScheme(keysSchemeUser, { type: 'http', scheme: 'basic', _key: 'schemeName' }, 'app-3')).toStrictEqual({
+      user: 'user',
+      pass: 'pass',
+    });
+  });
+
+  it('should return emptystring for anything else', () => {
+    expect(getByScheme(topLevelUser, { type: 'unknown' })).toBe('');
+    expect(getByScheme({}, { type: 'http', scheme: 'basic' })).toStrictEqual({ user: '', pass: '' });
+    expect(getByScheme({}, { type: 'http', scheme: 'bearer' })).toBe('');
+    expect(getByScheme({}, { type: 'http', scheme: 'unknown' })).toBe('');
+    expect(getByScheme(keysUser, { type: 'unknown' })).toBe('');
+    expect(getByScheme(keysUser, { type: 'unknown' }, 'app-2')).toBe('');
+  });
+
+  it('should allow scheme to be undefined', () => {
+    expect(getByScheme(topLevelUser)).toBe('');
+  });
+});

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -1,5 +1,6 @@
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
 const { pathToRegexp, match } = require('path-to-regexp');
+const getAuth = require('./lib/get-auth');
 const getPathOperation = require('./lib/get-path-operation');
 const getUserVariable = require('./lib/get-user-variable');
 const Operation = require('./operation');
@@ -226,6 +227,25 @@ class Oas {
     }
 
     return this.operation(op.url.nonNormalizedPath, method);
+  }
+
+  /**
+   * With an object of user information, retrieve an appropriate API key from the current OAS definition.
+   *
+   * @link https://docs.readme.com/docs/passing-data-to-jwt
+   * @param {Object} user
+   * @param {Boolean|String} selectedApp
+   * @return {Object}
+   */
+  getAuth(user, selectedApp = false) {
+    if (
+      Object.keys(this.components || {}).length === 0 ||
+      Object.keys(this.components.securitySchemes || {}).length === 0
+    ) {
+      return {};
+    }
+
+    return getAuth(this, user, selectedApp);
   }
 
   /**

--- a/tooling/lib/get-auth.js
+++ b/tooling/lib/get-auth.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-underscore-dangle */
+function getKey(user, scheme) {
+  switch (scheme.type) {
+    case 'oauth2':
+    case 'apiKey':
+      return user[scheme._key] || user.apiKey || scheme['x-default'] || '';
+
+    case 'http':
+      if (scheme.scheme === 'basic') {
+        return user[scheme._key] || { user: user.user || '', pass: user.pass || '' };
+      }
+
+      if (scheme.scheme === 'bearer') {
+        return user[scheme._key] || user.apiKey || '';
+      }
+      return '';
+
+    default:
+      return '';
+  }
+}
+
+function getByScheme(user, scheme = {}, selectedApp = false) {
+  if (user.keys && user.keys.length) {
+    if (selectedApp) {
+      return getKey(
+        user.keys.find(key => key.name === selectedApp),
+        scheme
+      );
+    }
+
+    return getKey(user.keys[0], scheme);
+  }
+
+  return getKey(user, scheme);
+}
+
+module.exports = (oas, user, selectedApp = false) => {
+  return Object.keys(oas.components.securitySchemes)
+    .map(scheme => {
+      return {
+        [scheme]: getByScheme(
+          user,
+          {
+            ...oas.components.securitySchemes[scheme],
+            _key: scheme,
+            selectedApp,
+          },
+          selectedApp
+        ),
+      };
+    })
+    .reduce((prev, next) => Object.assign(prev, next), {});
+};
+
+module.exports.getByScheme = getByScheme;


### PR DESCRIPTION
## 🧰 What's being changed?

This adds a new `getAuth()` method on the OAS class that can be used to pull back an object of auth data for use in `@readme/oas-to-har`.

The code for this currently exists in https://github.com/readmeio/api-explorer/blob/next/packages/api-explorer/src/lib/get-auth.js, but this is a better place for it.

## 🧪 Testing

See unit tests.