### PR TITLE
fix: bug where non-variabled path colons weren't being escaped

### DIFF
--- a/__tests__/tooling/__fixtures__/multiple-securities.json
+++ b/__tests__/tooling/__fixtures__/multiple-securities.json
@@ -220,9 +220,6 @@
       }
     }
   },
-  "x-explorer-enabled": true,
-  "x-samples-enabled": true,
-  "x-samples-languages": ["curl", "node", "ruby", "javascript", "python"],
   "components": {
     "securitySchemes": {
       "oauthScheme": {

--- a/__tests__/tooling/__fixtures__/path-variable-quirks.json
+++ b/__tests__/tooling/__fixtures__/path-variable-quirks.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Path variable quirks",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/people/{personIdType}:{personId}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "personIdType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "personId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/__tests__/tooling/__fixtures__/server-variables.json
+++ b/__tests__/tooling/__fixtures__/server-variables.json
@@ -1,5 +1,9 @@
 {
   "openapi": "3.0.0",
+  "info": {
+    "title": "Server variables",
+    "version": "1.0.0"
+  },
   "servers": [
     {
       "url": "https://{name}.example.com:{port}/{basePath}",
@@ -16,10 +20,6 @@
       }
     }
   ],
-  "info": {
-    "version": "1.0.0",
-    "title": "Server variables"
-  },
   "paths": {
     "/post": {
       "post": {
@@ -29,8 +29,5 @@
         "responses": {}
       }
     }
-  },
-  "x-explorer-enabled": true,
-  "x-samples-enabled": true,
-  "x-samples-languages": ["curl", "node", "ruby", "javascript", "python"]
+  }
 }

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -60,7 +60,12 @@ function transformUrlIntoRegex(url) {
 }
 
 function normalizePath(path) {
-  return path.replace(/{(.*?)}/g, ':$1');
+  // In addition to transforming `{pathParam}` into `:pathParam` we also need to escape cases where a non-variabled
+  // colon is next to a variabled-colon because if we don't `path-to-regexp` won't be able to correct identify where the
+  // variable starts.
+  //
+  // For example if the URL is `/post/:param1::param2` we'll be escaping it to `/post/:param1\::param2`.
+  return path.replace(/{(.*?)}/g, ':$1').replace(/::/, '\\::');
 }
 
 function generatePathMatches(paths, pathName, origin) {
@@ -81,7 +86,7 @@ function generatePathMatches(paths, pathName, origin) {
       return {
         url: {
           origin,
-          path: cleanedPath,
+          path: cleanedPath.replace(/\\::/, '::'),
           nonNormalizedPath: path,
           slugs,
         },


### PR DESCRIPTION
## 🧰 What's being changed?

This fixes a quirk in our interactions with `path-to-regexp` where if an incoming URL looked like `/post/:param1::param2` `path-to-regexp` would throw errors because it wouldn't be able to determine where `:param2` began. Cases of double-colons are now being escaped before they're supplied to path lookups, so `/post/:param1::param2` becomes `/post/:param1\::param2` 

This'll fix RM-915.

## 🧪 Testing

See tests.