### PR TITLE
fix: quirk where a path with a query string would break matching

### DIFF
--- a/__tests__/__fixtures__/path-matching-quirks.json
+++ b/__tests__/__fixtures__/path-matching-quirks.json
@@ -20,6 +20,15 @@
         }
       }
     },
+    "/rating_stats": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/rating_stats?listing_ids[]=1234567": {
       "get": {
         "responses": {

--- a/__tests__/__fixtures__/path-matching-quirks.json
+++ b/__tests__/__fixtures__/path-matching-quirks.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Path Matching Quirks",
+    "description": "Example API definition to cover some quirks with path matching where a query param in a path might break `Oas.findOperation()`",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v2"
+    }
+  ],
+  "paths": {
+    "/listings": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/rating_stats?listing_ids[]=1234567": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/listings#hash": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,13 @@ function normalizePath(path) {
   // variable starts.
   //
   // For example if the URL is `/post/:param1::param2` we'll be escaping it to `/post/:param1\::param2`.
-  return path.replace(/{(.*?)}/g, ':$1').replace(/::/, '\\::');
+  return (
+    path
+      .replace(/{(.*?)}/g, ':$1')
+      .replace(/::/, '\\::')
+      // Need to escape question marks too because they're treated as regex modifiers in `path-to-regexp`
+      .split('?')[0]
+  );
 }
 
 function generatePathMatches(paths, pathName, origin) {
@@ -403,6 +409,7 @@ class Oas {
     if (!annotatedPaths) {
       return undefined;
     }
+
     const includesMethod = filterPathMethods(annotatedPaths, method);
     if (!includesMethod.length) return undefined;
     return findTargetPath(includesMethod);


### PR DESCRIPTION
## 🧰 Changes

This fixes a quirk in our `findOperation()` method where if a path in the API definition had a query param (like `?param=123` it would completely kill the method because the `?` was being interpreted as a regex modifier for [path-to-regexp](http://npm.im/path-to-regexp). To resolve this, I've loosened up matching on these kinds of paths so it'll look on `/path` instead of `/path?param=123`.

Fixes RM-1396

## 🧬 QA & Testing

I've added test cases for the initial regression as well as some other potential variants of this quirk.