### PR TITLE
refactor: extract part of prepareSecurity() function into a new function

### DIFF
--- a/__tests__/tooling/operation.test.js
+++ b/__tests__/tooling/operation.test.js
@@ -280,6 +280,134 @@ describe('#getSecurity()', () => {
   });
 });
 
+describe('#getSecurityWithTypes()', () => {
+  const security = [{ auth: [], invalid: [] }];
+  const securitySchemes = {
+    auth: {
+      type: 'http',
+      scheme: 'basic',
+    },
+  };
+  const securitiesWithTypes = [
+    [
+      {
+        security: {
+          _key: 'auth',
+          scheme: 'basic',
+          type: 'http',
+        },
+        type: 'Basic',
+      },
+      false,
+    ],
+  ];
+
+  const filteredSecuritiesWithTypes = [
+    [
+      {
+        security: {
+          _key: 'auth',
+          scheme: 'basic',
+          type: 'http',
+        },
+        type: 'Basic',
+      },
+    ],
+  ];
+
+  it('should return the array of securities on this operation', () => {
+    expect(
+      new Oas({
+        info: { version: '1.0' },
+        paths: {
+          '/things': {
+            post: {
+              security,
+            },
+          },
+        },
+        components: {
+          securitySchemes,
+        },
+      })
+        .operation('/things', 'post')
+        .getSecurityWithTypes()
+    ).toStrictEqual(securitiesWithTypes);
+  });
+
+  it('should return the filtered array if filter flag is set to true', () => {
+    expect(
+      new Oas({
+        info: { version: '1.0' },
+        paths: {
+          '/things': {
+            post: {
+              security,
+            },
+          },
+        },
+        components: {
+          securitySchemes,
+        },
+      })
+        .operation('/things', 'post')
+        .getSecurityWithTypes(true)
+    ).toStrictEqual(filteredSecuritiesWithTypes);
+  });
+
+  it('should fallback to global security', () => {
+    expect(
+      new Oas({
+        info: { version: '1.0' },
+        paths: {
+          '/things': {
+            post: {},
+          },
+        },
+        security,
+        components: {
+          securitySchemes,
+        },
+      })
+        .operation('/things', 'post')
+        .getSecurityWithTypes()
+    ).toStrictEqual(securitiesWithTypes);
+  });
+
+  it('should default to empty array if no security object defined', () => {
+    expect(
+      new Oas({
+        info: { version: '1.0' },
+        paths: {
+          '/things': {
+            post: {},
+          },
+        },
+      })
+        .operation('/things', 'post')
+        .getSecurityWithTypes()
+    ).toStrictEqual([]);
+  });
+
+  it('should default to empty array if no securitySchemes are defined', () => {
+    expect(
+      new Oas({
+        info: { version: '1.0' },
+        paths: {
+          '/things': {
+            post: {
+              security,
+            },
+          },
+        },
+        components: {},
+      })
+        .operation('/things', 'post')
+        .getSecurityWithTypes()
+    ).toStrictEqual([]);
+  });
+});
+
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
 describe('#prepareSecurity()', () => {
   const path = '/auth';

--- a/tooling/operation.js
+++ b/tooling/operation.js
@@ -66,6 +66,11 @@ class Operation {
     return matchesMimeType.xml(this.getContentType());
   }
 
+  /**
+   * @returns The securities associated with this operation.
+   * If none are defined at an operation level, the securities for the entire `oas` are returned
+   * (with an empty array as a fallback).
+   */
   getSecurity() {
     if (!('components' in this.oas) || !('securitySchemes' in this.oas.components)) {
       return [];
@@ -74,6 +79,14 @@ class Operation {
     return this.schema.security || this.oas.security || [];
   }
 
+  /**
+   * @param {boolean} filter Optional flag that filters out invalid/nonexistent security schemes,
+   * rather than returning `false`.
+   * @returns An array of arrays of objects of grouped security schemes.
+   * The inner array determines and-grouped security schemes, the outer array determines or-groups.
+   *
+   * See https://swagger.io/docs/specification/authentication/#multiple
+   */
   getSecurityWithTypes(filter = false) {
     const securityRequirements = this.getSecurity();
 
@@ -119,6 +132,10 @@ class Operation {
     });
   }
 
+  /**
+   * @returns An object where the keys are unique scheme types,
+   * and the values are arrays containing each security scheme of that type.
+   */
   prepareSecurity() {
     const securitiesWithTypes = this.getSecurityWithTypes();
 

--- a/tooling/operation.js
+++ b/tooling/operation.js
@@ -80,14 +80,14 @@ class Operation {
   }
 
   /**
-   * @param {boolean} filter Optional flag that, when set to `true`,
+   * @param {boolean} filterInvalid Optional flag that, when set to `true`,
    * filters out invalid/nonexistent security schemes, rather than returning `false`.
    * @returns An array of arrays of objects of grouped security schemes.
    * The inner array determines and-grouped security schemes, the outer array determines or-groups.
    *
    * See https://swagger.io/docs/specification/authentication/#multiple
    */
-  getSecurityWithTypes(filter = false) {
+  getSecurityWithTypes(filterInvalid = false) {
     const securityRequirements = this.getSecurity();
 
     return securityRequirements.map(requirement => {
@@ -126,7 +126,7 @@ class Operation {
         return { type, security };
       });
 
-      if (filter) return keysWithTypes.filter(key => key !== false);
+      if (filterInvalid) return keysWithTypes.filter(key => key !== false);
 
       return keysWithTypes;
     });

--- a/tooling/operation.js
+++ b/tooling/operation.js
@@ -80,8 +80,8 @@ class Operation {
   }
 
   /**
-   * @param {boolean} filter Optional flag that filters out invalid/nonexistent security schemes,
-   * rather than returning `false`.
+   * @param {boolean} filter Optional flag that, when set to `true`,
+   * filters out invalid/nonexistent security schemes, rather than returning `false`.
    * @returns An array of arrays of objects of grouped security schemes.
    * The inner array determines and-grouped security schemes, the outer array determines or-groups.
    *


### PR DESCRIPTION
## 🧰 What's being changed?

As part of the changes I made in https://github.com/readmeio/readme/pull/3811, I wrote a little helper function [here](https://github.com/readmeio/readme/blob/b2b01ecbfe0a3c82c847aefb3ce0eaf711afe7b3/packages/react/src/ui/APIAuth/index.jsx#L70-L72) that uses some of the logic we use in [`operation.prepareSecurity()`](https://github.com/readmeio/oas/blob/7d5c1575ef1dcf6b9913657c89f3c5dbaf404bb6/tooling/operation.js#L122) for validating and setting types for security schemes (while maintaining the array structure so multiple auth grouping is preserved). That function should probably live in this library instead.

I simply extracted that part of the `prepareSecurity()` function into its own function (and added a tiny flag for filtering out junk)—hence I'm considering this a refactor, but it could arguably be called a feature?

We might be able to deprecate `operation.prepareSecurity()` because I'm not sure what that's used for now, but I'm leaving it in here since it feels unnecessary to introduce breaking changes.

## 🧪 Testing

Added some test coverage for the new function, confirmed that the changes don't break `operation.prepareSecurity()`.
