### PR TITLE
feat: use null instead of empty-string for empty state

### DIFF
--- a/__tests__/lib/get-auth.test.js
+++ b/__tests__/lib/get-auth.test.js
@@ -8,15 +8,15 @@ const oas = new Oas(multipleSecurities);
 test('should fetch all auths from the OAS files', () => {
   expect(oas.getAuth({ oauthScheme: 'oauth', apiKeyScheme: 'apikey' })).toStrictEqual({
     apiKeyScheme: 'apikey',
-    apiKeySignature: '',
+    apiKeySignature: null,
     basicAuth: {
-      pass: '',
-      user: '',
+      pass: null,
+      user: null,
     },
-    httpBearer: '',
-    oauthDiff: '',
+    httpBearer: null,
+    oauthDiff: null,
     oauthScheme: 'oauth',
-    unknownAuthType: '',
+    unknownAuthType: null,
   });
 });
 
@@ -107,16 +107,16 @@ describe('#getByScheme', () => {
     });
   });
 
-  it('should return emptystring for anything else', () => {
-    expect(getByScheme(topLevelUser, { type: 'unknown' })).toBe('');
-    expect(getByScheme({}, { type: 'http', scheme: 'basic' })).toStrictEqual({ user: '', pass: '' });
-    expect(getByScheme({}, { type: 'http', scheme: 'bearer' })).toBe('');
-    expect(getByScheme({}, { type: 'http', scheme: 'unknown' })).toBe('');
-    expect(getByScheme(keysUser, { type: 'unknown' })).toBe('');
-    expect(getByScheme(keysUser, { type: 'unknown' }, 'app-2')).toBe('');
+  it('should return null for anything else', () => {
+    expect(getByScheme(topLevelUser, { type: 'unknown' })).toBeNull();
+    expect(getByScheme({}, { type: 'http', scheme: 'basic' })).toStrictEqual({ user: null, pass: null });
+    expect(getByScheme({}, { type: 'http', scheme: 'bearer' })).toBeNull();
+    expect(getByScheme({}, { type: 'http', scheme: 'unknown' })).toBeNull();
+    expect(getByScheme(keysUser, { type: 'unknown' })).toBeNull();
+    expect(getByScheme(keysUser, { type: 'unknown' }, 'app-2')).toBeNull();
   });
 
   it('should allow scheme to be undefined', () => {
-    expect(getByScheme(topLevelUser)).toBe('');
+    expect(getByScheme(topLevelUser)).toBeNull();
   });
 });

--- a/src/lib/get-auth.js
+++ b/src/lib/get-auth.js
@@ -3,20 +3,20 @@ function getKey(user, scheme) {
   switch (scheme.type) {
     case 'oauth2':
     case 'apiKey':
-      return user[scheme._key] || user.apiKey || scheme['x-default'] || '';
+      return user[scheme._key] || user.apiKey || scheme['x-default'] || null;
 
     case 'http':
       if (scheme.scheme === 'basic') {
-        return user[scheme._key] || { user: user.user || '', pass: user.pass || '' };
+        return user[scheme._key] || { user: user.user || null, pass: user.pass || null };
       }
 
       if (scheme.scheme === 'bearer') {
-        return user[scheme._key] || user.apiKey || '';
+        return user[scheme._key] || user.apiKey || null;
       }
-      return '';
+      return null;
 
     default:
-      return '';
+      return null;
   }
 }
 


### PR DESCRIPTION
## 🧰 What's being changed?

Allows consumers of this package to more easy distinguish between an empty oas file and empty user input.

## 🧪 Testing

Updated the tests so they pass.

## ⚠️ Potentially Breaking Changes

- Whenever we integrate this into the `api-explorer` package, there are some [tests](https://github.com/readmeio/api-explorer/blob/main/packages/api-explorer/__tests__/lib/get-auth.test.js) that may need to be updated. I don't see any code in that project that seems like this it will be affected by this change.
- There are some places in the ReadMe project that explicitly check for empty strings that likely need to updated.
  - [SelectWidget](https://github.com/readmeio/readme/blob/next/packages/schema-form/src/Form/components/widgets/SelectWidget.js#L103)
  - [BaseInput](https://github.com/readmeio/readme/blob/next/packages/schema-form/src/Form/components/widgets/BaseInput.js#L72)
  - [TextAreaWidget](https://github.com/readmeio/readme/blob/next/packages/schema-form/src/Form/components/widgets/TextareaWidget.js#L7)
  - Maybe for some of the empty-string checks in [Form/utils](https://github.com/readmeio/readme/blob/next/packages/schema-form/src/Form/utils.js)
  - Maybe [MultiSchemaField](https://github.com/readmeio/readme/blob/next/packages/schema-form/src/form-components/MultiSchemaField.jsx#L36)
