### PR TITLE
fix: treat objects without any properties as `additionalProperties` 

### DIFF
--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -859,6 +859,27 @@ describe('type', () => {
       });
     });
 
+    it('should repair an object that has no `properties` or `additionalProperties`', () => {
+      const oas = createOas({
+        parameters: [
+          {
+            name: 'userId',
+            in: 'query',
+            schema: {
+              type: 'object',
+            },
+          },
+        ],
+      });
+
+      expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema.properties).toStrictEqual({
+        userId: {
+          type: 'object',
+          additionalProperties: true,
+        },
+      });
+    });
+
     describe('repair invalid schema that has no `type`', () => {
       it('should repair an invalid schema that has no `type` as just a simple string', () => {
         const oas = createOas({
@@ -968,6 +989,37 @@ describe('type', () => {
         properties: { name: { type: 'string' } },
         required: ['name'],
         type: 'object',
+      });
+    });
+
+    it('should repair an object that has no `properties` or `additionalProperties`', () => {
+      const oas = createOas({
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  host: {
+                    type: 'object',
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+
+      expect(schema[0].schema).toStrictEqual({
+        type: 'object',
+        properties: {
+          host: {
+            type: 'object',
+            additionalProperties: true,
+          },
+        },
       });
     });
 
@@ -1269,7 +1321,7 @@ describe('additionalProperties', () => {
     it.each([
       ['true', true],
       ['false', false],
-      ['an empty object', {}],
+      ['an empty object', true],
       ['an object containing a string', { type: 'string' }],
     ])('when set to %s', (tc, additionalProperties) => {
       parameters[0].schema.items.additionalProperties = additionalProperties;
@@ -1315,7 +1367,7 @@ describe('additionalProperties', () => {
     it.each([
       ['true', true],
       ['false', false],
-      ['an empty object', {}],
+      ['an empty object', true],
       ['an object containing a string', { type: 'string' }],
     ])('when set to %s', (tc, additionalProperties) => {
       requestBody.content['application/json'].schema.items.additionalProperties = additionalProperties;

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -130,8 +130,8 @@ describe('parameters', () => {
           schemas: {
             string_enum: {
               name: 'string enum',
-              enum: ['available', 'pending', 'sold'],
               type: 'string',
+              enum: ['available', 'pending', 'sold'],
             },
           },
         }
@@ -141,8 +141,8 @@ describe('parameters', () => {
 
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema.properties.param.items).toStrictEqual({
         name: 'string enum',
-        enum: ['available', 'pending', 'sold'],
         type: 'string',
+        enum: ['available', 'pending', 'sold'],
       });
     });
 
@@ -213,8 +213,8 @@ describe('parameters', () => {
       expect(schema).toHaveLength(1);
       expect(schema[0].schema.properties).toStrictEqual({
         param: {
-          description: 'Param description',
           type: 'string',
+          description: 'Param description',
         },
       });
     });
@@ -791,12 +791,12 @@ describe('request bodies', () => {
       expect(schema[0].schema.properties.nestedParam.properties.nestedParamProp).toStrictEqual({
         [prop]: [
           {
+            type: 'object',
             properties: {
               nestedNum: {
                 type: 'integer',
               },
             },
-            type: 'object',
           },
           {
             type: 'integer',
@@ -823,9 +823,9 @@ describe('type', () => {
       });
 
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema).toStrictEqual({
+        type: 'object',
         properties: { param: { items: {}, type: 'array' } },
         required: [],
-        type: 'object',
       });
     });
 
@@ -846,6 +846,7 @@ describe('type', () => {
       });
 
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema).toStrictEqual({
+        type: 'object',
         properties: {
           param: {
             type: 'object',
@@ -855,7 +856,6 @@ describe('type', () => {
           },
         },
         required: [],
-        type: 'object',
       });
     });
 
@@ -896,8 +896,8 @@ describe('type', () => {
 
         expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema.properties).toStrictEqual({
           userId: {
-            description: 'User ID',
             type: 'string',
+            description: 'User ID',
           },
         });
       });
@@ -912,13 +912,13 @@ describe('type', () => {
               schema: {
                 [prop]: [
                   {
+                    title: 'range_query_specs',
+                    type: 'object',
                     properties: {
                       gt: {
                         type: 'integer',
                       },
                     },
-                    title: 'range_query_specs',
-                    type: 'object',
                   },
                   {
                     type: 'integer',
@@ -966,17 +966,17 @@ describe('type', () => {
           content: {
             'application/json': {
               schema: {
+                description: '',
                 type: 'array',
                 items: {
-                  required: ['name'],
                   type: 'array',
                   properties: {
                     name: {
                       type: 'string',
                     },
                   },
+                  required: ['name'],
                 },
-                description: '',
               },
             },
           },
@@ -986,9 +986,9 @@ describe('type', () => {
       const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
 
       expect(schema[0].schema.items).toStrictEqual({
+        type: 'object',
         properties: { name: { type: 'string' } },
         required: ['name'],
-        type: 'object',
       });
     });
 
@@ -1045,13 +1045,13 @@ describe('type', () => {
         const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
 
         expect(schema[0].schema).toStrictEqual({
+          type: 'object',
           properties: {
             host: {
-              description: 'Host name to check validity of.',
               type: 'string',
+              description: 'Host name to check validity of.',
             },
           },
-          type: 'object',
         });
       });
 
@@ -1323,17 +1323,17 @@ describe('additionalProperties', () => {
       ['false', false],
       ['an empty object', true],
       ['an object containing a string', { type: 'string' }],
-    ])('when set to %s', (tc, additionalProperties) => {
+    ])('should support when set to %s', (tc, additionalProperties) => {
       parameters[0].schema.items.additionalProperties = additionalProperties;
       const oas = createOas({ parameters });
 
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema.properties.param.items).toStrictEqual({
-        additionalProperties,
         type: 'object',
+        additionalProperties,
       });
     });
 
-    it('when set to an object containing an array', () => {
+    it('should support when set to an object containing an array', () => {
       parameters[0].schema.items.additionalProperties = {
         type: 'array',
         items: {
@@ -1350,8 +1350,8 @@ describe('additionalProperties', () => {
       const oas = createOas({ parameters });
 
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema.properties.param.items).toStrictEqual({
-        additionalProperties: parameters[0].schema.items.additionalProperties,
         type: 'object',
+        additionalProperties: parameters[0].schema.items.additionalProperties,
       });
     });
   });
@@ -1369,13 +1369,13 @@ describe('additionalProperties', () => {
       ['false', false],
       ['an empty object', true],
       ['an object containing a string', { type: 'string' }],
-    ])('when set to %s', (tc, additionalProperties) => {
+    ])('should support when set to %s', (tc, additionalProperties) => {
       requestBody.content['application/json'].schema.items.additionalProperties = additionalProperties;
       const oas = createOas({ requestBody });
 
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema.items).toStrictEqual({
-        additionalProperties,
         type: 'object',
+        additionalProperties,
       });
     });
   });

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -328,7 +328,7 @@ function constructSchema(
           !('$ref' in schema.additionalProperties) &&
           !isPolymorphicSchema(schema.additionalProperties)
         ) {
-          schema.additionalProperties = {};
+          schema.additionalProperties = true;
         } else {
           schema.additionalProperties = constructSchema(
             data.additionalProperties,
@@ -338,6 +338,13 @@ function constructSchema(
           );
         }
       }
+    }
+
+    // Since neither `properties` and `additionalProperties` are actually required to be present on an object, since we
+    // construct this schema work to build up a form we still need *something* for the user to enter in for this object
+    // so we'll add back in `additionalProperties` for that.
+    if (!isPolymorphicSchema(schema) && !('properties' in schema) && !('additionalProperties' in schema)) {
+      schema.additionalProperties = true;
     }
   }
 


### PR DESCRIPTION
## 🧰 Changes

This adds some handling for objects that have no `properties`, `additionalPropeties`, and aren't polymorphic, to rewrite their schemas as being `additionalProperties` objects so that when we handle them in our form system we'll be able to generate inputs for the user.

This'll help resolve RM-1256.
 
## 🧬 QA & Testing

For example the following object schema:

```js
{
  type: 'object'
}
```

will be rewritten into becoming the following when we construct JSON Schema:

```js
{
  type: 'object'
  additionalProperties: true
}
```