### PR TITLE
fix: improper handling of empty response content objects

### DIFF
--- a/__tests__/operation/get-response-as-json-schema.test.js
+++ b/__tests__/operation/get-response-as-json-schema.test.js
@@ -16,6 +16,19 @@ test('it should return with null if there is not a response', () => {
   expect(createOas({ responses: {} }).operation('/', 'get').getResponseAsJsonSchema('200')).toBeNull();
 });
 
+test('it should return with null if there is empty content', () => {
+  const oas = createOas({
+    responses: {
+      200: {
+        description: 'OK',
+        content: {},
+      },
+    },
+  });
+
+  expect(oas.operation('/', 'get').getResponseAsJsonSchema('200')).toBeNull();
+});
+
 test('it should return a response as JSON Schema', async () => {
   const oas = new Oas(petstore);
   await oas.dereference();

--- a/src/operation/get-response-as-json-schema.js
+++ b/src/operation/get-response-as-json-schema.js
@@ -67,6 +67,9 @@ module.exports = function getResponseAsJsonSchema(operation, oas, statusCode) {
     }
 
     const contentTypes = Object.keys(content);
+    if (!contentTypes.length) {
+      return null;
+    }
 
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < contentTypes.length; i++) {


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug in our `Operation.getResponseAsJsonSchema()` method where if a response had an empty `content` object present, `getResponseAsJsonSchema` would crash.

## 🧬 QA & Testing

See tests.