### PR TITLE
fix: path matching quirk in oas files missing servers

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -750,6 +750,39 @@ describe('#findOperation()', () => {
         method: 'GET',
       });
     });
+
+    it('should be able to find an operation if `servers` are missing from the API definition', () => {
+      const oas = new Oas({
+        openapi: '3.0.1',
+        info: {
+          title: 'Some Test API',
+          version: '1',
+        },
+        paths: {
+          '/v1/endpoint': {
+            get: {
+              responses: {
+                200: {
+                  description: 'OK',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const uri = 'https://example.com/v1/endpoint';
+      const method = 'get';
+
+      const res = oas.findOperation(uri, method);
+      expect(res.url).toStrictEqual({
+        origin: 'https://example.com',
+        path: '/v1/endpoint',
+        nonNormalizedPath: '/v1/endpoint',
+        slugs: {},
+        method: 'GET',
+      });
+    });
   });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -328,16 +328,23 @@ class Oas {
     const originRegExp = new RegExp(origin);
     const { servers, paths } = this;
 
-    if (!servers || !servers.length) {
-      return undefined;
-    }
-
     let pathName;
     let targetServer;
-    let matchedServer = servers.find(s => originRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
-    if (!matchedServer) {
-      const hostnameRegExp = new RegExp(hostname);
-      matchedServer = servers.find(s => hostnameRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
+    let matchedServer;
+
+    if (!servers || !servers.length) {
+      // If this API definition doesn't have any servers set up let's treat it as if it were https://example.com because
+      // that's the default origin we add in `normalizedUrl` under the same circumstances. Without this we won't be able
+      // to match paths within what is otherwise a valid OpenAPI definition.
+      matchedServer = {
+        url: 'https://example.com',
+      };
+    } else {
+      matchedServer = servers.find(s => originRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
+      if (!matchedServer) {
+        const hostnameRegExp = new RegExp(hostname);
+        matchedServer = servers.find(s => hostnameRegExp.exec(this.replaceUrl(s.url, s.variables || {})));
+      }
     }
 
     // If we **still** haven't found a matching server, then the OAS server URL might have server variables and we


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug with `findOperation` where if an API definition didn't have any defined `servers` we wouldn't be able to match any operation within it.

Fixes RM-1425

## 🧬 QA & Testing

See attached test.