### PR TITLE
fix: bug where variable-casing in servers and urls would break path matching

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -698,7 +698,7 @@ describe('#findOperation()', () => {
       });
     });
 
-    it('should return a match if but the uri has variable casing', () => {
+    it("should return a match if the uri has variable casing but the defined server doesn't", () => {
       const oas = new Oas({
         servers: [{ url: 'https://api.example.com/' }],
         paths: {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -673,6 +673,56 @@ describe('#findOperation()', () => {
   });
 
   describe('quirks', () => {
+    it('should return a match if a defined server has camelcasing, but the uri is all lower', () => {
+      const oas = new Oas({
+        servers: [{ url: 'https://api.Example.com/' }],
+        paths: {
+          '/anything': {
+            get: {
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+        },
+      });
+
+      const uri = 'https://api.example.com/anything';
+      const method = 'get';
+
+      const res = oas.findOperation(uri, method);
+      expect(res.url).toStrictEqual({
+        origin: 'https://api.Example.com',
+        path: '/anything',
+        nonNormalizedPath: '/anything',
+        slugs: {},
+        method: 'GET',
+      });
+    });
+
+    it('should return a match if but the uri has variable casing', () => {
+      const oas = new Oas({
+        servers: [{ url: 'https://api.example.com/' }],
+        paths: {
+          '/anything': {
+            get: {
+              responses: { 200: { description: 'OK' } },
+            },
+          },
+        },
+      });
+
+      const uri = 'https://api.EXAMPLE.com/anything';
+      const method = 'get';
+
+      const res = oas.findOperation(uri, method);
+      expect(res.url).toStrictEqual({
+        origin: 'https://api.example.com',
+        path: '/anything',
+        nonNormalizedPath: '/anything',
+        slugs: {},
+        method: 'GET',
+      });
+    });
+
     it('should return result if path contains non-variabled colons', () => {
       const oas = new Oas(pathVariableQuirks);
       const uri = 'https://api.example.com/people/GWID:3';

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -675,7 +675,7 @@ describe('#findOperation()', () => {
   describe('quirks', () => {
     it('should return a match if a defined server has camelcasing, but the uri is all lower', () => {
       const oas = new Oas({
-        servers: [{ url: 'https://api.Example.com/' }],
+        servers: [{ url: 'https://api.EXAMPLE.com/' }],
         paths: {
           '/anything': {
             get: {
@@ -690,7 +690,7 @@ describe('#findOperation()', () => {
 
       const res = oas.findOperation(uri, method);
       expect(res.url).toStrictEqual({
-        origin: 'https://api.Example.com',
+        origin: 'https://api.EXAMPLE.com',
         path: '/anything',
         nonNormalizedPath: '/anything',
         slugs: {},

--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,7 @@ class Oas {
 
   findOperationMatches(url) {
     const { origin, hostname } = new URL(url);
-    const originRegExp = new RegExp(origin);
+    const originRegExp = new RegExp(origin, 'i');
     const { servers, paths } = this;
 
     let pathName;
@@ -391,7 +391,7 @@ class Oas {
         url: this.replaceUrl(matchedServer.url, matchedServer.variables || {}),
       };
 
-      [, pathName] = url.split(targetServer.url);
+      [, pathName] = url.split(new RegExp(targetServer.url, 'i'));
     }
 
     if (pathName === undefined) return undefined;


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug in `Oas.findOperation()` where if a defined API definition server url had variable casing we wouldn't be able to match it if the `uri` being passed into `findOperation` was all lowercased.

## 🧬 QA & Testing

I've added tests for this original case of the server not matching the incoming URL, but also the reverse situation.
