### PR TITLE
fix: quirk with request/response examples where readonly/writeonly was ignored in allOf

### DIFF
--- a/__tests__/__datasets__/readonly-writeonly.json
+++ b/__tests__/__datasets__/readonly-writeonly.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "https://httpbin.org/"
+      "url": "https://httpbin.org"
     }
   ],
   "paths": {
@@ -69,10 +69,54 @@
           }
         }
       }
+    },
+    "/allOf": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/product_allOf"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/product_allOf"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "product_allOf": {
+        "allOf": [
+          { "$ref": "#/components/schemas/product" },
+          {
+            "type": "object",
+            "properties": {
+              "readOnly_primitive": {
+                "type": "string",
+                "readOnly": true
+              },
+              "writeOnly_primitive": {
+                "type": "string",
+                "writeOnly": true
+              }
+            }
+          }
+        ]
+      },
       "product": {
         "type": "object",
         "properties": {

--- a/__tests__/__snapshots__/operation.test.js.snap
+++ b/__tests__/__snapshots__/operation.test.js.snap
@@ -193,8 +193,8 @@ Array [
         "securitySchemes": Object {
           "api_key": Object {
             "in": "header",
-            "scheme": "basic",
-            "type": "http",
+            "name": "api_key",
+            "type": "apiKey",
           },
           "petstore_auth": Object {
             "_key": "petstore_auth",

--- a/__tests__/__snapshots__/operation.test.js.snap
+++ b/__tests__/__snapshots__/operation.test.js.snap
@@ -193,8 +193,8 @@ Array [
         "securitySchemes": Object {
           "api_key": Object {
             "in": "header",
-            "name": "api_key",
-            "type": "apiKey",
+            "scheme": "basic",
+            "type": "http",
           },
           "petstore_auth": Object {
             "_key": "petstore_auth",

--- a/__tests__/operation/get-requestbody-examples.test.js
+++ b/__tests__/operation/get-requestbody-examples.test.js
@@ -289,4 +289,27 @@ describe('readOnly / writeOnly handling', () => {
       },
     ]);
   });
+
+  it('should retain `readOnly` and `writeOnly` settings when merging an allOf', async () => {
+    const spec = new Oas(exampleRoWo);
+    await spec.dereference();
+
+    const operation = spec.operation('/allOf', 'post');
+
+    expect(operation.getRequestBodyExamples()).toStrictEqual([
+      {
+        mediaType: 'application/json',
+        examples: [
+          {
+            value: {
+              end_date: '2021-08-20',
+              product_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+              start_date: '2021-08-20',
+              writeOnly_primitive: 'string',
+            },
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/__tests__/operation/get-response-examples.test.js
+++ b/__tests__/operation/get-response-examples.test.js
@@ -456,6 +456,34 @@ describe('readOnly / writeOnly handling', () => {
       },
     ]);
   });
+
+  it('should retain `readOnly` and `writeOnly` settings when merging an allOf', async () => {
+    const spec = new Oas(exampleRoWo);
+    await spec.dereference();
+
+    const operation = spec.operation('/allOf', 'post');
+
+    expect(operation.getResponseExamples()).toStrictEqual([
+      {
+        status: '200',
+        mediaTypes: {
+          'application/json': [
+            {
+              value: {
+                end_date: '2021-08-20',
+                end_hour: 'string',
+                id: 'string',
+                product_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                readOnly_primitive: 'string',
+                start_date: '2021-08-20',
+                start_hour: 'string',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+  });
 });
 
 test('sample generation should not corrupt the supplied operation', async () => {

--- a/src/samples/index.js
+++ b/src/samples/index.js
@@ -51,13 +51,14 @@ const sampleFromSchema = (schema, config = {}) => {
             // Ignore any unrecognized OAS-specific keywords that might be present on the schema (like `xml`).
             defaultResolver: mergeAllOf.options.resolvers.title,
           },
-        })
+        }),
+        config
       );
     } catch (error) {
       return undefined;
     }
   } else if (hasPolymorphism) {
-    return sampleFromSchema(objectifySchema[hasPolymorphism][0]);
+    return sampleFromSchema(objectifySchema[hasPolymorphism][0], config);
   }
 
   const { example, additionalProperties, properties, items } = objectifySchema;


### PR DESCRIPTION
## 🧰 Changes

Fixes a quirk with `readOnly` and `writeOnly` where if they were within a schema that was in an `allOf` we wouldn't include them in generated examples.

Fixes RM-1765

## 🧬 QA & Testing

See tests.