### PR TITLE
feat: improved handling of same-level properties and oneOf's

### DIFF
--- a/__tests__/__fixtures__/polymorphism-quirks.json
+++ b/__tests__/__fixtures__/polymorphism-quirks.json
@@ -11,34 +11,17 @@
     }
   ],
   "paths": {
-    "/anything/RM-1499": {
+    "/anything/RM-1499/object": {
       "summary": "`properties` and `oneOf` at the same level`",
-      "description": "This operation has a query parameter and a requestBody that are both intending to overload a `title` and `required` declaration on top of an existing `properties` schema. When we construct this schema we should transform each of the `oneOf` options into an `allOf` with the `properties` schema alongside it.\n\n",
+      "description": "This operation has a query parameter and a requestBody that are both intending to overload a `title` and `required` declaration on top of an existing `properties` schema. When we construct this schema we should transform each of the `oneOf` options into an `allOf` with the `properties` schema alongside it.",
       "get": {
+        "tags": ["RM-1499"],
         "parameters": [
           {
             "in": "query",
             "name": "polymorphicParam",
             "schema": {
-              "type": "object",
-              "oneOf": [
-                {
-                  "title": "Primitive is required",
-                  "required": ["primitive"]
-                },
-                {
-                  "title": "Boolean is required",
-                  "required": ["boolean"]
-                }
-              ],
-              "properties": {
-                "primitive": {
-                  "type": "string"
-                },
-                "boolean": {
-                  "type": "boolean"
-                }
-              }
+              "$ref": "#/components/schemas/RM-1499_object"
             }
           }
         ],
@@ -49,30 +32,13 @@
         }
       },
       "post": {
+        "tags": ["RM-1499"],
         "requestBody": {
           "description": "Body description",
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "oneOf": [
-                  {
-                    "title": "Primitive is required",
-                    "required": ["primitive"]
-                  },
-                  {
-                    "title": "Boolean is required",
-                    "required": ["boolean"]
-                  }
-                ],
-                "properties": {
-                  "primitive": {
-                    "type": "string"
-                  },
-                  "boolean": {
-                    "type": "boolean"
-                  }
-                }
+                "$ref": "#/components/schemas/RM-1499_object"
               }
             }
           }
@@ -80,6 +46,86 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/anything/RM-1499/array": {
+      "summary": "`items` and `oneOf` at the same level`",
+      "description": "This operation has a query parameter and a requestBody that are both intending to overload a `title` and `required` declaration on top of an existing `items` schema. When we construct this schema we should transform each of the `oneOf` options into an `allOf` with the `items` schema alongside it.",
+      "get": {
+        "tags": ["RM-1499"],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "polymorphicParam",
+            "schema": {
+              "$ref": "#/components/schemas/RM-1499_array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "tags": ["RM-1499"],
+        "requestBody": {
+          "description": "Body description",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RM-1499_array"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RM-1499_array": {
+        "type": "array",
+        "oneOf": [
+          {
+            "title": "Example",
+            "example": "Pug"
+          },
+          {
+            "title": "Alt Example",
+            "example": "Buster"
+          }
+        ],
+        "items": {
+          "type": "string"
+        }
+      },
+      "RM-1499_object": {
+        "type": "object",
+        "oneOf": [
+          {
+            "title": "Primitive is required",
+            "required": ["primitive"]
+          },
+          {
+            "title": "Boolean is required",
+            "required": ["boolean"]
+          }
+        ],
+        "properties": {
+          "primitive": {
+            "type": "string"
+          },
+          "boolean": {
+            "type": "boolean"
           }
         }
       }

--- a/__tests__/__fixtures__/polymorphism-quirks.json
+++ b/__tests__/__fixtures__/polymorphism-quirks.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Polymorphism Quirks",
+    "description": "Covering some quirks with handling and generation of polymorhism schemas.\n\nhttps://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything/RM-1499": {
+      "summary": "`properties` and `oneOf` at the same level`",
+      "description": "This operation has a query parameter and a requestBody that are both intending to overload a `title` and `required` declaration on top of an existing `properties` schema. When we construct this schema we should transform each of the `oneOf` options into an `allOf` with the `properties` schema alongside it.\n\n",
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "polymorphicParam",
+            "schema": {
+              "type": "object",
+              "oneOf": [
+                {
+                  "title": "Primitive is required",
+                  "required": ["primitive"]
+                },
+                {
+                  "title": "Boolean is required",
+                  "required": ["boolean"]
+                }
+              ],
+              "properties": {
+                "primitive": {
+                  "type": "string"
+                },
+                "boolean": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "description": "Body description",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "oneOf": [
+                  {
+                    "title": "Primitive is required",
+                    "required": ["primitive"]
+                  },
+                  {
+                    "title": "Boolean is required",
+                    "required": ["boolean"]
+                  }
+                ],
+                "properties": {
+                  "primitive": {
+                    "type": "string"
+                  },
+                  "boolean": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -493,34 +493,66 @@ describe('parameters', () => {
       });
     });
 
-    it('should hoist `properties` into a same-level `oneOf` and transform each option into an `allOf`', () => {
-      const oas = new Oas(polymorphismQuirks);
-      const schema = oas.operation('/anything/RM-1499', 'get').getParametersAsJsonSchema();
+    describe('quirks', () => {
+      it('should hoist `properties` into a same-level `oneOf` and transform each option into an `allOf`', async () => {
+        const oas = new Oas(polymorphismQuirks);
+        await oas.dereference();
+        const schema = oas.operation('/anything/RM-1499/object', 'get').getParametersAsJsonSchema();
 
-      const propertiesSchema = {
-        type: 'object',
-        properties: {
-          primitive: { type: 'string' },
-          boolean: { type: 'boolean' },
-        },
-      };
-
-      expect(schema[0].schema).toStrictEqual({
-        type: 'object',
-        properties: {
-          polymorphicParam: {
-            type: 'object',
-            oneOf: [
-              {
-                allOf: [{ title: 'Primitive is required', required: ['primitive'] }, propertiesSchema],
-              },
-              {
-                allOf: [{ title: 'Boolean is required', required: ['boolean'] }, propertiesSchema],
-              },
-            ],
+        const propertiesSchema = {
+          type: 'object',
+          properties: {
+            primitive: { type: 'string' },
+            boolean: { type: 'boolean' },
           },
-        },
-        required: [],
+        };
+
+        expect(schema[0].schema).toStrictEqual({
+          type: 'object',
+          properties: {
+            polymorphicParam: {
+              type: 'object',
+              oneOf: [
+                {
+                  allOf: [{ title: 'Primitive is required', required: ['primitive'] }, propertiesSchema],
+                },
+                {
+                  allOf: [{ title: 'Boolean is required', required: ['boolean'] }, propertiesSchema],
+                },
+              ],
+            },
+          },
+          required: [],
+        });
+      });
+
+      it('should hoist `items` into a same-level `oneOf` and transform each option into an `allOf`', async () => {
+        const oas = new Oas(polymorphismQuirks);
+        await oas.dereference();
+        const schema = oas.operation('/anything/RM-1499/array', 'get').getParametersAsJsonSchema();
+
+        const itemsSchema = {
+          type: 'array',
+          items: { type: 'string' },
+        };
+
+        expect(schema[0].schema).toStrictEqual({
+          type: 'object',
+          properties: {
+            polymorphicParam: {
+              type: 'array',
+              oneOf: [
+                {
+                  allOf: [{ title: 'Example', examples: ['Pug'] }, itemsSchema],
+                },
+                {
+                  allOf: [{ title: 'Alt Example', examples: ['Buster'] }, itemsSchema],
+                },
+              ],
+            },
+          },
+          required: [],
+        });
       });
     });
   });
@@ -837,28 +869,56 @@ describe('request bodies', () => {
       });
     });
 
-    it('should hoist `properties` into a same-level `oneOf` and transform each option into an `allOf`', () => {
-      const oas = new Oas(polymorphismQuirks);
-      const schema = oas.operation('/anything/RM-1499', 'post').getParametersAsJsonSchema();
+    describe('quirks', () => {
+      it('should hoist `properties` into a same-level `oneOf` and transform each option into an `allOf`', async () => {
+        const oas = new Oas(polymorphismQuirks);
+        await oas.dereference();
+        const schema = oas.operation('/anything/RM-1499/object', 'post').getParametersAsJsonSchema();
 
-      const propertiesSchema = {
-        type: 'object',
-        properties: {
-          primitive: { type: 'string' },
-          boolean: { type: 'boolean' },
-        },
-      };
+        const propertiesSchema = {
+          type: 'object',
+          properties: {
+            primitive: { type: 'string' },
+            boolean: { type: 'boolean' },
+          },
+        };
 
-      expect(schema[0].schema).toStrictEqual({
-        type: 'object',
-        oneOf: [
-          {
-            allOf: [{ title: 'Primitive is required', required: ['primitive'] }, propertiesSchema],
-          },
-          {
-            allOf: [{ title: 'Boolean is required', required: ['boolean'] }, propertiesSchema],
-          },
-        ],
+        expect(schema[0].schema).toStrictEqual({
+          type: 'object',
+          oneOf: [
+            {
+              allOf: [{ title: 'Primitive is required', required: ['primitive'] }, propertiesSchema],
+            },
+            {
+              allOf: [{ title: 'Boolean is required', required: ['boolean'] }, propertiesSchema],
+            },
+          ],
+          components: expect.any(Object),
+        });
+      });
+
+      it('should hoist `items` into a same-level `oneOf` and transform each option into an `allOf`', async () => {
+        const oas = new Oas(polymorphismQuirks);
+        await oas.dereference();
+        const schema = oas.operation('/anything/RM-1499/array', 'post').getParametersAsJsonSchema();
+
+        const itemsSchema = {
+          type: 'array',
+          items: { type: 'string' },
+        };
+
+        expect(schema[0].schema).toStrictEqual({
+          type: 'array',
+          oneOf: [
+            {
+              allOf: [{ title: 'Example', examples: ['Pug'] }, itemsSchema],
+            },
+            {
+              allOf: [{ title: 'Alt Example', examples: ['Buster'] }, itemsSchema],
+            },
+          ],
+          components: expect.any(Object),
+        });
       });
     });
   });

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -1867,7 +1867,9 @@ describe('example support', () => {
         },
       });
 
-      expect(schema.components.schemas.Pet.properties.id.examples).toStrictEqual([20]);
+      // `Pet` schema `id` example should not be present because that `id` was set against the `requestBody`, not the
+      // component.
+      expect(schema.components.schemas.Pet.properties.id.examples).toBeUndefined();
       expect(schema.components.schemas.Pet.properties.name.examples).toStrictEqual(['doggie']);
     });
   });

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -177,19 +177,21 @@ function searchForExampleByPointer(pointer, examples = []) {
  * @link https://json-schema.org/draft/2019-09/json-schema-validation.html
  * @link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md
  * @param {Object} data
- * @param {Object[]} prevSchemas
- * @param {String} currentLocation
- * @param {Object} globalDefaults
- * @param {Boolean} isPolymorphicAllOfChild
+ * @param {Object} opts
+ * @param {Object[]} opts.prevSchemas - Array of parent schemas to utilize when attempting to path together examples.
+ * @param {String} opts.currentLocation - Current location within the schema -- this is a JSON pointer.
+ * @param {Object} opts.globalDefaults - Object containing a global set of defaults that we should apply to schemas that match it.
+ * @param {Boolean} opts.isPolymorphicAllOfChild - Is this schema the child of a polymorphic `allOf` schema?
  */
-function constructSchema(
-  data,
-  prevSchemas = [],
-  currentLocation = '',
-  globalDefaults,
-  isPolymorphicAllOfChild = false
-) {
+function constructSchema(data, opts = {}) {
   const schema = { ...data };
+  const { prevSchemas, currentLocation, globalDefaults, isPolymorphicAllOfChild } = {
+    prevSchemas: [],
+    currentLocation: '',
+    globalDefaults: {},
+    isPolymorphicAllOfChild: false,
+    ...opts,
+  };
 
   // If this schema contains a `$ref`, it's circular and we shouldn't try to resolve it. Just return and move along.
   if (schema.$ref) {
@@ -197,6 +199,40 @@ function constructSchema(
       $ref: schema.$ref,
     };
   }
+
+  // If we don't have a set type, but are dealing with an `anyOf`, `oneOf`, or `allOf` representation let's run through
+  // them and make sure they're good.
+  ['allOf', 'anyOf', 'oneOf'].forEach(polyType => {
+    if (polyType in schema && Array.isArray(schema[polyType])) {
+      schema[polyType].forEach((item, idx) => {
+        const polyOptions = {
+          prevSchemas,
+          currentLocation: `${currentLocation}/${idx}`,
+          globalDefaults,
+          isPolymorphicAllOfChild: polyType === 'allOf',
+        };
+
+        // When `properties` are present alongside a polymorphic schema instead of letting whatever JSON Schema
+        // interpreter is handling these constructed schemas we can guide its hand a bit by manually transforming it
+        // into an inferred `allOf` of the `properties` + the polymorph schema.
+        if ('properties' in schema) {
+          schema[polyType][idx] = constructSchema(
+            {
+              allOf: [
+                item,
+                {
+                  properties: schema.properties,
+                },
+              ],
+            },
+            polyOptions
+          );
+        } else {
+          schema[polyType][idx] = constructSchema(item, polyOptions);
+        }
+      });
+    }
+  });
 
   // If this schema is malformed for some reason, let's do our best to repair it.
   if (!('type' in schema) && !isPolymorphicSchema(schema) && !isRequestBodySchema(schema)) {
@@ -292,7 +328,11 @@ function constructSchema(
         // `items` contains a `$ref`, so since it's circular we should do a no-op here and ignore it.
       } else {
         // Run through the arrays contents and clean them up.
-        schema.items = constructSchema(schema.items, prevSchemas, `${currentLocation}/0`, globalDefaults);
+        schema.items = constructSchema(schema.items, {
+          prevSchemas,
+          currentLocation: `${currentLocation}/0`,
+          globalDefaults,
+        });
       }
     } else if ('properties' in schema || 'additionalProperties' in schema) {
       // This is a fix to handle cases where someone may have typod `items` as `properties` on an array. Since
@@ -308,12 +348,11 @@ function constructSchema(
   } else if (schema.type === 'object') {
     if ('properties' in schema) {
       Object.keys(schema.properties).map(prop => {
-        schema.properties[prop] = constructSchema(
-          schema.properties[prop],
+        schema.properties[prop] = constructSchema(schema.properties[prop], {
           prevSchemas,
-          `${currentLocation}/${encodePointer(prop)}`,
-          globalDefaults
-        );
+          currentLocation: `${currentLocation}/${encodePointer(prop)}`,
+          globalDefaults,
+        });
 
         return true;
       });
@@ -330,12 +369,11 @@ function constructSchema(
         ) {
           schema.additionalProperties = true;
         } else {
-          schema.additionalProperties = constructSchema(
-            data.additionalProperties,
+          schema.additionalProperties = constructSchema(data.additionalProperties, {
             prevSchemas,
             currentLocation,
-            globalDefaults
-          );
+            globalDefaults,
+          });
         }
       }
     }
@@ -347,22 +385,6 @@ function constructSchema(
       schema.additionalProperties = true;
     }
   }
-
-  // If we don't have a set type, but are dealing with an `anyOf`, `oneOf`, or `allOf` representation let's run through
-  // them and make sure they're good.
-  ['allOf', 'anyOf', 'oneOf'].forEach(polyType => {
-    if (polyType in schema && Array.isArray(schema[polyType])) {
-      schema[polyType].forEach((item, idx) => {
-        schema[polyType][idx] = constructSchema(
-          item,
-          prevSchemas,
-          `${currentLocation}/${idx}`,
-          globalDefaults,
-          polyType === 'allOf'
-        );
-      });
-    }
-  });
 
   // Users can pass in parameter defaults via JWT User Data: https://docs.readme.com/docs/passing-data-to-jwt
   // We're checking to see if the defaults being passed in exist on endpoints via jsonpointer
@@ -386,6 +408,11 @@ function constructSchema(
       // If the default is empty and we don't want to allowEmptyValue, we need to remove the default.
       delete schema.default;
     }
+  }
+
+  // Clean up any remaining `properties` objects lying around if there's also polymorphism present.
+  if ('properties' in schema && ('allOf' in schema || 'anyOf' in schema || 'oneOf' in schema)) {
+    delete schema.properties;
   }
 
   // Remove unsupported JSON Schema props.
@@ -415,7 +442,7 @@ function getRequestBody(operation, oas, globalDefaults) {
     examples.push({ examples: requestBody.examples });
   }
 
-  const cleanedSchema = constructSchema(requestBody.schema, examples, '', globalDefaults);
+  const cleanedSchema = constructSchema(requestBody.schema, { prevSchemas: examples, globalDefaults });
   if (oas.components) {
     const components = {};
     Object.keys(oas.components).forEach(componentType => {
@@ -425,12 +452,9 @@ function getRequestBody(operation, oas, globalDefaults) {
         }
 
         Object.keys(oas.components[componentType]).forEach(schemaName => {
-          components[componentType][schemaName] = constructSchema(
-            oas.components[componentType][schemaName],
-            [],
-            '',
-            globalDefaults
-          );
+          components[componentType][schemaName] = constructSchema(oas.components[componentType][schemaName], {
+            globalDefaults,
+          });
         });
       }
     });
@@ -490,7 +514,9 @@ function getParameters(path, operation, oas, globalDefaults) {
       let schema = {};
       if ('schema' in current) {
         schema = {
-          ...(current.schema ? constructSchema(current.schema, [], `/${current.name}`, globalDefaults) : {}),
+          ...(current.schema
+            ? constructSchema(current.schema, { currentLocation: `/${current.name}`, globalDefaults })
+            : {}),
         };
       } else if ('content' in current && typeof current.content === 'object') {
         const contentKeys = Object.keys(current.content);
@@ -512,7 +538,10 @@ function getParameters(path, operation, oas, globalDefaults) {
           if (typeof current.content[contentType] === 'object' && 'schema' in current.content[contentType]) {
             schema = {
               ...(current.content[contentType].schema
-                ? constructSchema(current.content[contentType].schema, [], `/${current.name}`, globalDefaults)
+                ? constructSchema(current.content[contentType].schema, {
+                    currentLocation: `/${current.name}`,
+                    globalDefaults,
+                  })
                 : {}),
             };
           }

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -442,7 +442,8 @@ function getRequestBody(operation, oas, globalDefaults) {
     examples.push({ examples: requestBody.examples });
   }
 
-  const cleanedSchema = constructSchema(requestBody.schema, { prevSchemas: examples, globalDefaults });
+  const requestBodySchema = JSON.parse(JSON.stringify(requestBody.schema));
+  const cleanedSchema = constructSchema(requestBodySchema, { prevSchemas: examples, globalDefaults });
   if (oas.components) {
     const components = {};
     Object.keys(oas.components).forEach(componentType => {
@@ -452,7 +453,8 @@ function getRequestBody(operation, oas, globalDefaults) {
         }
 
         Object.keys(oas.components[componentType]).forEach(schemaName => {
-          components[componentType][schemaName] = constructSchema(oas.components[componentType][schemaName], {
+          const componentSchema = JSON.parse(JSON.stringify(oas.components[componentType][schemaName]));
+          components[componentType][schemaName] = constructSchema(componentSchema, {
             globalDefaults,
           });
         });


### PR DESCRIPTION
## 🧰 Changes

This updates our `getParametersAsJsonSchema` library to improve some of its handling with `properties` and polymorphic `oneOf` schemas that are at the same level. That's a lot of goobledegook, let me explain.

See the following schema:

![Screen Shot 2021-08-03 at 1 39 18 PM](https://user-images.githubusercontent.com/33762/128083028-0e1968ab-2a66-48fc-937b-5643406ce0dd.png)

In this there's a `properties` object and a `oneOf` array at the same level within the `exclusiveRequirements` object. Currently when we process this schema the `properties` object is left alone because it's fully formed but we add a `type: string` into each of the options within the `oneOf` because we think that they're malformed schemas. The result of this when we render it within ReadMe is this:

![Screen Shot 2021-08-03 at 1 41 39 PM](https://user-images.githubusercontent.com/33762/128083252-43b50681-7374-4730-97a6-f594d562d707.png)

Instead what this schema is actually trying to tell us is that `exclusiveRequirements` can be either the `properties` object with `requiredOne` as required or the same but with `requiredTwo` required.

Because attempting to fix this kind of thing within our JSON Schema form work is an **incredibly** daunting task it's much easier for us to guide its hand a bit by reframing what this schema looks like into something that'll be handled as it's intended to be rendered. Automatically.

![Screen Shot 2021-08-02 at 4 52 54 PM](https://user-images.githubusercontent.com/33762/128083529-67300a7c-0a1b-484d-a088-ebc0880b7a0f.png)

With this work if there's a `properties` or `oneOf`/`anyOf`/`allOf` at the same level within an object, that polymorphic part of the equation will be transposed into a nested `allOf` array including the `properties` schema. So in this case the `{ title: '...', required: [...] }` object will now look like:

```
{
  "allOf": [
    {
      "title": "...",
      "required": [...]
    },
    {
      "properties": {
        "requiredOne": { ... },
        "requiredTwo": { ... },
        "optional": { ... }
      }
    }
  ]
}
```

Now when our JSON Schema form handles this it'll run it through [json-schema-merge-allof](https://www.npmjs.com/package/json-schema-merge-allof) and generate something that looks like this:

![Screen Shot 2021-08-03 at 1 46 56 PM](https://user-images.githubusercontent.com/33762/128083947-98ddd847-8a02-4c20-a13b-4951e619353f.png)

Fix in support of RM-1499.

## 🧬 QA & Testing

See attached unit tests.

> ⚠️  Note that the screenshots above are a bit misleading and show "Option 1" where it should say "One data member is required.", as well as the duplicate descriptions, are bugs within our form system and will be addressed within that codebase.