### PR TITLE
fix: revert repositioning of description

### DIFF
--- a/__tests__/tooling/operation/get-response-as-json-schema.test.js
+++ b/__tests__/tooling/operation/get-response-as-json-schema.test.js
@@ -40,9 +40,10 @@ test('it should return a schema when one is present', () => {
       .getResponseAsJsonSchema('200')
   ).toStrictEqual([
     {
-      schema: { ...simpleObjectSchema(), description: 'response level description' },
+      schema: simpleObjectSchema(),
       type: 'object',
       label: 'Response body',
+      description: 'response level description',
     },
   ]);
 });
@@ -63,9 +64,10 @@ test('it should return a schema when one is present with a vendor content type',
       .getResponseAsJsonSchema('200')
   ).toStrictEqual([
     {
-      schema: { ...simpleObjectSchema(), description: 'response level description' },
+      schema: simpleObjectSchema(),
       type: 'object',
       label: 'Response body',
+      description: 'response level description',
     },
   ]);
 });
@@ -89,9 +91,10 @@ test('it should return a schema when more than one content type is present', () 
       .getResponseAsJsonSchema('200')
   ).toStrictEqual([
     {
-      schema: { ...simpleObjectSchema(), description: 'response level description' },
+      schema: simpleObjectSchema(),
       type: 'object',
       label: 'Response body',
+      description: 'response level description',
     },
   ]);
 });
@@ -121,9 +124,10 @@ test('the returned schema should include components if they exist', () => {
       .getResponseAsJsonSchema('200')
   ).toStrictEqual([
     {
-      schema: { ...simpleObjectSchema(), components, description: 'response level description' },
+      schema: { ...simpleObjectSchema(), components },
       type: 'object',
       label: 'Response body',
+      description: 'response level description',
     },
   ]);
 });
@@ -147,9 +151,10 @@ test('the returned schema should include headers (OAS 3.0.3) if they exist', () 
       .getResponseAsJsonSchema('200')
   ).toStrictEqual([
     {
-      schema: { ...simpleObjectSchema(), description: 'response level description' },
+      schema: simpleObjectSchema(),
       type: 'object',
       label: 'Headers',
+      description: 'response level description',
     },
   ]);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "10.6.3",
+  "version": "10.6.2",
   "description": "Working with Swagger and OpenAPI definitions is hard. This makes it easier.",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (http://readme.io)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "description": "Working with Swagger and OpenAPI definitions is hard. This makes it easier.",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (http://readme.io)",

--- a/tooling/operation/get-response-as-json-schema.js
+++ b/tooling/operation/get-response-as-json-schema.js
@@ -30,7 +30,7 @@ function buildHeadersSchema(response) {
   };
 
   if (response.description && headersWrapper.schema) {
-    headersWrapper.schema.description = response.description;
+    headersWrapper.description = response.description;
   }
 
   return headersWrapper;
@@ -81,7 +81,7 @@ module.exports = function getResponseAsJsonSchema(operation, oas, statusCode) {
     };
 
     if (response.description && schemaWrapper.schema) {
-      schemaWrapper.schema.description = response.description;
+      schemaWrapper.description = response.description;
     }
 
     // Components are included so we can identify the names of refs


### PR DESCRIPTION
## 🧰 What's being changed?

The old way of surfacing response descriptions was more accurate in the big picture, so this changes it back.
