### PR TITLE
fix: bug where request or response example fetching would update the operation schema

### DIFF
--- a/__tests__/__datasets__/readonly-writeonly.json
+++ b/__tests__/__datasets__/readonly-writeonly.json
@@ -44,6 +44,63 @@
             }
           }
         }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/product"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/product"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "product": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "YYYY-MM-DD"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "YYYY-MM-DD"
+          },
+          "start_hour": {
+            "type": "string",
+            "readOnly": true
+          },
+          "end_hour": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
       }
     }
   }

--- a/__tests__/operation/get-response-examples.test.js
+++ b/__tests__/operation/get-response-examples.test.js
@@ -457,3 +457,46 @@ describe('readOnly / writeOnly handling', () => {
     ]);
   });
 });
+
+test('sample generation should not corrupt the supplied operation', async () => {
+  const spec = new Oas(exampleRoWo);
+  await spec.dereference();
+
+  const operation = spec.operation('/', 'post');
+
+  // Running this before `getResponseExamples` should have no effects on the output of the `getResponseExamples` call.
+  expect(operation.getRequestBodyExamples()).toStrictEqual([
+    {
+      mediaType: 'application/json',
+      examples: [
+        {
+          value: {
+            product_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            start_date: '2021-08-09',
+            end_date: '2021-08-09',
+          },
+        },
+      ],
+    },
+  ]);
+
+  expect(operation.getResponseExamples()).toStrictEqual([
+    {
+      status: '201',
+      mediaTypes: {
+        'application/json': [
+          {
+            value: {
+              id: 'string',
+              product_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+              start_date: '2021-08-09',
+              end_date: '2021-08-09',
+              start_hour: 'string',
+              end_hour: 'string',
+            },
+          },
+        ],
+      },
+    },
+  ]);
+});

--- a/src/lib/get-mediatype-examples.js
+++ b/src/lib/get-mediatype-examples.js
@@ -67,7 +67,7 @@ module.exports = function getMediaTypeExamples(mediaType, mediaTypeObject, opts 
     if (!matchesMimeType.xml(mediaType)) {
       return [
         {
-          value: sampleFromSchema(mediaTypeObject.schema, opts),
+          value: sampleFromSchema(JSON.parse(JSON.stringify(mediaTypeObject.schema)), opts),
         },
       ];
     }

--- a/src/samples/index.js
+++ b/src/samples/index.js
@@ -14,6 +14,7 @@ const primitives = {
   string_email: () => 'user@example.com',
   'string_date-time': () => new Date().toISOString(),
   string_date: () => new Date().toISOString().substring(0, 10),
+  'string_YYYY-MM-DD': () => new Date().toISOString().substring(0, 10),
   string_uuid: () => '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   string_hostname: () => 'example.com',
   string_ipv4: () => '198.51.100.42',


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug in our core `sampleFromSchema` handling for request and response example generation where if you ran one before the other, schemas that are either `readOnly` or `writeOnly` would be excluded when they should normally be present. This was happening because the object we were passing into `sampleFromSchema` was being passed as a reference and that code updates the schema object, which was then propagating back upstream to the `Operation` class instance.

I'm also adding support for `format: YYYY-MM-DD` because I noticed a spec we have has that instead of the more common `format: date`.

Fix in support of RM-1765.

## 🧬 QA & Testing

See added tests.
