### PR TITLE
feat: preserving ref schema names during dereferencing

### DIFF
--- a/__tests__/__datasets__/complex-nesting.json
+++ b/__tests__/__datasets__/complex-nesting.json
@@ -1,0 +1,142 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Responses with various schema formats",
+    "description": "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#schema-object",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/multischema/of-everything": {
+      "post": {
+        "summary": "Multischema of Everything",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultischemaOfEverything"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultischemaOfEverything"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MultischemaOfEverything": {
+        "oneOf": [
+          {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ArrayOfObjectsOfObjectsAndArrays"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "objEverything": {
+                    "$ref": "#/components/schemas/ObjectOfEverything"
+                  },
+                  "flatObj": {
+                    "$ref": "#/components/schemas/FlatObject"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "$ref": "#/components/schemas/ArrayOfPrimitives"
+          },
+          {
+            "$ref": "#/components/schemas/ArrayOfFlatObjects"
+          },
+          {
+            "$ref": "#/components/schemas/FlatObject"
+          },
+          {
+            "$ref": "#/components/schemas/ObjectOfEverything"
+          }
+        ]
+      },
+      "ArrayOfObjectsOfObjectsAndArrays": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ObjectOfObjectsAndArrays"
+        }
+      },
+      "ObjectOfEverything": {
+        "type": "object",
+        "properties": {
+          "ObjectOfObjectsAndArrays": {
+            "$ref": "#/components/schemas/ObjectOfObjectsAndArrays"
+          },
+          "ArrayOfObjectsOfObjectsAndArrays": {
+            "$ref": "#/components/schemas/ArrayOfObjectsOfObjectsAndArrays"
+          },
+          "StringPrimitive": {
+            "type": "string"
+          }
+        }
+      },
+      "ArrayOfPrimitives": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ArrayOfFlatObjects": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FlatObject"
+        }
+      },
+      "ObjectOfObjectsAndArrays": {
+        "type": "object",
+        "properties": {
+          "ObjectPropInArray": {
+            "$ref": "#/components/schemas/FlatObject"
+          },
+          "PrimitiveArrayPropInArray": {
+            "$ref": "#/components/schemas/ArrayOfPrimitives"
+          },
+          "ObjectArrayPropInArray": {
+            "$ref": "#/components/schemas/ArrayOfFlatObjects"
+          },
+          "StringPrimitive": {
+            "type": "string"
+          }
+        }
+      },
+      "FlatObject": {
+        "type": "object",
+        "properties": {
+          "StringProp": {
+            "type": "string"
+          },
+          "BoolProp": {
+            "type": "boolean"
+          },
+          "NumProp": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1,5 +1,730 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`#dereference() should add metadata to components pre-dereferencing to preserve their lineage 1`] = `
+Object {
+  "/multischema/of-everything": Object {
+    "post": Object {
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "oneOf": Array [
+                Object {
+                  "oneOf": Array [
+                    Object {
+                      "items": Object {
+                        "properties": Object {
+                          "ObjectArrayPropInArray": Object {
+                            "items": Object {
+                              "properties": Object {
+                                "BoolProp": Object {
+                                  "type": "boolean",
+                                },
+                                "NumProp": Object {
+                                  "type": "number",
+                                },
+                                "StringProp": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "x-readme-ref-name": "FlatObject",
+                            },
+                            "type": "array",
+                            "x-readme-ref-name": "ArrayOfFlatObjects",
+                          },
+                          "ObjectPropInArray": Object {
+                            "properties": Object {
+                              "BoolProp": Object {
+                                "type": "boolean",
+                              },
+                              "NumProp": Object {
+                                "type": "number",
+                              },
+                              "StringProp": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "x-readme-ref-name": "FlatObject",
+                          },
+                          "PrimitiveArrayPropInArray": Object {
+                            "items": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "x-readme-ref-name": "ArrayOfPrimitives",
+                          },
+                          "StringPrimitive": Object {
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                        "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                      },
+                      "type": "array",
+                      "x-readme-ref-name": "ArrayOfObjectsOfObjectsAndArrays",
+                    },
+                    Object {
+                      "properties": Object {
+                        "flatObj": Object {
+                          "properties": Object {
+                            "BoolProp": Object {
+                              "type": "boolean",
+                            },
+                            "NumProp": Object {
+                              "type": "number",
+                            },
+                            "StringProp": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "x-readme-ref-name": "FlatObject",
+                        },
+                        "objEverything": Object {
+                          "properties": Object {
+                            "ArrayOfObjectsOfObjectsAndArrays": Object {
+                              "items": Object {
+                                "properties": Object {
+                                  "ObjectArrayPropInArray": Object {
+                                    "items": Object {
+                                      "properties": Object {
+                                        "BoolProp": Object {
+                                          "type": "boolean",
+                                        },
+                                        "NumProp": Object {
+                                          "type": "number",
+                                        },
+                                        "StringProp": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "type": "object",
+                                      "x-readme-ref-name": "FlatObject",
+                                    },
+                                    "type": "array",
+                                    "x-readme-ref-name": "ArrayOfFlatObjects",
+                                  },
+                                  "ObjectPropInArray": Object {
+                                    "properties": Object {
+                                      "BoolProp": Object {
+                                        "type": "boolean",
+                                      },
+                                      "NumProp": Object {
+                                        "type": "number",
+                                      },
+                                      "StringProp": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                    "x-readme-ref-name": "FlatObject",
+                                  },
+                                  "PrimitiveArrayPropInArray": Object {
+                                    "items": Object {
+                                      "type": "string",
+                                    },
+                                    "type": "array",
+                                    "x-readme-ref-name": "ArrayOfPrimitives",
+                                  },
+                                  "StringPrimitive": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "type": "object",
+                                "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                              },
+                              "type": "array",
+                              "x-readme-ref-name": "ArrayOfObjectsOfObjectsAndArrays",
+                            },
+                            "ObjectOfObjectsAndArrays": Object {
+                              "properties": Object {
+                                "ObjectArrayPropInArray": Object {
+                                  "items": Object {
+                                    "properties": Object {
+                                      "BoolProp": Object {
+                                        "type": "boolean",
+                                      },
+                                      "NumProp": Object {
+                                        "type": "number",
+                                      },
+                                      "StringProp": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                    "x-readme-ref-name": "FlatObject",
+                                  },
+                                  "type": "array",
+                                  "x-readme-ref-name": "ArrayOfFlatObjects",
+                                },
+                                "ObjectPropInArray": Object {
+                                  "properties": Object {
+                                    "BoolProp": Object {
+                                      "type": "boolean",
+                                    },
+                                    "NumProp": Object {
+                                      "type": "number",
+                                    },
+                                    "StringProp": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "type": "object",
+                                  "x-readme-ref-name": "FlatObject",
+                                },
+                                "PrimitiveArrayPropInArray": Object {
+                                  "items": Object {
+                                    "type": "string",
+                                  },
+                                  "type": "array",
+                                  "x-readme-ref-name": "ArrayOfPrimitives",
+                                },
+                                "StringPrimitive": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                            },
+                            "StringPrimitive": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "x-readme-ref-name": "ObjectOfEverything",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  ],
+                },
+                Object {
+                  "items": Object {
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "x-readme-ref-name": "ArrayOfPrimitives",
+                },
+                Object {
+                  "items": Object {
+                    "properties": Object {
+                      "BoolProp": Object {
+                        "type": "boolean",
+                      },
+                      "NumProp": Object {
+                        "type": "number",
+                      },
+                      "StringProp": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                    "x-readme-ref-name": "FlatObject",
+                  },
+                  "type": "array",
+                  "x-readme-ref-name": "ArrayOfFlatObjects",
+                },
+                Object {
+                  "properties": Object {
+                    "BoolProp": Object {
+                      "type": "boolean",
+                    },
+                    "NumProp": Object {
+                      "type": "number",
+                    },
+                    "StringProp": Object {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                  "x-readme-ref-name": "FlatObject",
+                },
+                Object {
+                  "properties": Object {
+                    "ArrayOfObjectsOfObjectsAndArrays": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "ObjectArrayPropInArray": Object {
+                            "items": Object {
+                              "properties": Object {
+                                "BoolProp": Object {
+                                  "type": "boolean",
+                                },
+                                "NumProp": Object {
+                                  "type": "number",
+                                },
+                                "StringProp": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "x-readme-ref-name": "FlatObject",
+                            },
+                            "type": "array",
+                            "x-readme-ref-name": "ArrayOfFlatObjects",
+                          },
+                          "ObjectPropInArray": Object {
+                            "properties": Object {
+                              "BoolProp": Object {
+                                "type": "boolean",
+                              },
+                              "NumProp": Object {
+                                "type": "number",
+                              },
+                              "StringProp": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "x-readme-ref-name": "FlatObject",
+                          },
+                          "PrimitiveArrayPropInArray": Object {
+                            "items": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "x-readme-ref-name": "ArrayOfPrimitives",
+                          },
+                          "StringPrimitive": Object {
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                        "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                      },
+                      "type": "array",
+                      "x-readme-ref-name": "ArrayOfObjectsOfObjectsAndArrays",
+                    },
+                    "ObjectOfObjectsAndArrays": Object {
+                      "properties": Object {
+                        "ObjectArrayPropInArray": Object {
+                          "items": Object {
+                            "properties": Object {
+                              "BoolProp": Object {
+                                "type": "boolean",
+                              },
+                              "NumProp": Object {
+                                "type": "number",
+                              },
+                              "StringProp": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "x-readme-ref-name": "FlatObject",
+                          },
+                          "type": "array",
+                          "x-readme-ref-name": "ArrayOfFlatObjects",
+                        },
+                        "ObjectPropInArray": Object {
+                          "properties": Object {
+                            "BoolProp": Object {
+                              "type": "boolean",
+                            },
+                            "NumProp": Object {
+                              "type": "number",
+                            },
+                            "StringProp": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "x-readme-ref-name": "FlatObject",
+                        },
+                        "PrimitiveArrayPropInArray": Object {
+                          "items": Object {
+                            "type": "string",
+                          },
+                          "type": "array",
+                          "x-readme-ref-name": "ArrayOfPrimitives",
+                        },
+                        "StringPrimitive": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                      "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                    },
+                    "StringPrimitive": Object {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                  "x-readme-ref-name": "ObjectOfEverything",
+                },
+              ],
+              "x-readme-ref-name": "MultischemaOfEverything",
+            },
+          },
+        },
+      },
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "oneOf": Array [
+                  Object {
+                    "oneOf": Array [
+                      Object {
+                        "items": Object {
+                          "properties": Object {
+                            "ObjectArrayPropInArray": Object {
+                              "items": Object {
+                                "properties": Object {
+                                  "BoolProp": Object {
+                                    "type": "boolean",
+                                  },
+                                  "NumProp": Object {
+                                    "type": "number",
+                                  },
+                                  "StringProp": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "type": "object",
+                                "x-readme-ref-name": "FlatObject",
+                              },
+                              "type": "array",
+                              "x-readme-ref-name": "ArrayOfFlatObjects",
+                            },
+                            "ObjectPropInArray": Object {
+                              "properties": Object {
+                                "BoolProp": Object {
+                                  "type": "boolean",
+                                },
+                                "NumProp": Object {
+                                  "type": "number",
+                                },
+                                "StringProp": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "x-readme-ref-name": "FlatObject",
+                            },
+                            "PrimitiveArrayPropInArray": Object {
+                              "items": Object {
+                                "type": "string",
+                              },
+                              "type": "array",
+                              "x-readme-ref-name": "ArrayOfPrimitives",
+                            },
+                            "StringPrimitive": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                        },
+                        "type": "array",
+                        "x-readme-ref-name": "ArrayOfObjectsOfObjectsAndArrays",
+                      },
+                      Object {
+                        "properties": Object {
+                          "flatObj": Object {
+                            "properties": Object {
+                              "BoolProp": Object {
+                                "type": "boolean",
+                              },
+                              "NumProp": Object {
+                                "type": "number",
+                              },
+                              "StringProp": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "x-readme-ref-name": "FlatObject",
+                          },
+                          "objEverything": Object {
+                            "properties": Object {
+                              "ArrayOfObjectsOfObjectsAndArrays": Object {
+                                "items": Object {
+                                  "properties": Object {
+                                    "ObjectArrayPropInArray": Object {
+                                      "items": Object {
+                                        "properties": Object {
+                                          "BoolProp": Object {
+                                            "type": "boolean",
+                                          },
+                                          "NumProp": Object {
+                                            "type": "number",
+                                          },
+                                          "StringProp": Object {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "type": "object",
+                                        "x-readme-ref-name": "FlatObject",
+                                      },
+                                      "type": "array",
+                                      "x-readme-ref-name": "ArrayOfFlatObjects",
+                                    },
+                                    "ObjectPropInArray": Object {
+                                      "properties": Object {
+                                        "BoolProp": Object {
+                                          "type": "boolean",
+                                        },
+                                        "NumProp": Object {
+                                          "type": "number",
+                                        },
+                                        "StringProp": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "type": "object",
+                                      "x-readme-ref-name": "FlatObject",
+                                    },
+                                    "PrimitiveArrayPropInArray": Object {
+                                      "items": Object {
+                                        "type": "string",
+                                      },
+                                      "type": "array",
+                                      "x-readme-ref-name": "ArrayOfPrimitives",
+                                    },
+                                    "StringPrimitive": Object {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "type": "object",
+                                  "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                                },
+                                "type": "array",
+                                "x-readme-ref-name": "ArrayOfObjectsOfObjectsAndArrays",
+                              },
+                              "ObjectOfObjectsAndArrays": Object {
+                                "properties": Object {
+                                  "ObjectArrayPropInArray": Object {
+                                    "items": Object {
+                                      "properties": Object {
+                                        "BoolProp": Object {
+                                          "type": "boolean",
+                                        },
+                                        "NumProp": Object {
+                                          "type": "number",
+                                        },
+                                        "StringProp": Object {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "type": "object",
+                                      "x-readme-ref-name": "FlatObject",
+                                    },
+                                    "type": "array",
+                                    "x-readme-ref-name": "ArrayOfFlatObjects",
+                                  },
+                                  "ObjectPropInArray": Object {
+                                    "properties": Object {
+                                      "BoolProp": Object {
+                                        "type": "boolean",
+                                      },
+                                      "NumProp": Object {
+                                        "type": "number",
+                                      },
+                                      "StringProp": Object {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                    "x-readme-ref-name": "FlatObject",
+                                  },
+                                  "PrimitiveArrayPropInArray": Object {
+                                    "items": Object {
+                                      "type": "string",
+                                    },
+                                    "type": "array",
+                                    "x-readme-ref-name": "ArrayOfPrimitives",
+                                  },
+                                  "StringPrimitive": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "type": "object",
+                                "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                              },
+                              "StringPrimitive": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "x-readme-ref-name": "ObjectOfEverything",
+                          },
+                        },
+                        "type": "object",
+                      },
+                    ],
+                  },
+                  Object {
+                    "items": Object {
+                      "type": "string",
+                    },
+                    "type": "array",
+                    "x-readme-ref-name": "ArrayOfPrimitives",
+                  },
+                  Object {
+                    "items": Object {
+                      "properties": Object {
+                        "BoolProp": Object {
+                          "type": "boolean",
+                        },
+                        "NumProp": Object {
+                          "type": "number",
+                        },
+                        "StringProp": Object {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                      "x-readme-ref-name": "FlatObject",
+                    },
+                    "type": "array",
+                    "x-readme-ref-name": "ArrayOfFlatObjects",
+                  },
+                  Object {
+                    "properties": Object {
+                      "BoolProp": Object {
+                        "type": "boolean",
+                      },
+                      "NumProp": Object {
+                        "type": "number",
+                      },
+                      "StringProp": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                    "x-readme-ref-name": "FlatObject",
+                  },
+                  Object {
+                    "properties": Object {
+                      "ArrayOfObjectsOfObjectsAndArrays": Object {
+                        "items": Object {
+                          "properties": Object {
+                            "ObjectArrayPropInArray": Object {
+                              "items": Object {
+                                "properties": Object {
+                                  "BoolProp": Object {
+                                    "type": "boolean",
+                                  },
+                                  "NumProp": Object {
+                                    "type": "number",
+                                  },
+                                  "StringProp": Object {
+                                    "type": "string",
+                                  },
+                                },
+                                "type": "object",
+                                "x-readme-ref-name": "FlatObject",
+                              },
+                              "type": "array",
+                              "x-readme-ref-name": "ArrayOfFlatObjects",
+                            },
+                            "ObjectPropInArray": Object {
+                              "properties": Object {
+                                "BoolProp": Object {
+                                  "type": "boolean",
+                                },
+                                "NumProp": Object {
+                                  "type": "number",
+                                },
+                                "StringProp": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "x-readme-ref-name": "FlatObject",
+                            },
+                            "PrimitiveArrayPropInArray": Object {
+                              "items": Object {
+                                "type": "string",
+                              },
+                              "type": "array",
+                              "x-readme-ref-name": "ArrayOfPrimitives",
+                            },
+                            "StringPrimitive": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                        },
+                        "type": "array",
+                        "x-readme-ref-name": "ArrayOfObjectsOfObjectsAndArrays",
+                      },
+                      "ObjectOfObjectsAndArrays": Object {
+                        "properties": Object {
+                          "ObjectArrayPropInArray": Object {
+                            "items": Object {
+                              "properties": Object {
+                                "BoolProp": Object {
+                                  "type": "boolean",
+                                },
+                                "NumProp": Object {
+                                  "type": "number",
+                                },
+                                "StringProp": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "x-readme-ref-name": "FlatObject",
+                            },
+                            "type": "array",
+                            "x-readme-ref-name": "ArrayOfFlatObjects",
+                          },
+                          "ObjectPropInArray": Object {
+                            "properties": Object {
+                              "BoolProp": Object {
+                                "type": "boolean",
+                              },
+                              "NumProp": Object {
+                                "type": "number",
+                              },
+                              "StringProp": Object {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "x-readme-ref-name": "FlatObject",
+                          },
+                          "PrimitiveArrayPropInArray": Object {
+                            "items": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "x-readme-ref-name": "ArrayOfPrimitives",
+                          },
+                          "StringPrimitive": Object {
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                        "x-readme-ref-name": "ObjectOfObjectsAndArrays",
+                      },
+                      "StringPrimitive": Object {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                    "x-readme-ref-name": "ObjectOfEverything",
+                  },
+                ],
+                "x-readme-ref-name": "MultischemaOfEverything",
+              },
+            },
+          },
+          "description": "OK",
+        },
+      },
+      "summary": "Multischema of Everything",
+    },
+  },
+}
+`;
+
 exports[`#operation() should return a default when no operation 1`] = `
 Operation {
   "contentType": undefined,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -4,6 +4,7 @@ const { Operation } = require('../src');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
 
 const circular = require('./__datasets__/circular.json');
+const complexNesting = require('./__datasets__/complex-nesting.json');
 const pathMatchingQuirks = require('./__datasets__/path-matching-quirks.json');
 const pathVariableQuirks = require('./__datasets__/path-variable-quirks.json');
 const petstoreServerVars = require('./__datasets__/petstore-server-vars.json');
@@ -1096,6 +1097,17 @@ describe('#dereference()', () => {
       description: 'Pet object that needs to be added to the store',
       required: true,
     });
+  });
+
+  it('should add metadata to components pre-dereferencing to preserve their lineage', async () => {
+    const oas = new Oas(complexNesting);
+    await oas.dereference();
+
+    expect(
+      oas.paths['/multischema/of-everything'].post.requestBody.content['application/json'].schema['x-readme-ref-name']
+    ).toStrictEqual('MultischemaOfEverything');
+
+    expect(oas.paths).toMatchSnapshot();
   });
 
   it('should retain the user object when dereferencing', async () => {

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
@@ -17,6 +17,7 @@ Array [
               },
             },
             "type": "object",
+            "x-readme-ref-name": "ProductStock",
           },
           "SalesLine": Object {
             "properties": Object {
@@ -25,10 +26,12 @@ Array [
               },
             },
             "type": "object",
+            "x-readme-ref-name": "SalesLine",
           },
           "dateTime": Object {
             "format": "date-time",
             "type": "string",
+            "x-readme-ref-name": "dateTime",
           },
           "offset": Object {
             "properties": Object {
@@ -40,6 +43,7 @@ Array [
               },
             },
             "type": "object",
+            "x-readme-ref-name": "offset",
           },
           "offsetTransition": Object {
             "properties": Object {
@@ -55,6 +59,7 @@ Array [
               },
             },
             "type": "object",
+            "x-readme-ref-name": "offsetTransition",
           },
           "rules": Object {
             "properties": Object {
@@ -66,6 +71,7 @@ Array [
               },
             },
             "type": "object",
+            "x-readme-ref-name": "rules",
           },
         },
       },
@@ -140,6 +146,7 @@ Array [
               "discrim",
             ],
             "type": "object",
+            "x-readme-ref-name": "OptionOneNoDisc",
           },
           "OptionTwoNoDisc": Object {
             "properties": Object {
@@ -154,6 +161,7 @@ Array [
               "discrim",
             ],
             "type": "object",
+            "x-readme-ref-name": "OptionTwoNoDisc",
           },
         },
       },
@@ -178,6 +186,7 @@ Array [
             "discrim",
           ],
           "type": "object",
+          "x-readme-ref-name": "OptionOneNoDisc",
         },
         Object {
           "properties": Object {
@@ -192,6 +201,7 @@ Array [
             "discrim",
           ],
           "type": "object",
+          "x-readme-ref-name": "OptionTwoNoDisc",
         },
       ],
     },
@@ -217,6 +227,7 @@ Array [
             },
           },
           "type": "object",
+          "x-readme-ref-name": "Category",
         },
         "id": Object {
           "format": "int64",
@@ -256,6 +267,7 @@ Array [
               },
             },
             "type": "object",
+            "x-readme-ref-name": "Tag",
           },
           "type": "array",
         },
@@ -265,6 +277,7 @@ Array [
         "photoUrls",
       ],
       "type": "object",
+      "x-readme-ref-name": "Pet",
     },
     "type": "body",
   },

--- a/__tests__/operation/get-requestbody-examples.test.js
+++ b/__tests__/operation/get-requestbody-examples.test.js
@@ -183,6 +183,7 @@ describe('defined within response `content`', () => {
                     type: 'string',
                   },
                 },
+                'x-readme-ref-name': 'user',
               },
             },
           ],

--- a/__tests__/operation/get-response-as-json-schema.test.js
+++ b/__tests__/operation/get-response-as-json-schema.test.js
@@ -31,6 +31,7 @@ test('it should return a response as JSON Schema', async () => {
           type: { type: 'string' },
           message: { type: 'string' },
         },
+        'x-readme-ref-name': 'ApiResponse',
       },
       type: 'object',
       label: 'Response body',

--- a/src/index.js
+++ b/src/index.js
@@ -495,6 +495,15 @@ class Oas {
     // Extract non-OAS properties that are on the class so we can supply only the OAS to the ref parser.
     const { _dereferencing, _promises, user, ...oas } = this;
 
+    // Because referencing will eliminate any lineage back to the original `$ref`, information that we might need at
+    // some point, we should run through all available component schemas and denote what their name is so that when
+    // dereferencing happens below those names will be preserved.
+    if (oas && oas.components && oas.components.schemas && typeof oas.components.schemas === 'object') {
+      Object.keys(oas.components.schemas).forEach(schemaName => {
+        oas.components.schemas[schemaName]['x-readme-ref-name'] = schemaName;
+      });
+    }
+
     return $RefParser
       .dereference(oas, {
         resolve: {


### PR DESCRIPTION
## 🧰 Changes

With the work I did in #479, I accidentaly broke some functionality in our form generator where for an `anyOf` or `oneOf` schema we use the name of the component schema if there isn't a `title` present. Since those schemas are no longer always present we need an alternative way to expose what the schema *was* called, and we're doing that now with this `x-readme-ref-name` extension.

Pre-dereferencing we now run through all component schemas and note what their name is so that when we dereference that metadata will be preserved wherever that schema `$ref` is utilized.

## 🧬 QA & Testing

See tests.