### PR TITLE
fix: automatic merging of dynamically generated `allOf` schemas

### DIFF
--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -513,12 +513,8 @@ describe('parameters', () => {
             polymorphicParam: {
               type: 'object',
               oneOf: [
-                {
-                  allOf: [{ title: 'Primitive is required', required: ['primitive'] }, propertiesSchema],
-                },
-                {
-                  allOf: [{ title: 'Boolean is required', required: ['boolean'] }, propertiesSchema],
-                },
+                { title: 'Primitive is required', required: ['primitive'], ...propertiesSchema },
+                { title: 'Boolean is required', required: ['boolean'], ...propertiesSchema },
               ],
             },
           },
@@ -542,12 +538,8 @@ describe('parameters', () => {
             polymorphicParam: {
               type: 'array',
               oneOf: [
-                {
-                  allOf: [{ title: 'Example', examples: ['Pug'] }, itemsSchema],
-                },
-                {
-                  allOf: [{ title: 'Alt Example', examples: ['Buster'] }, itemsSchema],
-                },
+                { title: 'Example', examples: ['Pug'], ...itemsSchema },
+                { title: 'Alt Example', examples: ['Buster'], ...itemsSchema },
               ],
             },
           },
@@ -886,12 +878,8 @@ describe('request bodies', () => {
         expect(schema[0].schema).toStrictEqual({
           type: 'object',
           oneOf: [
-            {
-              allOf: [{ title: 'Primitive is required', required: ['primitive'] }, propertiesSchema],
-            },
-            {
-              allOf: [{ title: 'Boolean is required', required: ['boolean'] }, propertiesSchema],
-            },
+            { title: 'Primitive is required', required: ['primitive'], ...propertiesSchema },
+            { title: 'Boolean is required', required: ['boolean'], ...propertiesSchema },
           ],
           components: expect.any(Object),
         });
@@ -910,12 +898,8 @@ describe('request bodies', () => {
         expect(schema[0].schema).toStrictEqual({
           type: 'array',
           oneOf: [
-            {
-              allOf: [{ title: 'Example', examples: ['Pug'] }, itemsSchema],
-            },
-            {
-              allOf: [{ title: 'Alt Example', examples: ['Buster'] }, itemsSchema],
-            },
+            { title: 'Example', examples: ['Pug'], ...itemsSchema },
+            { title: 'Alt Example', examples: ['Buster'], ...itemsSchema },
           ],
           components: expect.any(Object),
         });


### PR DESCRIPTION
## 🧰 Changes

This is a slight modification to #475 where instead of migrating `properties` and/or `items` into a newly created `allOf` we're now going to dynamically merge those objects if possible.

Doing this because there's some quirks with our form generator where if you give it a `oneOf` where each option contains an `allOf` it can't pick up the `title` from inside of the `allOf` and honestly it's just easier to fix this by doing it in here instead of there.

## 🧬 QA & Testing

See updated tests.