### PR TITLE
feat: adding a `getIdentifier` accessor on the Callback class

### DIFF
--- a/__tests__/operation.test.js
+++ b/__tests__/operation.test.js
@@ -818,6 +818,7 @@ describe('#getCallback()', () => {
     const operation = new Oas(callbackSchema).operation('/callbacks', 'get');
     const callback = operation.getCallback('myCallback', '{$request.query.queryUrl}', 'post');
 
+    expect(callback.identifier).toBe('myCallback');
     expect(callback.method).toBe('post');
     expect(callback.path).toBe('{$request.query.queryUrl}');
     expect(callback).toBeInstanceOf(Callback);

--- a/__tests__/samples/index.test.js
+++ b/__tests__/samples/index.test.js
@@ -2,7 +2,7 @@
  * This file has been extracted and modified from Swagger UI.
  *
  * @license Apache 2.0
- * @link https://github.com/swagger-api/swagger-ui/blob/master/test/unit/core/plugins/samples/fn.js
+ * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/test/unit/core/plugins/samples/fn.js}
  */
 const { sampleFromSchema } = require('../../src/samples');
 

--- a/src/index.js
+++ b/src/index.js
@@ -481,7 +481,7 @@ class Oas {
   /**
    * With an object of user information, retrieve an appropriate API key from the current OAS definition.
    *
-   * @link https://docs.readme.com/docs/passing-data-to-jwt
+   * @see {@link https://docs.readme.com/docs/passing-data-to-jwt}
    * @param {Object} user
    * @param {Boolean|String} selectedApp
    * @return {Object}
@@ -501,8 +501,8 @@ class Oas {
    * Returns the `paths` object that exists in this API definition but with every `method` mapped to an instance of
    * the `Operation` class.
    *
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    * @returns {object}
    */
   getPaths() {
@@ -529,8 +529,8 @@ class Oas {
    * Returns the `webhooks` object that exists in this API definition but with every `method` mapped to an instance of
    * the `Operation` class.
    *
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    * @returns {object}
    */
   getWebhooks() {
@@ -551,8 +551,8 @@ class Oas {
    *
    * Note: This method right now does **not** factor in webhooks that have tags.
    *
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    * @param {boolean} setIfMissing If a tag is not present on an operation that operations path will be added into the
    *    list of tags returned.
    * @returns {array}

--- a/src/lib/get-mediatype-examples.js
+++ b/src/lib/get-mediatype-examples.js
@@ -6,7 +6,7 @@ const matchesMimeType = require('./matches-mimetype');
  * property, the first item in an `examples` array, or if none of those are present it will generate an example based
  * off its schema.
  *
- * @link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject}
  * @param {string} mediaType
  * @param {object} mediaTypeObject
  * @param {object} opts Configuration for controlling `includeReadOnly` and `includeWriteOnly`.

--- a/src/lib/openapi-to-json-schema.js
+++ b/src/lib/openapi-to-json-schema.js
@@ -7,7 +7,7 @@ const jsonpointer = require('jsonpointer');
  * `readOnly` aren't represented within JSON Schema, we support it within that library's handling of OpenAPI-friendly
  * JSON Schema.
  *
- * @link https://github.com/openapi-contrib/openapi-schema-to-json-schema/blob/master/index.js#L23-L27
+ * @see {@link https://github.com/openapi-contrib/openapi-schema-to-json-schema/blob/master/index.js#L23-L27}
  */
 const UNSUPPORTED_SCHEMA_PROPS = [
   'nullable',
@@ -23,7 +23,7 @@ const UNSUPPORTED_SCHEMA_PROPS = [
 /**
  * List partially sourced from `openapi-schema-to-json-schema`.
  *
- * @link https://github.com/openapi-contrib/openapi-schema-to-json-schema/blob/master/lib/converters/schema.js#L140-L154
+ * @see {@link https://github.com/openapi-contrib/openapi-schema-to-json-schema/blob/master/lib/converters/schema.js#L140-L154}
  */
 const FORMAT_OPTIONS = {
   INT8_MIN: 0 - 2 ** 7, // -128
@@ -54,7 +54,7 @@ const FORMAT_OPTIONS = {
 /**
  * Take a string and encode it to be used as a JSON pointer.
  *
- * @link https://tools.ietf.org/html/rfc6901
+ * @see {@link https://tools.ietf.org/html/rfc6901}
  * @param {String} str
  * @returns {String}
  */
@@ -108,7 +108,7 @@ function isRequestBodySchema(schema) {
  * That said, any example is usually better than no example though, so while it's quirky behavior it shouldn't raise
  * immediate cause for alarm.
  *
- * @link https://tools.ietf.org/html/rfc6901
+ * @see {@link https://tools.ietf.org/html/rfc6901}
  * @param {String} pointer
  * @param {Object[]} examples
  * @returns {(undefined|*)}
@@ -195,8 +195,8 @@ function searchForExampleByPointer(pointer, examples = []) {
  * of API definitions in our database that aren't currently valid so we need to have a lot of bespoke handling for odd
  * quirks, typos, and missing declarations that they've got.
  *
- * @link https://json-schema.org/draft/2019-09/json-schema-validation.html
- * @link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md
+ * @see {@link https://json-schema.org/draft/2019-09/json-schema-validation.html{}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md}
  * @param {Object} data
  * @param {Object} opts
  * @param {String} opts.currentLocation - Current location within the schema -- this is a JSON pointer.

--- a/src/operation.js
+++ b/src/operation.js
@@ -81,8 +81,8 @@ class Operation {
   }
 
   /**
-   * @link https://swagger.io/docs/specification/authentication/#multiple
-   * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object
+   * @see {@link https://swagger.io/docs/specification/authentication/#multiple}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object}
    * @param {boolean} filterInvalid Optional flag that, when set to `true`, filters out invalid/nonexistent security
    *    schemes, rather than returning `false`.
    * @returns {array} An array of arrays of objects of grouped security schemes. The inner array determines and-grouped
@@ -409,7 +409,7 @@ class Operation {
     const callback = this.schema.callbacks[identifier] ? this.schema.callbacks[identifier][expression] : false;
     if (!callback || !callback[method]) return false;
     // eslint-disable-next-line no-use-before-define
-    return new Callback(this.oas, expression, method, callback[method]);
+    return new Callback(this.oas, expression, method, callback[method], identifier);
   }
 
   /**
@@ -428,6 +428,7 @@ class Operation {
         });
       });
     });
+
     return callbackOperations;
   }
 
@@ -446,7 +447,26 @@ class Operation {
   }
 }
 
-class Callback extends Operation {}
+class Callback extends Operation {
+  constructor(oas, path, method, operation, identifier) {
+    super(oas, path, method, operation);
+
+    this.identifier = identifier;
+  }
+
+  /**
+   * Return the primary identifier for this callback.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject}
+   *
+   * @returns {string}
+   */
+  getIdentifier() {
+    return this.identifier;
+  }
+}
+
 class Webhook extends Operation {}
 
 module.exports = Operation;

--- a/src/operation/get-callback-examples.js
+++ b/src/operation/get-callback-examples.js
@@ -6,17 +6,17 @@ const getResponseExamples = require('./get-response-examples');
 module.exports = operation => {
   // spreads the contents of the map for each callback so there's not nested arrays returned
   return [].concat(
-    ...Object.keys(operation.callbacks || {}).map(callback => {
+    ...Object.keys(operation.callbacks || {}).map(identifier => {
       // spreads the contents again so there's not nested arrays returned
       return []
         .concat(
-          ...Object.keys(operation.callbacks[callback]).map(expression => {
-            return Object.keys(operation.callbacks[callback][expression]).map(method => {
-              const example = getResponseExamples(operation.callbacks[callback][expression][method]);
+          ...Object.keys(operation.callbacks[identifier]).map(expression => {
+            return Object.keys(operation.callbacks[identifier][expression]).map(method => {
+              const example = getResponseExamples(operation.callbacks[identifier][expression][method]);
               if (example.length === 0) return false;
 
               return {
-                identifier: callback,
+                identifier,
                 expression,
                 method,
                 example,

--- a/src/operation/get-response-as-json-schema.js
+++ b/src/operation/get-response-as-json-schema.js
@@ -4,7 +4,7 @@ const { json: isJSON } = require('../lib/matches-mimetype');
 /**
  * Turn a header map from oas 3.0.3 (and some earlier versions too) into a schema. Does not cover 3.1.0's header format
  *
- * @link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#headerObject
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#headerObject}
  * @param {object} response
  * @returns object
  */

--- a/src/samples/index.js
+++ b/src/samples/index.js
@@ -2,7 +2,7 @@
  * This file has been extracted and modified from Swagger UI.
  *
  * @license Apache 2.0
- * @link https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/samples/fn.js
+ * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/samples/fn.js}
  */
 
 const { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } = require('./utils');

--- a/src/samples/utils.js
+++ b/src/samples/utils.js
@@ -2,7 +2,7 @@
  * Portions of this file have been extracted and modified from Swagger UI.
  *
  * @license Apache 2.0
- * @link https://github.com/swagger-api/swagger-ui/blob/master/src/core/utils.js
+ * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/src/core/utils.js}
  */
 
 function isObject(obj) {


### PR DESCRIPTION
## 🧰 Changes

* [x] Updates the `Callback` constructor to take a new argument for `identifier`.
* [x] Adds a `getIdentifier()` accessor to retrieve this data.
* [x] Updates some `@link` comments to be the proper JSDoc `@see {@link ...}` way to document it.

## 🧬 QA & Testing

See tests.