### PR TITLE
feat: exposting deprecated parameters

### DIFF
--- a/src/lib/openapi-to-json-schema.js
+++ b/src/lib/openapi-to-json-schema.js
@@ -17,7 +17,7 @@ const UNSUPPORTED_SCHEMA_PROPS = [
   'xml',
   'externalDocs',
   'example', // OpenAPI supports `example`, but we're mapping it to `examples` below.
-  'deprecated',
+  // 'deprecated',
 ];
 
 /**

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -139,7 +139,9 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
             // `examples` isn't actually supported here in OAS 3.0, but we might as well support it because `examples` is
             // JSON Schema and that's fully supported in OAS 3.1.
             currentSchema.examples = current.examples;
-          }
+          } 
+
+          if (current?.deprecated) currentSchema.deprecated = current.deprecated;
 
           schema = {
             ...toJSONSchema(currentSchema, {
@@ -179,6 +181,8 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
                 // JSON Schema and that's fully supported in OAS 3.1.
                 currentSchema.examples = current.examples;
               }
+
+              if (current.deprecated) currentSchema.deprecated = current.deprecated;
 
               schema = {
                 ...toJSONSchema(currentSchema, {


### PR DESCRIPTION
## 🧰 Changes
WIP
Exposing the deprecated property on schemas for use in the reference section, and removing it from our unsupported property list. I have been using this via npm link to test adding the deprecated badge to the schema forms on the other side

## 🧬 QA & Testing
- [ ] Is this a good way to expose this property or should it be done more similarly to required? 
- [ ] Did I miss anything important?
- [ ] Tests (that I need to write) are passing 
