### PR TITLE
feat: constrain integer and number formats when generating JSON Schema

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,7 @@ __tests__/
 .github/
 .husky/
 coverage/
+.babel*
 .eslint*
 .prettier*
+webpack.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+__tests__/cli/__fixtures__/
 coverage/
 dist/
 packages/

--- a/__tests__/__snapshots__/operation.test.js.snap
+++ b/__tests__/__snapshots__/operation.test.js.snap
@@ -44,6 +44,8 @@ Array [
             "properties": Object {
               "code": Object {
                 "format": "int32",
+                "maximum": 2147483647,
+                "minimum": -2147483648,
                 "type": "integer",
               },
               "message": Object {
@@ -59,6 +61,8 @@ Array [
             "properties": Object {
               "id": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "type": "integer",
               },
               "name": Object {
@@ -75,14 +79,20 @@ Array [
               },
               "id": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "type": "integer",
               },
               "petId": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "type": "integer",
               },
               "quantity": Object {
                 "format": "int32",
+                "maximum": 2147483647,
+                "minimum": -2147483648,
                 "type": "integer",
               },
               "shipDate": Object {
@@ -108,6 +118,8 @@ Array [
               },
               "id": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "readOnly": true,
                 "type": "integer",
               },
@@ -149,6 +161,8 @@ Array [
             "properties": Object {
               "id": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "type": "integer",
               },
               "name": Object {
@@ -167,6 +181,8 @@ Array [
               },
               "id": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "type": "integer",
               },
               "lastName": Object {
@@ -181,6 +197,8 @@ Array [
               "userStatus": Object {
                 "description": "User Status",
                 "format": "int32",
+                "maximum": 2147483647,
+                "minimum": -2147483648,
                 "type": "integer",
               },
               "username": Object {

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
@@ -100,6 +100,8 @@ Array [
         "petId": Object {
           "description": "Pet id to delete",
           "format": "int64",
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
           "type": "integer",
         },
       },
@@ -220,6 +222,8 @@ Array [
           "properties": Object {
             "id": Object {
               "format": "int64",
+              "maximum": 9223372036854776000,
+              "minimum": -9223372036854776000,
               "type": "integer",
             },
             "name": Object {
@@ -231,6 +235,8 @@ Array [
         },
         "id": Object {
           "format": "int64",
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
           "readOnly": true,
           "type": "integer",
         },
@@ -260,6 +266,8 @@ Array [
             "properties": Object {
               "id": Object {
                 "format": "int64",
+                "maximum": 9223372036854776000,
+                "minimum": -9223372036854776000,
                 "type": "integer",
               },
               "name": Object {
@@ -293,6 +301,8 @@ Array [
         "petId": Object {
           "description": "ID of pet that needs to be updated",
           "format": "int64",
+          "maximum": 9223372036854776000,
+          "minimum": -9223372036854776000,
           "type": "integer",
         },
       },

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -470,6 +470,8 @@ describe('descriptions', () => {
         pathId: {
           type: 'integer',
           format: 'uint32',
+          maximum: 4294967295,
+          minimum: 0,
           description: 'Description for the pathId',
         },
       },

--- a/__tests__/operation/get-response-as-json-schema.test.js
+++ b/__tests__/operation/get-response-as-json-schema.test.js
@@ -27,7 +27,7 @@ test('it should return a response as JSON Schema', async () => {
       schema: {
         type: 'object',
         properties: {
-          code: { type: 'integer', format: 'int32' },
+          code: { type: 'integer', format: 'int32', maximum: 2147483647, minimum: -2147483648 },
           type: { type: 'string' },
           message: { type: 'string' },
         },

--- a/src/lib/openapi-to-json-schema.js
+++ b/src/lib/openapi-to-json-schema.js
@@ -21,39 +21,31 @@ const UNSUPPORTED_SCHEMA_PROPS = [
 ];
 
 /**
- * int8: -128 to 127
- * int16: -32768 to 32767
- * int32: -2147483648 to 2147483647
- * int64: -9223372036854775808 to 9223372036854775807
- * uint8: 0 to 255
- * uint16: 0 to 65535
- * uint32: 0 to 4294967295
- * uint64: 0 to 18446744073709551615
- * float: -3.402823669209385e+38 to 3.402823669209385e+38
+ * List partially sourced from `openapi-schema-to-json-schema`.
  *
  * @link https://github.com/openapi-contrib/openapi-schema-to-json-schema/blob/master/lib/converters/schema.js#L140-L154
  */
 const FORMAT_OPTIONS = {
-  INT8_MIN: 0 - 2 ** 7,
-  INT8_MAX: 2 ** 7 - 1,
-  INT16_MIN: 0 - 2 ** 15,
-  INT16_MAX: 2 ** 15 - 1,
-  INT32_MIN: 0 - 2 ** 31,
-  INT32_MAX: 2 ** 31 - 1,
-  INT64_MIN: 0 - 2 ** 63,
-  INT64_MAX: 2 ** 63 - 1,
+  INT8_MIN: 0 - 2 ** 7, // -128
+  INT8_MAX: 2 ** 7 - 1, // 127
+  INT16_MIN: 0 - 2 ** 15, // -32768
+  INT16_MAX: 2 ** 15 - 1, // 32767
+  INT32_MIN: 0 - 2 ** 31, // -2147483648
+  INT32_MAX: 2 ** 31 - 1, // 2147483647
+  INT64_MIN: 0 - 2 ** 63, // -9223372036854775808
+  INT64_MAX: 2 ** 63 - 1, // 9223372036854775807
 
   UINT8_MIN: 0,
-  UINT8_MAX: 2 ** 8 - 1,
+  UINT8_MAX: 2 ** 8 - 1, // 255
   UINT16_MIN: 0,
-  UINT16_MAX: 2 ** 16 - 1,
+  UINT16_MAX: 2 ** 16 - 1, // 65535
   UINT32_MIN: 0,
-  UINT32_MAX: 2 ** 32 - 1,
+  UINT32_MAX: 2 ** 32 - 1, // 4294967295
   UINT64_MIN: 0,
-  UINT64_MAX: 2 ** 64 - 1,
+  UINT64_MAX: 2 ** 64 - 1, // 18446744073709551615
 
-  FLOAT_MIN: 0 - 2 ** 128,
-  FLOAT_MAX: 2 ** 128 - 1,
+  FLOAT_MIN: 0 - 2 ** 128, // -3.402823669209385e+38
+  FLOAT_MAX: 2 ** 128 - 1, // 3.402823669209385e+38
 
   DOUBLE_MIN: 0 - Number.MAX_VALUE,
   DOUBLE_MAX: Number.MAX_VALUE,


### PR DESCRIPTION
## 🧰 Changes

This updates our JSON Schema generation to constrain known `integer` and `number` formats within the limits defined by their formats. These include:

| Type | Format |
| :--- | :--- |
| integer | int8 |
| integer |  int8 |
| integer | int16 |
| integer | int32 |
| integer | int64 |
| integer | uint8 |
| integer | uint16 |
| integer | uint32 |
| integer | uint64 |
| number | float |
| number | double |

Fix in support of RM-1716.

## 🧬 QA & Testing

See tests.