### PR TITLE
fix: edgecase where server urls would get corrupted with normalized versions

### DIFF
--- a/__tests__/tooling/index.test.js
+++ b/__tests__/tooling/index.test.js
@@ -510,6 +510,25 @@ describe('#findOperation()', () => {
       },
     });
   });
+
+  it('should not overwrite the servers in the core OAS while looking for matches', () => {
+    const oas = new Oas(serverVariables);
+    const uri = 'https://demo.example.com:443/v2/post';
+    const method = 'post';
+
+    expect(oas.servers[0].url).toStrictEqual('https://{name}.example.com:{port}/{basePath}');
+
+    const res = oas.findOperation(uri, method);
+    expect(res.url).toMatchObject({
+      origin: 'https://demo.example.com:443/v2',
+      path: '/post',
+      nonNormalizedPath: '/post',
+      slugs: {},
+      method: 'POST',
+    });
+
+    expect(oas.servers[0].url).toStrictEqual('https://{name}.example.com:{port}/{basePath}');
+  });
 });
 
 // Since this is just a wrapper for findOperation, we don't need to re-test everything that the tests for that does. All

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -257,16 +257,22 @@ class Oas {
 
     // Since a host can match against multiple different schemes in an OAS we should prioritize it over matching the
     // hostname.
-    let targetServer = servers.find(s => originRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
-    if (!targetServer) {
+    let matchedServer = servers.find(s => originRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
+    if (!matchedServer) {
       const hostnameRegExp = new RegExp(hostname);
-      targetServer = servers.find(s => hostnameRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
-      if (!targetServer) {
+      matchedServer = servers.find(s => hostnameRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
+      if (!matchedServer) {
         return undefined;
       }
     }
 
-    targetServer.url = this.replaceUrl(targetServer.url, targetServer.variables || {});
+    // Instead of setting `url` directly against `matchedServer` we need to set it to an intermediary object as directly
+    // modifying `matchedServer.url` will in turn update `this.servers[idx].url` which we absolutely do not want to
+    // happen.
+    const targetServer = {
+      ...matchedServer,
+      url: this.replaceUrl(matchedServer.url, matchedServer.variables || {}),
+    };
 
     let [, pathName] = url.split(targetServer.url);
     if (pathName === undefined) return undefined;


### PR DESCRIPTION
## 🧰 What's being changed?

This was being surfaced in our `APIServers` component where because we do `findOperation` lookups in a handful of spots to be able to handle servers with variables, our `findOperationMatches` code was actually overwriting the core `servers` data within the OAS, resulting in complete data loss of these servers variables. 

Because apparently of this:

```js
const servers = [{ url: 'https://example.com' }];
const found = servers.find(server => server.url === 'https://example.com');
found.url = 'https://google.com';

console.log(servers[0].url); // https://google.com
```

🤡 

## 🧪 Testing

See the unit test I added.
