### PR TITLE
fix: remove duplicate items from enums

### DIFF
--- a/__tests__/lib/openapi-to-json-schema.test.js
+++ b/__tests__/lib/openapi-to-json-schema.test.js
@@ -396,6 +396,13 @@ describe('`enum` support', () => {
 
     expect(toJSONSchema(schema)).toStrictEqual(schema);
   });
+
+  it('should fitler out duplicate items from an enum', () => {
+    expect(toJSONSchema({ type: 'string', enum: ['cat', 'cat', 'dog', 'dog', 'snake'] })).toStrictEqual({
+      type: 'string',
+      enum: ['cat', 'dog', 'snake'],
+    });
+  });
 });
 
 describe('`format` support', () => {

--- a/src/lib/openapi-to-json-schema.js
+++ b/src/lib/openapi-to-json-schema.js
@@ -412,6 +412,11 @@ function toJSONSchema(data, opts = {}) {
     }
   }
 
+  // Enums should not have duplicated items as those will break AJV validation.
+  if ('enum' in schema && Array.isArray(schema.enum)) {
+    schema.enum = [...new Set(schema.enum)];
+  }
+
   // Clean up any remaining `items` or `properties` schema fragments lying around if there's also polymorphism present.
   if ('allOf' in schema || 'anyOf' in schema || 'oneOf' in schema) {
     if ('properties' in schema) {


### PR DESCRIPTION
## 🧰 Changes

This updates our JSON Schema generation and handling of `enum` properties to filter out any duplicate items that may be present within it. Duplicate items in an enum will cause AJV to throw errors:

![Screen Shot 2021-08-27 at 2 29 53 PM](https://user-images.githubusercontent.com/33762/131190571-0f8080d7-d569-42b4-a404-35f7630ea086.png)

## 🧬 QA & Testing

See tests.