### PR TITLE
Handle Oas with a server URL that has no host or domain

### DIFF
--- a/__tests__/tooling/index.test.js
+++ b/__tests__/tooling/index.test.js
@@ -54,6 +54,10 @@ describe('#url([selected])', () => {
     expect(new Oas({ servers: [{ url: 'https://example.com' }] }).url(10)).toBe('https://example.com');
   });
 
+  it('should make example.com the origin if none is present', () => {
+    expect(new Oas({ servers: [{ url: '/api/v3' }] }).url()).toBe('https://example.com/api/v3');
+  });
+
   describe('server variables', () => {
     const oas = new Oas({
       servers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "oas",
-  "version": "10.7.4",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.7.4",
+      "version": "11.0.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",

--- a/tooling/index.js
+++ b/tooling/index.js
@@ -30,6 +30,7 @@ function stripTrailingSlash(url) {
 }
 
 function normalizedUrl(oas, selected) {
+  const exampleDotCom = 'https://example.com';
   let url;
   try {
     url = oas.servers[selected].url;
@@ -38,8 +39,16 @@ function normalizedUrl(oas, selected) {
 
     // Stripping the '/' off the end
     url = stripTrailingSlash(url);
+
+    // RM-1044 Check if the URL is just a path a missing an origin, for example `/api/v3`
+    // If so, then make example.com the origin to avoid it becoming something invalid like https:///api/v3
+    if (url.startsWith('/') && !url.startsWith('//')) {
+      const urlWithOrigin = new URL(exampleDotCom);
+      urlWithOrigin.pathname = url;
+      url = urlWithOrigin.href;
+    }
   } catch (e) {
-    url = 'https://example.com';
+    url = exampleDotCom;
   }
 
   return ensureProtocol(url);


### PR DESCRIPTION
## [🎟](https://linear.app/readme-io/issue/RM-1044/handle-oas-spec-with-a-server-url-that-has-no-host-or-domain) What's being changed?

This handles an oas with a server URL that has no host or domain, such as `/api/v3`. An example of this can be found in the `server` specified in this petstore v3 [oas](https://petstore3.swagger.io/api/v3/openapi.json).
