### PR TITLE
refactor: don't pull required deprecated params out to deprecatedProps

### DIFF
--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
@@ -108,20 +108,6 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paramet
             ],
             "type": "string",
           },
-          "status": Object {
-            "deprecated": true,
-            "items": Object {
-              "default": "available",
-              "deprecated": true,
-              "enum": Array [
-                "available",
-                "pending",
-                "sold",
-              ],
-              "type": "string",
-            },
-            "type": "array",
-          },
         },
         "required": Array [
           "status",
@@ -140,6 +126,20 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paramet
             "inactive",
           ],
           "type": "string",
+        },
+        "status": Object {
+          "deprecated": true,
+          "items": Object {
+            "default": "available",
+            "deprecated": true,
+            "enum": Array [
+              "available",
+              "pending",
+              "sold",
+            ],
+            "type": "string",
+          },
+          "type": "array",
         },
       },
       "required": Array [
@@ -185,24 +185,6 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-
             "maximum": 9223372036854776000,
             "minimum": -9223372036854776000,
             "type": "integer",
-          },
-          "name": Object {
-            "deprecated": true,
-            "examples": Array [
-              "doggie",
-            ],
-            "type": "string",
-          },
-          "photoUrls": Object {
-            "deprecated": true,
-            "items": Object {
-              "deprecated": true,
-              "examples": Array [
-                "https://example.com/photo.png",
-              ],
-              "type": "string",
-            },
-            "type": "array",
           },
           "status": Object {
             "deprecated": true,
@@ -263,6 +245,24 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-
           },
           "type": "object",
           "x-readme-ref-name": "Category",
+        },
+        "name": Object {
+          "deprecated": true,
+          "examples": Array [
+            "doggie",
+          ],
+          "type": "string",
+        },
+        "photoUrls": Object {
+          "deprecated": true,
+          "items": Object {
+            "deprecated": true,
+            "examples": Array [
+              "https://example.com/photo.png",
+            ],
+            "type": "string",
+          },
+          "type": "array",
         },
         "polymorphism": Object {
           "properties": Object {

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -681,7 +681,7 @@ describe('deprecated', () => {
       deprecatedSchema.required.forEach(requiredParam => {
         expect(requiredParam in deprecatedSchema.properties).toBe(false);
       });
-      expect(Object.keys(deprecatedSchema.properties)).toHaveLength(4); 
+      expect(Object.keys(deprecatedSchema.properties)).toHaveLength(4);
     });
   });
 

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -636,7 +636,6 @@ describe('deprecated', () => {
             pathId: {
               name: 'pathId',
               in: 'path',
-              required: true,
               deprecated: true,
               schema: {
                 type: 'integer',
@@ -649,7 +648,8 @@ describe('deprecated', () => {
 
       await oas.dereference();
 
-      expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].deprecatedProps.schema).toStrictEqual({
+      const schem = oas.operation('/', 'get').getParametersAsJsonSchema();
+      expect(schem[0].deprecatedProps.schema).toStrictEqual({
         type: 'object',
         properties: {
           pathId: {
@@ -660,7 +660,7 @@ describe('deprecated', () => {
             deprecated: true,
           },
         },
-        required: ['pathId'],
+        required: [],
       });
     });
 
@@ -670,6 +670,18 @@ describe('deprecated', () => {
       const operation = oas.operation('/anything', 'post');
 
       expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+    });
+
+    it('should not put required deprecated parameters in deprecatedProps', async () => {
+      const oas = new Oas(deprecated);
+      await oas.dereference();
+      const operation = oas.operation('/anything', 'post');
+      const deprecatedSchema = operation.getParametersAsJsonSchema()[1].deprecatedProps.schema;
+
+      deprecatedSchema.required.forEach(requiredParam => {
+        expect(requiredParam in deprecatedSchema.properties).toBe(false);
+      });
+      expect(Object.keys(deprecatedSchema.properties)).toHaveLength(4); 
     });
   });
 

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -647,9 +647,7 @@ describe('deprecated', () => {
       );
 
       await oas.dereference();
-
-      const schem = oas.operation('/', 'get').getParametersAsJsonSchema();
-      expect(schem[0].deprecatedProps.schema).toStrictEqual({
+      expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].deprecatedProps.schema).toStrictEqual({
         type: 'object',
         properties: {
           pathId: {

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -39,7 +39,7 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
     const deprecatedBody = cloneObject(schema);
     const requiredParams = schema.required || [];
 
-    // Find all top-level deprecated properties from the schema - required params are excludedkitchen-
+    // Find all top-level deprecated properties from the schema - required params are excluded
     const allDeprecatedProps = {};
     Object.keys(deprecatedBody.properties).forEach(key => {
       if (deprecatedBody.properties[key].deprecated && !requiredParams.includes(key)) {

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -37,11 +37,12 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
     if (!schema || !schema.properties) return null;
     // Clone the original schema so this doesn't interfere with it
     const deprecatedBody = cloneObject(schema);
+    const requiredParams = schema.required || [];
 
-    // Find all top-level deprecated properties from the schema
+    // Find all top-level deprecated properties from the schema - required params are excludedkitchen-
     const allDeprecatedProps = {};
     Object.keys(deprecatedBody.properties).forEach(key => {
-      if (deprecatedBody.properties[key].deprecated) {
+      if (deprecatedBody.properties[key].deprecated && !requiredParams.includes(key)) {
         allDeprecatedProps[key] = deprecatedBody.properties[key];
       }
     });
@@ -57,7 +58,7 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
     // Remove deprecated properties from the original schema
     // Not using the clone here becuase we WANT this to affect the original
     Object.keys(schema.properties).forEach(key => {
-      if (schema.properties[key].deprecated) delete schema.properties[key];
+      if (schema.properties[key].deprecated && !requiredParams.includes(key)) delete schema.properties[key];
     });
 
     return {


### PR DESCRIPTION
## 🧰 Changes

Required params were getting put under the accordion along with everything else, this stops them from being pulled so we aren't hiding anything that is top-level required. Works by checking to make sure the param doesn't exist in the `required` array in the schema before pulling & deleting it 

## 🧬 QA & Testing
see tests (refactored some + added test to check for required params) 
