### PR TITLE
feat: adding a new `getTags` method to the operation class

### DIFF
--- a/__tests__/operation.test.js
+++ b/__tests__/operation.test.js
@@ -658,6 +658,59 @@ describe('#getOperationId()', () => {
   });
 });
 
+describe('#getTags()', () => {
+  it('should return tags if tags exist', () => {
+    const operation = new Oas(petstore).operation('/pet', 'post');
+
+    expect(operation.getTags()).toStrictEqual([
+      {
+        name: 'pet',
+        description: 'Everything about your Pets',
+        externalDocs: { description: 'Find out more', url: 'http://swagger.io' },
+      },
+    ]);
+  });
+
+  it("should not return any tag metadata with the tag if it isn't defined at the OAS level", () => {
+    const spec = new Oas({
+      paths: {
+        '/': {
+          get: {
+            tags: ['dogs'],
+            responses: {
+              200: {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const operation = spec.operation('/', 'get');
+    expect(operation.getTags()).toStrictEqual([{ name: 'dogs' }]);
+  });
+
+  it('should return an empty array if no tags are present', () => {
+    const spec = new Oas({
+      paths: {
+        '/': {
+          get: {
+            responses: {
+              200: {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const operation = spec.operation('/', 'get');
+    expect(operation.getTags()).toHaveLength(0);
+  });
+});
+
 describe('#getParameters()', () => {
   it('should return parameters', () => {
     const operation = new Oas(petstore).operation('/pet/{petId}', 'delete');

--- a/src/operation.js
+++ b/src/operation.js
@@ -247,6 +247,41 @@ class Operation {
   }
 
   /**
+   * Return an array of all tags, and their metadata, that exist on this operation.
+   *
+   * @returns {array}
+   */
+  getTags() {
+    if (!('tags' in this.schema)) {
+      return [];
+    }
+
+    let oasTags = new Map();
+    if ('tags' in this.oas) {
+      this.oas.tags.forEach(tag => {
+        oasTags.set(tag.name, tag);
+      });
+    }
+
+    oasTags = Object.fromEntries(oasTags);
+
+    const tags = [];
+    if (Array.isArray(this.schema.tags)) {
+      this.schema.tags.forEach(tag => {
+        if (tag in oasTags) {
+          tags.push(oasTags[tag]);
+        } else {
+          tags.push({
+            name: tag,
+          });
+        }
+      });
+    }
+
+    return tags;
+  }
+
+  /**
    * Return the parameters (non-request body) on the operation.
    *
    * @todo This should also pull in common params.


### PR DESCRIPTION
## 🧰 Changes

Adds a new `.getTags()` method to the `Operation` class that will pull back tags, and their OAS-level defined metadata, for the current operation.

## 🧬 QA & Testing

See tests.