### PR TITLE
feat: support polymorphistic response examples

### DIFF
--- a/__tests__/tooling/samples/index.test.js
+++ b/__tests__/tooling/samples/index.test.js
@@ -798,5 +798,55 @@ describe('sampleFromSchema', () => {
 
       expect(sampleFromSchema(definition)).toStrictEqual(expected);
     });
+
+    it('should grab properties from polymorphism', () => {
+      const polymorphismSchema = {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              param1: {
+                allOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      name: {
+                        type: 'string',
+                        example: 'Owlbert',
+                      },
+                    },
+                  },
+                ],
+                type: 'object',
+              },
+              param2: {
+                allOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      description: {
+                        type: 'string',
+                        example: 'Mascot of ReadMe',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+
+      const expected = {
+        param1: {
+          name: 'Owlbert',
+        },
+        param2: {
+          description: 'Mascot of ReadMe',
+        },
+      };
+
+      expect(sampleFromSchema(polymorphismSchema)).toStrictEqual(expected);
+    });
   });
 });

--- a/__tests__/tooling/samples/index.test.js
+++ b/__tests__/tooling/samples/index.test.js
@@ -799,7 +799,7 @@ describe('sampleFromSchema', () => {
       expect(sampleFromSchema(definition)).toStrictEqual(expected);
     });
 
-    it('should grab properties from polymorphism', () => {
+    it('should grab properties from allOf polymorphism', () => {
       const polymorphismSchema = {
         allOf: [
           {
@@ -843,6 +843,65 @@ describe('sampleFromSchema', () => {
         },
         param2: {
           description: 'Mascot of ReadMe',
+        },
+      };
+
+      expect(sampleFromSchema(polymorphismSchema)).toStrictEqual(expected);
+    });
+
+    it('should grab first property from anyOf/oneOf polymorphism', () => {
+      const polymorphismSchema = {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              param1: {
+                allOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      name: {
+                        type: 'string',
+                        example: 'Owlbert',
+                      },
+                    },
+                  },
+                ],
+                type: 'object',
+              },
+              param2: {
+                anyOf: [
+                  {
+                    type: 'object',
+                    properties: {
+                      position: {
+                        type: 'string',
+                        example: 'Chief Whimsical Officer',
+                      },
+                    },
+                  },
+                  {
+                    type: 'object',
+                    properties: {
+                      description: {
+                        type: 'string',
+                        example: 'Mascot of ReadMe',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+
+      const expected = {
+        param1: {
+          name: 'Owlbert',
+        },
+        param2: {
+          position: 'Chief Whimsical Officer',
         },
       };
 

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -42,23 +42,21 @@ const sampleFromSchema = (schema, config = {}) => {
   let { type } = objectifySchema;
 
   const hasPolymorphism = usesPolymorphism(objectifySchema);
-  if (hasPolymorphism) {
-    if (hasPolymorphism === 'allOf') {
-      try {
-        return sampleFromSchema(
-          mergeAllOf(objectifySchema, {
-            resolvers: {
-              // Ignore any unrecognized OAS-specific keywords that might be present on the schema (like `xml`).
-              defaultResolver: mergeAllOf.options.resolvers.title,
-            },
-          })
-        );
-      } catch (error) {
-        return undefined;
-      }
-    } else {
-      return sampleFromSchema(objectifySchema[hasPolymorphism]);
+  if (hasPolymorphism === 'allOf') {
+    try {
+      return sampleFromSchema(
+        mergeAllOf(objectifySchema, {
+          resolvers: {
+            // Ignore any unrecognized OAS-specific keywords that might be present on the schema (like `xml`).
+            defaultResolver: mergeAllOf.options.resolvers.title,
+          },
+        })
+      );
+    } catch (error) {
+      return undefined;
     }
+  } else if (hasPolymorphism) {
+    return sampleFromSchema(objectifySchema[hasPolymorphism]);
   }
 
   const { example, additionalProperties, properties, items } = objectifySchema;

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -39,8 +39,18 @@ const primitive = schema => {
 
 const sampleFromSchema = (schema, config = {}) => {
   const objectifySchema = objectify(schema);
-  let { type } = objectifySchema;
-  const { example, properties, additionalProperties, items } = objectifySchema;
+  let { type, properties, items } = objectifySchema;
+  const { example, additionalProperties } = objectifySchema;
+
+  const usesPolymorphism = hasPolymorphism(objectifySchema);
+  if (usesPolymorphism === 'allOf') {
+    const mergedAllOf = mergeAllOf(objectifySchema);
+    properties = mergedAllOf.properties;
+    items = mergedAllOf.items;
+  } else if (usesPolymorphism) {
+    properties = objectifySchema[usesPolymorphism][0].properties;
+    items = objectifySchema[usesPolymorphism][0].items;
+  }
 
   const { includeReadOnly, includeWriteOnly } = config;
 

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -5,7 +5,7 @@
  * @link https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/samples/fn.js
  */
 
-const { objectify, isFunc, normalizeArray, deeplyStripKey } = require('./utils');
+const { objectify, hasPolymorphism, isFunc, normalizeArray, deeplyStripKey } = require('./utils');
 const memoize = require('memoizee');
 const mergeAllOf = require('json-schema-merge-allof');
 

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -76,21 +76,6 @@ const sampleFromSchema = (schema, config = {}) => {
     } else if (items) {
       type = 'array';
     } else {
-      if ('allOf' in objectifySchema) {
-        try {
-          return sampleFromSchema(
-            mergeAllOf(objectifySchema, {
-              resolvers: {
-                // Ignore any unrecognized OAS-specific keywords that might be present on the schema (like `xml`).
-                defaultResolver: mergeAllOf.options.resolvers.title,
-              },
-            })
-          );
-        } catch (e) {
-          // Unable to merge the schema for whatever reason so let's just ignore it and do a no-op here.
-        }
-      }
-
       return undefined;
     }
   }

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -8,6 +8,7 @@
 const { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } = require('./utils');
 const memoize = require('memoizee');
 const mergeAllOf = require('json-schema-merge-allof');
+const { object } = require('prop-types');
 
 const primitives = {
   string: () => 'string',
@@ -56,7 +57,7 @@ const sampleFromSchema = (schema, config = {}) => {
       return undefined;
     }
   } else if (hasPolymorphism) {
-    return sampleFromSchema(objectifySchema[hasPolymorphism]);
+    return sampleFromSchema(objectifySchema[hasPolymorphism][0]);
   }
 
   const { example, additionalProperties, properties, items } = objectifySchema;

--- a/tooling/samples/index.js
+++ b/tooling/samples/index.js
@@ -8,7 +8,6 @@
 const { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } = require('./utils');
 const memoize = require('memoizee');
 const mergeAllOf = require('json-schema-merge-allof');
-const { object } = require('prop-types');
 
 const primitives = {
   string: () => 'string',

--- a/tooling/samples/utils.js
+++ b/tooling/samples/utils.js
@@ -9,7 +9,7 @@ function isObject(obj) {
   return !!obj && typeof obj === 'object';
 }
 
-module.exports.hasPolymorphism = schema => {
+module.exports.usesPolymorphism = schema => {
   let polymorphism;
 
   if (schema.oneOf) {

--- a/tooling/samples/utils.js
+++ b/tooling/samples/utils.js
@@ -9,6 +9,20 @@ function isObject(obj) {
   return !!obj && typeof obj === 'object';
 }
 
+module.exports.hasPolymorphism = schema => {
+  let polymorphism;
+
+  if (schema.oneOf) {
+    polymorphism = 'oneOf';
+  } else if (schema.anyOf) {
+    polymorphism = 'anyOf';
+  } else if (schema.allOf) {
+    polymorphism = 'allOf';
+  }
+
+  return polymorphism;
+};
+
 module.exports.objectify = thing => {
   if (!isObject(thing)) {
     return {};


### PR DESCRIPTION
## 🧰 What's being changed?
| [Linear Ticket](https://linear.app/readme-io/issue/CX-183/allof-property-causes-display-issue) |
|------------------------------------------------------------------------------------------------|

This PR adds support to render responses that are currently using polymorphism. 

The operation with the response:
![image](https://user-images.githubusercontent.com/41130056/110724399-8cc48b80-81ca-11eb-9026-68b59f1a8497.png)

The respective components:
![image](https://user-images.githubusercontent.com/41130056/110724480-b67db280-81ca-11eb-8c97-042d64c9b904.png)

We currently render the response example in the above operation like so:
![image](https://user-images.githubusercontent.com/41130056/110724596-e927ab00-81ca-11eb-9717-616556fbdc82.png)

As you can see, the `reach` parameter is using `allOf`, although it is a weird use of `allOf`, but we don't render the object that `reach` is referencing. 

With these changes, we're correctly grabbing the `properties` object from the schema to show the following:
![image](https://user-images.githubusercontent.com/41130056/110724902-79fe8680-81cb-11eb-9257-356477ad162c.png)


## 🧪 Testing
1. Use the OA file in the Linear ticket or the one on my [test project](https://darren.readme.io/openapi/60497c0392b39a0065e98136) for a condensed down version. 
2. Upload the file
3. You should see the updated response example when the package has been bumped in the explorer.

I did run into an issue where `mergeAllOf` couldn't merge the `allOf` schema so I am making it return the first item in the polymorphism array. Here's an example of an `allOf` schema that was having trouble:
![image](https://user-images.githubusercontent.com/41130056/110726197-da8ec300-81cd-11eb-8470-1cb1d3d1c83d.png)


