### PR TITLE
fix: support generating response json schema for non-json content types

### DIFF
--- a/src/operation/get-response-as-json-schema.js
+++ b/src/operation/get-response-as-json-schema.js
@@ -75,7 +75,10 @@ module.exports = function getResponseAsJsonSchema(operation, oas, statusCode) {
       }
     }
 
-    return null;
+    // We always want to prefer the JSON-compatible content types over everything else but if we haven't found one we
+    // should default to the first available.
+    const contentType = contentTypes.shift();
+    return toJSONSchema(content[contentType].schema, { refLogger });
   }
 
   const foundSchema = getPreferredSchema(response.content);


### PR DESCRIPTION
## 🧰 Changes

This adds support to `Operation.getResponseAsJsonSchema()` to return JSON Schema for content/media types that aren't JSON-compatible.

I'm not sure why I originally introduced this restriction but it doesn't make sense because JSON Schema generation isn't clamped down to only JSON. If you you have a response that returns `image/png` and a schema of `type: string` we can still generate functional JSON Schema for that. 

For example, this operation returns `*/*` and right now we render:

![Screen Shot 2021-08-31 at 4 28 53 PM](https://user-images.githubusercontent.com/33762/131588642-821fae1e-cccf-428a-8c84-ce4889f19e6b.png)

We're already able to handle non-JSON media types properly within `getParametersAsJsonSchema()` already, just we prefer JSON over everything else and if we don't have JSON we'll use what we have. That flow is now being utilized within `getResponseAsJsonSchema`. 

Fix in support of RM-2075.

## 🧬 QA & Testing

See tests.