### PR TITLE
fix: quirks with operation discovery on servers that have variables

### DIFF
--- a/__tests__/tooling/index.test.js
+++ b/__tests__/tooling/index.test.js
@@ -53,7 +53,7 @@ describe('#url([selected])', () => {
     expect(new Oas({ servers: [{ url: 'https://example.com' }] }).url(10)).toBe('https://example.com');
   });
 
-  describe('variable replacement', () => {
+  describe('server variables', () => {
     const oas = new Oas({
       servers: [
         {
@@ -81,6 +81,69 @@ describe('#url([selected])', () => {
       expect(oas.url(0, { basePath: 'v3', name: 'subdomain', port: '8080' })).toBe(
         'https://subdomain.example.com:8080/v3'
       );
+    });
+
+    it('should use defaults', () => {
+      expect(
+        new Oas({
+          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
+        }).url()
+      ).toBe('https://example.com/path');
+    });
+
+    it('should use user variables over defaults', () => {
+      expect(
+        new Oas(
+          {
+            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+          },
+          { username: 'domh' }
+        ).url()
+      ).toBe('https://domh.example.com');
+    });
+
+    it('should fetch user variables from keys array', () => {
+      expect(
+        new Oas(
+          {
+            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+          },
+          { keys: [{ name: 1, username: 'domh' }] }
+        ).url()
+      ).toBe('https://domh.example.com');
+    });
+
+    it('should look for variables in selected server', () => {
+      expect(
+        new Oas({
+          servers: [
+            { url: 'https://{username1}.example.com', variables: { username1: { default: 'demo1' } } },
+            { url: 'https://{username2}.example.com', variables: { username2: { default: 'demo2' } } },
+          ],
+        }).url(1)
+      ).toBe('https://demo2.example.com');
+    });
+
+    it.skip('should fetch user variables from selected app', () => {
+      expect(
+        new Oas(
+          {
+            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+          },
+          {
+            keys: [
+              { name: 1, username: 'domh' },
+              { name: 2, username: 'readme' },
+            ],
+          },
+          2
+        ).url()
+      ).toBe('https://readme.example.com');
+    });
+
+    // Test encodeURI
+    it('should pass through if no default set', () => {
+      expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe('https://example.com/{path}');
     });
   });
 });
@@ -573,70 +636,90 @@ describe('#getOperation()', () => {
     expect(operation.path).toBe('/store/order/{orderId}');
     expect(operation.method).toBe('get');
   });
-});
 
-describe('server variables', () => {
-  it('should use defaults', () => {
-    expect(
-      new Oas({
-        servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
-      }).url()
-    ).toBe('https://example.com/path');
-  });
-
-  it('should use user variables over defaults', () => {
-    expect(
-      new Oas(
+  describe('server variables', () => {
+    const apiDefinition = {
+      servers: [
         {
-          servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+          url: 'https://{region}.node.example.com/v14',
+          variables: {
+            region: {
+              default: 'us',
+              enum: ['us', 'eu'],
+            },
+          },
         },
-        { username: 'domh' }
-      ).url()
-    ).toBe('https://domh.example.com');
-  });
-
-  it('should fetch user variables from keys array', () => {
-    expect(
-      new Oas(
-        {
-          servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+      ],
+      paths: {
+        '/api/esm': {
+          put: {
+            responses: {
+              200: {
+                description: '200',
+              },
+            },
+          },
         },
-        { keys: [{ name: 1, username: 'domh' }] }
-      ).url()
-    ).toBe('https://domh.example.com');
-  });
+      },
+    };
 
-  it('should look for variables in selected server', () => {
-    expect(
-      new Oas({
-        servers: [
-          { url: 'https://{username1}.example.com', variables: { username1: { default: 'demo1' } } },
-          { url: 'https://{username2}.example.com', variables: { username2: { default: 'demo2' } } },
-        ],
-      }).url(1)
-    ).toBe('https://demo2.example.com');
-  });
+    it('should be able to find an operation where the variable matches the url', () => {
+      const source = {
+        url: 'https://eu.node.example.com/v14/api/esm',
+        method: 'put',
+      };
 
-  it.skip('should fetch user variables from selected app', () => {
-    expect(
-      new Oas(
-        {
-          servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
-        },
-        {
-          keys: [
-            { name: 1, username: 'domh' },
-            { name: 2, username: 'readme' },
-          ],
-        },
-        2
-      ).url()
-    ).toBe('https://readme.example.com');
-  });
+      const method = source.method.toLowerCase();
+      const oas = new Oas(apiDefinition, { region: 'eu' });
+      const operation = oas.getOperation(source.url, method);
 
-  // Test encodeURI
-  it('should pass through if no default set', () => {
-    expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe('https://example.com/{path}');
+      expect(operation).not.toBeUndefined();
+      expect(operation.path).toBe('/api/esm');
+      expect(operation.method).toBe('put');
+    });
+
+    it("should be able to find an operation where the variable **doesn't** match the url", () => {
+      const source = {
+        url: 'https://eu.node.example.com/v14/api/esm',
+        method: 'put',
+      };
+
+      const method = source.method.toLowerCase();
+      const oas = new Oas(apiDefinition, { region: 'us' });
+      const operation = oas.getOperation(source.url, method);
+
+      expect(operation).not.toBeUndefined();
+      expect(operation.path).toBe('/api/esm');
+      expect(operation.method).toBe('put');
+    });
+
+    it('should be able to find an operation if there are no user variables present', () => {
+      const source = {
+        url: 'https://eu.node.example.com/v14/api/esm',
+        method: 'put',
+      };
+
+      const method = source.method.toLowerCase();
+      const oas = new Oas(apiDefinition);
+      const operation = oas.getOperation(source.url, method);
+
+      expect(operation).not.toBeUndefined();
+      expect(operation.path).toBe('/api/esm');
+      expect(operation.method).toBe('put');
+    });
+
+    it('should fail to find a match on a url that doesnt quite match', () => {
+      const source = {
+        url: 'https://eu.buster.example.com/v14/api/esm',
+        method: 'put',
+      };
+
+      const method = source.method.toLowerCase();
+      const oas = new Oas(apiDefinition, { region: 'us' });
+      const operation = oas.getOperation(source.url, method);
+
+      expect(operation).toBeUndefined();
+    });
   });
 });
 

--- a/__tests__/tooling/index.test.js
+++ b/__tests__/tooling/index.test.js
@@ -688,7 +688,7 @@ describe('#getOperation()', () => {
       const oas = new Oas(apiDefinition, { region: 'us' });
       const operation = oas.getOperation(source.url, method);
 
-      expect(operation).not.toBeUndefined();
+      expect(operation).toBeDefined();
       expect(operation.path).toBe('/api/esm');
       expect(operation.method).toBe('put');
     });
@@ -703,7 +703,7 @@ describe('#getOperation()', () => {
       const oas = new Oas(apiDefinition);
       const operation = oas.getOperation(source.url, method);
 
-      expect(operation).not.toBeUndefined();
+      expect(operation).toBeDefined();
       expect(operation.path).toBe('/api/esm');
       expect(operation.method).toBe('put');
     });
@@ -719,6 +719,35 @@ describe('#getOperation()', () => {
       const operation = oas.getOperation(source.url, method);
 
       expect(operation).toBeUndefined();
+    });
+
+    it('should be able to find a match on a url with an server OAS that doesnt have fleshed out server variables', () => {
+      const oas = new Oas({
+        servers: [{ url: 'https://{region}.node.example.com/v14' }],
+        paths: {
+          '/api/esm': {
+            put: {
+              responses: {
+                200: {
+                  description: '200',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const source = {
+        url: 'https://us.node.example.com/v14/api/esm',
+        method: 'put',
+      };
+
+      const method = source.method.toLowerCase();
+      const operation = oas.getOperation(source.url, method);
+
+      expect(operation).toBeDefined();
+      expect(operation.path).toBe('/api/esm');
+      expect(operation.method).toBe('put');
     });
   });
 });

--- a/__tests__/tooling/index.test.js
+++ b/__tests__/tooling/index.test.js
@@ -341,7 +341,7 @@ describe('#operation()', () => {
 
   it("should still return an operation object if the operation isn't found", () => {
     const operation = new Oas(petstore).operation('/pet', 'patch');
-    expect(operation.schema).not.toBeUndefined();
+    expect(operation.schema).toBeDefined();
   });
 });
 
@@ -673,7 +673,7 @@ describe('#getOperation()', () => {
       const oas = new Oas(apiDefinition, { region: 'eu' });
       const operation = oas.getOperation(source.url, method);
 
-      expect(operation).not.toBeUndefined();
+      expect(operation).toBeDefined();
       expect(operation.path).toBe('/api/esm');
       expect(operation.method).toBe('put');
     });

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -45,6 +45,20 @@ function normalizedUrl(oas, selected) {
   return ensureProtocol(url);
 }
 
+/**
+ * With a URL that may contain server variables, transform those server variables into regex that we can query against.
+ *
+ * For example, when given `https://{region}.node.example.com/v14` this will return back:
+ *
+ *    https://([-_a-zA-Z0-9[\\]]+).node.example.com/v14
+ *
+ * @param {String} url
+ * @returns {String}
+ */
+function transformUrlIntoRegex(url) {
+  return stripTrailingSlash(url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, () => '([-_a-zA-Z0-9[\\]]+)'));
+}
+
 function normalizePath(path) {
   return path.replace(/{(.*?)}/g, ':$1');
 }
@@ -255,26 +269,61 @@ class Oas {
       return undefined;
     }
 
-    // Since a host can match against multiple different schemes in an OAS we should prioritize it over matching the
-    // hostname.
+    let pathName;
+    let targetServer;
     let matchedServer = servers.find(s => originRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
     if (!matchedServer) {
       const hostnameRegExp = new RegExp(hostname);
       matchedServer = servers.find(s => hostnameRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
-      if (!matchedServer) {
-        return undefined;
-      }
     }
 
-    // Instead of setting `url` directly against `matchedServer` we need to set it to an intermediary object as directly
-    // modifying `matchedServer.url` will in turn update `this.servers[idx].url` which we absolutely do not want to
-    // happen.
-    const targetServer = {
-      ...matchedServer,
-      url: this.replaceUrl(matchedServer.url, matchedServer.variables || {}),
-    };
+    // If we **still** haven't found a matching server, then the OAS server URL might have server variables and we
+    // should loosen it up with regex to try to discover a matching path.
+    //
+    // For example if an OAS has `https://{region}.node.example.com/v14` set as its server URL, and the `this.user`
+    // object has a `region` value of `us`, if we're trying to locate an operation for
+    // https://eu.node.example.com/v14/api/esm we won't be able to because normally the users `region` of `us` will be
+    // transposed in and we'll be trying to locate `eu.node.example.com` in `us.node.example.com` -- which won't work.
+    //
+    // So what this does is transform `https://{region}.node.example.com/v14` into
+    // `https://([-_a-zA-Z0-9[\\]]+).node.example.com/v14`, and from there we'll be able to match
+    // https://eu.node.example.com/v14/api/esm and ultimately find the operation matches for `/api/esm`.
+    if (!matchedServer) {
+      const matchedServerAndPath = servers
+        .map(server => {
+          const rgx = transformUrlIntoRegex(server.url);
+          const found = new RegExp(rgx).exec(url);
+          if (!found) {
+            return false;
+          }
 
-    let [, pathName] = url.split(targetServer.url);
+          return {
+            matchedServer: server,
+            pathName: url.split(new RegExp(rgx)).slice(-1).pop(),
+          };
+        })
+        .filter(Boolean);
+
+      if (!matchedServerAndPath.length) {
+        return undefined;
+      }
+
+      pathName = matchedServerAndPath[0].pathName;
+      targetServer = {
+        ...matchedServerAndPath[0].matchedServer,
+      };
+    } else {
+      // Instead of setting `url` directly against `matchedServer` we need to set it to an intermediary object as directly
+      // modifying `matchedServer.url` will in turn update `this.servers[idx].url` which we absolutely do not want to
+      // happen.
+      targetServer = {
+        ...matchedServer,
+        url: this.replaceUrl(matchedServer.url, matchedServer.variables || {}),
+      };
+
+      [, pathName] = url.split(targetServer.url);
+    }
+
     if (pathName === undefined) return undefined;
     if (pathName === '') pathName = '/';
     const annotatedPaths = generatePathMatches(paths, pathName, targetServer.url);

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -313,9 +313,9 @@ class Oas {
         ...matchedServerAndPath[0].matchedServer,
       };
     } else {
-      // Instead of setting `url` directly against `matchedServer` we need to set it to an intermediary object as directly
-      // modifying `matchedServer.url` will in turn update `this.servers[idx].url` which we absolutely do not want to
-      // happen.
+      // Instead of setting `url` directly against `matchedServer` we need to set it to an intermediary object as
+      // directly modifying `matchedServer.url` will in turn update `this.servers[idx].url` which we absolutely do not
+      // want to happen.
       targetServer = {
         ...matchedServer,
         url: this.replaceUrl(matchedServer.url, matchedServer.variables || {}),


### PR DESCRIPTION
## 🧰 What's being changed?

This is a weird one!

Say you have an OAS that has a server URL of `https://{region}.node.example.com/v14` and a logged in user JWT with `region` set to `us`. `region` is an enum that can be either `us` or `eu`. Now say you're trying to find an operation for https://eu.node.example.com/v14/api/esm. Won't work.

The way we do operation discovery (with `getOperation()` and `findOperation()`) is we run through a checklist of things to look for:

1. First we replace the server URL with the users variables so https://{region}.node.example.com/v14 becomes https://us.node.example.com/v14
2. Then we look at the origin of the URL we're looking for: https://us.node.example.com
3. If that fails we fallback to the hostname we're looking for: us.node.example.com
4. If we've got a match, split our found server URL off the URL we're looking for. So https://us.node.example.com/v14 is removed from https://us.node.example.com/v14/api/esm resulting in the path we should pull operations for: `/api/esm`.

Now where this breaks is that if either the user is logged out (no JWT variables), or you're looking at an old log you want to pull records for (like in metrics) where you might have https://eu.node.example.com/v14/api/esm. Since `eu` **isn't** the default value for `region` we'll never be able to find `/api/esm` without regexing `https://(.*).node.example.com/v14` out.

That's what this does. 😰 

## 🧪 Testing

I reorganized some tests around in here, but peep the ones I added to the `getOperation()` block.
