### PR TITLE
feat: adding support retrieving 204/empty responses

### DIFF
--- a/__tests__/tooling/__datasets__/operation-examples.json
+++ b/__tests__/tooling/__datasets__/operation-examples.json
@@ -355,6 +355,9 @@
                 "examples": {}
               }
             }
+          },
+          "204": {
+            "description": "No content"
           }
         }
       }
@@ -394,11 +397,7 @@
     "/none": {
       "get": {
         "description": "This operation has neither a requestBody or response schema, but also no examples for either.",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
+        "responses": {}
       }
     },
     "/ref-examples": {

--- a/__tests__/tooling/operation/get-response-examples.test.js
+++ b/__tests__/tooling/operation/get-response-examples.test.js
@@ -12,7 +12,7 @@ beforeAll(async () => {
   await oas2.dereference();
 });
 
-test('should return early if there is no response', () => {
+test('should return early if there are no responses', () => {
   const operation = oas.operation('/none', 'get');
   expect(operation.getResponseExamples()).toStrictEqual([]);
 });
@@ -68,7 +68,16 @@ test('should do its best at handling circular schemas', async () => {
 describe('no curated examples present', () => {
   it('should not generate an example if there is no schema and an empty example', () => {
     const operation = oas.operation('/emptyexample', 'post');
-    expect(operation.getResponseExamples()).toStrictEqual([]);
+    expect(operation.getResponseExamples()).toStrictEqual([
+      {
+        languages: [],
+        status: '200',
+      },
+      {
+        languages: [],
+        status: '204',
+      },
+    ]);
   });
 
   it('should generate examples if an `examples` property is present but empty', () => {
@@ -124,6 +133,10 @@ describe('no curated examples present', () => {
           },
         ],
         status: '200',
+      },
+      {
+        languages: [],
+        status: '400',
       },
     ]);
   });

--- a/__tests__/tooling/operation/get-response-examples.test.js
+++ b/__tests__/tooling/operation/get-response-examples.test.js
@@ -21,6 +21,7 @@ test('should support */* media types', () => {
   const operation = oas.operation('/wildcard-media-type', 'post');
   expect(operation.getResponseExamples()).toStrictEqual([
     {
+      status: '200',
       languages: [
         {
           code: cleanStringify({
@@ -32,7 +33,6 @@ test('should support */* media types', () => {
           multipleExamples: false,
         },
       ],
-      status: '200',
     },
   ]);
 });
@@ -70,12 +70,12 @@ describe('no curated examples present', () => {
     const operation = oas.operation('/emptyexample', 'post');
     expect(operation.getResponseExamples()).toStrictEqual([
       {
-        languages: [],
         status: '200',
+        languages: [],
       },
       {
-        languages: [],
         status: '204',
+        languages: [],
       },
     ]);
   });
@@ -84,6 +84,7 @@ describe('no curated examples present', () => {
     const operation = oas.operation('/emptyexample-with-schema', 'post');
     expect(operation.getResponseExamples()).toStrictEqual([
       {
+        status: '200',
         languages: [
           {
             code: cleanStringify([
@@ -96,7 +97,6 @@ describe('no curated examples present', () => {
             multipleExamples: false,
           },
         ],
-        status: '200',
       },
     ]);
   });
@@ -125,6 +125,7 @@ describe('no curated examples present', () => {
     const operation = oas2.operation('/pet/findByStatus', 'get');
     expect(operation.getResponseExamples()).toStrictEqual([
       {
+        status: '200',
         languages: [
           {
             code: petExample,
@@ -132,11 +133,10 @@ describe('no curated examples present', () => {
             multipleExamples: false,
           },
         ],
-        status: '200',
       },
       {
-        languages: [],
         status: '400',
+        languages: [],
       },
     ]);
   });
@@ -211,6 +211,7 @@ describe('defined within response `content`', () => {
     ])('%s', (tc, operation) => {
       expect(operation.getResponseExamples()).toStrictEqual([
         {
+          status: '200',
           languages: [
             {
               code: cleanStringify({
@@ -223,9 +224,9 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: '200',
         },
         {
+          status: '400',
           languages: [
             {
               code:
@@ -234,9 +235,9 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: '400',
         },
         {
+          status: 'default',
           languages: [
             {
               code: cleanStringify({
@@ -250,7 +251,6 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: 'default',
         },
       ]);
     });
@@ -260,6 +260,7 @@ describe('defined within response `content`', () => {
 
       expect(operation.getResponseExamples()).toStrictEqual([
         {
+          status: '200',
           languages: [
             {
               code: cleanStringify({
@@ -270,9 +271,9 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: '200',
         },
         {
+          status: '400',
           languages: [
             {
               code:
@@ -281,7 +282,6 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: '400',
         },
       ]);
     });
@@ -310,6 +310,7 @@ describe('defined within response `content`', () => {
 
       expect(spec.operation('/', 'get').getResponseExamples()).toStrictEqual([
         {
+          status: '500',
           languages: [
             {
               code: 'string',
@@ -327,7 +328,6 @@ describe('defined within response `content`', () => {
               ],
             },
           ],
-          status: '500',
         },
       ]);
     });
@@ -337,6 +337,7 @@ describe('defined within response `content`', () => {
 
       expect(await operation.getResponseExamples()).toStrictEqual([
         {
+          status: '200',
           languages: [
             {
               code: cleanStringify([
@@ -349,9 +350,9 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: '200',
         },
         {
+          status: '400',
           languages: [
             {
               code:
@@ -360,7 +361,6 @@ describe('defined within response `content`', () => {
               multipleExamples: false,
             },
           ],
-          status: '400',
         },
       ]);
     });

--- a/tooling/operation/get-response-examples.js
+++ b/tooling/operation/get-response-examples.js
@@ -61,13 +61,10 @@ module.exports = operation => {
         return true;
       });
 
-      // If we don't have any languages or media types to show here, don't bother return anything.
-      if (mediaTypes.length === 0) return false;
-
       return {
         status,
 
-        // This should return a mediaTypes object instead of `languages`, but since `response.language` is integrated
+        // This should return a `mediaTypes` array instead of `languages`, but since `response.language` is integrated
         // into our legacy manual editor, we'll leave this alone for now.
         // @todo
         languages: mediaTypes,


### PR DESCRIPTION
## 🧰 What's being changed?

* [x] Updates `Operation.getResponseExamples` to no longer filter out examples that don't document anything (like `204 No Content` does).

## 🧪 Testing

This is going to require some updates to `@readme/api-explorer` and the Reference Redesign to account for this work, but this'll allow those codebases access to this data.

See attached unit tests.