### PR TITLE
fix: update getParameters to pass parameter name to constructSchema

### DIFF
--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -1369,7 +1369,7 @@ describe('defaults', () => {
         expect(jsonSchema[0].schema.properties.category.default).toBeUndefined();
       });
 
-      it('should use user defined jwtDefaults', async () => {
+      it('should use user defined jwtDefaults for requestBody', async () => {
         const schema = new Oas(petstore);
         await schema.dereference();
         const operation = schema.operation('/pet', 'post');
@@ -1382,6 +1382,18 @@ describe('defaults', () => {
 
         const jsonSchema = operation.getParametersAsJsonSchema(jwtDefaults);
         expect(jsonSchema[0].schema.properties.category.default).toStrictEqual(jwtDefaults.category);
+      });
+
+      it('should use user defined jwtDefaults for parameters', async () => {
+        const schema = new Oas(petstore);
+        await schema.dereference();
+        const operation = schema.operation('/pet/{petId}', 'get');
+        const jwtDefaults = {
+          petId: 1,
+        };
+
+        const jsonSchema = operation.getParametersAsJsonSchema(jwtDefaults);
+        expect(jsonSchema[0].schema.properties.petId.default).toStrictEqual(jwtDefaults.petId);
       });
 
       it.todo('with usages of `oneOf` cases');

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -505,7 +505,7 @@ function getParameters(path, operation, oas, globalDefaults) {
           if (typeof current.content[contentType] === 'object' && 'schema' in current.content[contentType]) {
             schema = {
               ...(current.content[contentType].schema
-                ? constructSchema(current.content[contentType].schema, [], '', globalDefaults)
+                ? constructSchema(current.content[contentType].schema, [], `/${current.name}`, globalDefaults)
                 : {}),
             };
           }

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -483,7 +483,8 @@ function getParameters(path, operation, oas, globalDefaults) {
       let schema = {};
       if ('schema' in current) {
         schema = {
-          ...(current.schema ? constructSchema(current.schema, [], '', globalDefaults) : {}),
+          ...(current.schema ? constructSchema(current.schema, [], `/${current.name}`, globalDefaults) : {}),
+          // ...(current.schema ? constructSchema(current.schema, [], '', globalDefaults) : {}),
         };
       } else if ('content' in current && typeof current.content === 'object') {
         const contentKeys = Object.keys(current.content);

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -484,7 +484,6 @@ function getParameters(path, operation, oas, globalDefaults) {
       if ('schema' in current) {
         schema = {
           ...(current.schema ? constructSchema(current.schema, [], `/${current.name}`, globalDefaults) : {}),
-          // ...(current.schema ? constructSchema(current.schema, [], '', globalDefaults) : {}),
         };
       } else if ('content' in current && typeof current.content === 'object') {
         const contentKeys = Object.keys(current.content);


### PR DESCRIPTION
## 🧰 Changes

Currently, for parameters, we don't pass in `current.name` as `currentLocation` to `constructSchema`. This makes it so that when we get into `consructSchema`, `currentLocation` will be blank for the first iteration.

This change makes it so `currentLocation` will be correct for each iteration of parameters.

## 🧬 QA & Testing

This is mostly to fix user defined JWT defaults not working for path, query and header parameters. I can provide testing steps when I open the PR in the main repo.