### PR TITLE
feat: adding support for showing/hiding readOnly and writeOnly example props

### DIFF
--- a/__tests__/__datasets__/readonly-writeonly.json
+++ b/__tests__/__datasets__/readonly-writeonly.json
@@ -20,8 +20,8 @@
                 "type": "object",
                 "properties": {
                   "id": { "type": "string" },
-                  "createdOn": { "type": "string", "readOnly": true },
-                  "updatedOn": { "type": "string", "writeOnly": true }
+                  "propWithReadOnly": { "type": "string", "readOnly": true },
+                  "propWithWriteOnly": { "type": "string", "writeOnly": true }
                 }
               }
             }
@@ -36,8 +36,8 @@
                   "type": "object",
                   "properties": {
                     "id": { "type": "string" },
-                    "createdOn": { "type": "string", "readOnly": true },
-                    "updatedOn": { "type": "string", "writeOnly": true }
+                    "propWithReadOnly": { "type": "string", "readOnly": true },
+                    "propWithWriteOnly": { "type": "string", "writeOnly": true }
                   }
                 }
               }

--- a/__tests__/__datasets__/readonly-writeonly.json
+++ b/__tests__/__datasets__/readonly-writeonly.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Operation with readOnly and writeOnly properties",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "createdOn": { "type": "string", "readOnly": true },
+                  "updatedOn": { "type": "string", "writeOnly": true }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "createdOn": { "type": "string", "readOnly": true },
+                    "updatedOn": { "type": "string", "writeOnly": true }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/operation/get-requestbody-examples.test.js
+++ b/__tests__/operation/get-requestbody-examples.test.js
@@ -222,26 +222,15 @@ describe('defined within response `content`', () => {
 });
 
 describe('readOnly / writeOnly handling', () => {
-  it('should exclude `readOnly` schemas', () => {
+  it('should exclude `readOnly` schemas and include `writeOnly`', () => {
     const spec = new Oas(exampleRoWo);
     const operation = spec.operation('/', 'get');
 
-    const readOnlyExample = JSON.parse(operation.getRequestBodyExamples()[0].code);
-    expect(readOnlyExample).toStrictEqual({
-      id: 'string',
-      updatedOn: 'string',
-    });
-  });
-
-  it('should include `writeOnly` schemas', () => {
-    const spec = new Oas(exampleRoWo);
-
-    const operation = spec.operation('/', 'get');
     expect(operation.getRequestBodyExamples()).toStrictEqual([
       {
         code: cleanStringify({
           id: 'string',
-          updatedOn: 'string',
+          propWithWriteOnly: 'string',
         }),
         mediaType: 'application/json',
         multipleExamples: false,

--- a/__tests__/operation/get-requestbody-examples.test.js
+++ b/__tests__/operation/get-requestbody-examples.test.js
@@ -1,6 +1,7 @@
 const Oas = require('../../src');
 const example = require('../__datasets__/operation-examples.json');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
+const exampleRoWo = require('../__datasets__/readonly-writeonly.json');
 const cleanStringify = require('../../src/lib/json-stringify-clean');
 
 const oas = new Oas(example);
@@ -217,5 +218,34 @@ describe('defined within response `content`', () => {
         },
       ]);
     });
+  });
+});
+
+describe('readOnly / writeOnly handling', () => {
+  it('should exclude `readOnly` schemas', () => {
+    const spec = new Oas(exampleRoWo);
+    const operation = spec.operation('/', 'get');
+
+    const readOnlyExample = JSON.parse(operation.getRequestBodyExamples()[0].code);
+    expect(readOnlyExample).toStrictEqual({
+      id: 'string',
+      updatedOn: 'string',
+    });
+  });
+
+  it('should include `writeOnly` schemas', () => {
+    const spec = new Oas(exampleRoWo);
+
+    const operation = spec.operation('/', 'get');
+    expect(operation.getRequestBodyExamples()).toStrictEqual([
+      {
+        code: cleanStringify({
+          id: 'string',
+          updatedOn: 'string',
+        }),
+        mediaType: 'application/json',
+        multipleExamples: false,
+      },
+    ]);
   });
 });

--- a/__tests__/operation/get-response-examples.test.js
+++ b/__tests__/operation/get-response-examples.test.js
@@ -414,31 +414,20 @@ describe('defined within response `content`', () => {
 });
 
 describe('readOnly / writeOnly handling', () => {
-  it('should include `readOnly` schemas', () => {
+  it('should include `readOnly` schemas and exclude `writeOnly`', () => {
     const spec = new Oas(exampleRoWo);
     const operation = spec.operation('/', 'get');
 
-    const readOnlyExample = JSON.parse(operation.getResponseExamples()[0].languages[0].code);
-    expect(readOnlyExample).toStrictEqual({
-      id: 'string',
-      createdOn: 'string',
-    });
-  });
-
-  it('should exclude `writeOnly` schemas', () => {
-    const spec = new Oas(exampleRoWo);
-
-    const operation = spec.operation('/', 'get');
     expect(operation.getResponseExamples()).toStrictEqual([
       {
         status: '200',
         languages: [
           {
-            language: 'application/json',
             code: cleanStringify({
               id: 'string',
-              createdOn: 'string',
+              propWithReadOnly: 'string',
             }),
+            language: 'application/json',
             multipleExamples: false,
           },
         ],

--- a/__tests__/operation/get-response-examples.test.js
+++ b/__tests__/operation/get-response-examples.test.js
@@ -1,6 +1,7 @@
 const Oas = require('../../src');
 const example = require('../__datasets__/operation-examples.json');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
+const exampleRoWo = require('../__datasets__/readonly-writeonly.json');
 const cleanStringify = require('../../src/lib/json-stringify-clean');
 const circular = require('../__fixtures__/circular.json');
 
@@ -106,6 +107,7 @@ describe('no curated examples present', () => {
   it('should generate examples if none are readily available', () => {
     const petExample = cleanStringify([
       {
+        id: 0,
         category: {
           id: 0,
           name: 'string',
@@ -408,5 +410,39 @@ describe('defined within response `content`', () => {
         },
       ]);
     });
+  });
+});
+
+describe('readOnly / writeOnly handling', () => {
+  it('should include `readOnly` schemas', () => {
+    const spec = new Oas(exampleRoWo);
+    const operation = spec.operation('/', 'get');
+
+    const readOnlyExample = JSON.parse(operation.getResponseExamples()[0].languages[0].code);
+    expect(readOnlyExample).toStrictEqual({
+      id: 'string',
+      createdOn: 'string',
+    });
+  });
+
+  it('should exclude `writeOnly` schemas', () => {
+    const spec = new Oas(exampleRoWo);
+
+    const operation = spec.operation('/', 'get');
+    expect(operation.getResponseExamples()).toStrictEqual([
+      {
+        status: '200',
+        languages: [
+          {
+            language: 'application/json',
+            code: cleanStringify({
+              id: 'string',
+              createdOn: 'string',
+            }),
+            multipleExamples: false,
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/src/lib/get-mediatype-examples.js
+++ b/src/lib/get-mediatype-examples.js
@@ -5,14 +5,16 @@ const matchesMimeType = require('./matches-mimetype');
 module.exports = {
   /**
    * Extracts an example from an OAS Media Type Object. The example will either come from the `example` property, the
-   * first item in an `examples` array, or if none of those are present it will generate an example based off its schema.
+   * first item in an `examples` array, or if none of those are present it will generate an example based off its
+   * schema.
    *
    * @link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject
    * @param {string} mediaType
    * @param {object} mediaTypeObject
+   * @param {object} opts Configuration for controlling `includeReadOnly` and `includeWriteOnly`.
    * @returns {(object|false)}
    */
-  getMediaTypeExample: (mediaType, mediaTypeObject) => {
+  getMediaTypeExample: (mediaType, mediaTypeObject, opts = {}) => {
     if (mediaTypeObject.example) {
       return mediaTypeObject.example;
     } else if (mediaTypeObject.examples) {
@@ -47,7 +49,7 @@ module.exports = {
         return false;
       }
 
-      return sampleFromSchema(mediaTypeObject.schema);
+      return sampleFromSchema(mediaTypeObject.schema, opts);
     }
 
     return false;

--- a/src/operation/get-requestbody-examples.js
+++ b/src/operation/get-requestbody-examples.js
@@ -37,7 +37,10 @@ module.exports = operation => {
   return Object.keys(operation.requestBody.content || {})
     .map(mediaType => {
       const mediaTypeObject = operation.requestBody.content[mediaType];
-      const example = getMediaTypeExample(mediaType, mediaTypeObject);
+      const example = getMediaTypeExample(mediaType, mediaTypeObject, {
+        includeReadOnly: false,
+        includeWriteOnly: true,
+      });
 
       return constructMediaType(mediaType, mediaTypeObject, example);
     })

--- a/src/operation/get-response-examples.js
+++ b/src/operation/get-response-examples.js
@@ -52,7 +52,12 @@ module.exports = operation => {
         if (!mediaType) return false;
 
         const mediaTypeObject = response.content[mediaType];
-        const example = mediaTypeObject.code || getMediaTypeExample(mediaType, mediaTypeObject);
+        const example =
+          mediaTypeObject.code ||
+          getMediaTypeExample(mediaType, mediaTypeObject, {
+            includeReadOnly: true,
+            includeWriteOnly: false,
+          });
         const cmt = constructMediaType(mediaType, mediaTypeObject, example);
         if (cmt) {
           mediaTypes.push(cmt);


### PR DESCRIPTION
## 🧰 Changes

* [x] Adds support for showing `readOnly` schema properties in response examples and hiding those with `writeOnly`.
* [x] Adds support for showing `writeOnly` schema properties in request examples and hiding those with `readOnly`.

Fix in support of CX-91

## 🧬 QA & Testing

* [ ] Tests pass?