### PR TITLE
refactor: changing how the Oas class internally stores its API definition

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -727,17 +727,10 @@ Object {
 
 exports[`#operation() should return a default when no operation 1`] = `
 Operation {
+  "api": Object {},
   "callbackExamples": undefined,
   "contentType": undefined,
   "method": "get",
-  "oas": Oas {
-    "_dereferencing": Object {
-      "complete": false,
-      "processing": false,
-    },
-    "_promises": Array [],
-    "user": Object {},
-  },
   "path": "/unknown",
   "requestBodyExamples": undefined,
   "responseExamples": undefined,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,6 @@
-const Oas = require('..');
+const Oas = require('../src');
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
-const { Operation, Webhook, utils } = require('..');
+const { Operation, Webhook, utils } = require('../src');
 
 const swagger = require('@readme/oas-examples/2.0/json/petstore.json');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
@@ -25,7 +25,7 @@ test('should be able to access properties on oas', () => {
   expect(
     new Oas({
       info: { version: '1.0' },
-    }).info.version
+    }).api.info.version
   ).toBe('1.0');
 });
 
@@ -247,7 +247,6 @@ describe('#splitUrl()', () => {
     ]);
   });
 
-  // Taken from here: https://github.com/readmeio/readme/blob/09ab5aab1836ec1b63d513d902152aa7cfac6e4d/packages/explorer/__tests__/PathUrl.test.jsx#L99-L111
   it('should work for multiple path params', () => {
     expect(
       new Oas({
@@ -711,7 +710,7 @@ describe('#findOperation()', () => {
     const uri = 'https://demo.example.com:443/v2/post';
     const method = 'post';
 
-    expect(oas.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
+    expect(oas.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
 
     const res = oas.findOperation(uri, method);
     expect(res.url).toMatchObject({
@@ -722,7 +721,7 @@ describe('#findOperation()', () => {
       method: 'POST',
     });
 
-    expect(oas.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
+    expect(oas.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
   });
 
   describe('quirks', () => {
@@ -1131,19 +1130,19 @@ describe('#dereference()', () => {
   it('should dereference the current OAS', async () => {
     const oas = new Oas(petstore);
 
-    expect(oas.paths['/pet'].post.requestBody).toStrictEqual({
+    expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
       $ref: '#/components/requestBodies/Pet',
     });
 
     await oas.dereference();
 
-    expect(oas.paths['/pet'].post.requestBody).toStrictEqual({
+    expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
       content: {
         'application/json': {
-          schema: oas.components.schemas.Pet,
+          schema: oas.api.components.schemas.Pet,
         },
         'application/xml': {
-          schema: oas.components.schemas.Pet,
+          schema: oas.api.components.schemas.Pet,
         },
       },
       description: 'Pet object that needs to be added to the store',
@@ -1156,10 +1155,12 @@ describe('#dereference()', () => {
     await oas.dereference();
 
     expect(
-      oas.paths['/multischema/of-everything'].post.requestBody.content['application/json'].schema['x-readme-ref-name']
+      oas.api.paths['/multischema/of-everything'].post.requestBody.content['application/json'].schema[
+        'x-readme-ref-name'
+      ]
     ).toBe('MultischemaOfEverything');
 
-    expect(oas.paths).toMatchSnapshot();
+    expect(oas.api.paths).toMatchSnapshot();
   });
 
   it('should retain the user object when dereferencing', async () => {
@@ -1173,7 +1174,7 @@ describe('#dereference()', () => {
 
     await oas.dereference();
 
-    expect(oas.paths['/pet'].post.requestBody).toStrictEqual({
+    expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
       content: expect.any(Object),
       description: 'Pet object that needs to be added to the store',
       required: true,
@@ -1191,7 +1192,7 @@ describe('#dereference()', () => {
     await oas.dereference();
 
     // $refs should remain in the OAS because they're circular and are ignored.
-    expect(oas.paths['/'].get).toStrictEqual({
+    expect(oas.api.paths['/'].get).toStrictEqual({
       responses: {
         200: {
           description: 'OK',
@@ -1221,7 +1222,7 @@ describe('#dereference()', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(oas._dereferencing).toStrictEqual({ processing: false, complete: true });
-      expect(oas.paths['/pet'].post.requestBody).not.toStrictEqual({
+      expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
         $ref: '#/components/requestBodies/Pet',
       });
 
@@ -1234,13 +1235,13 @@ describe('#dereference()', () => {
 
       await oas.dereference();
       expect(oas._dereferencing).toStrictEqual({ processing: false, complete: true });
-      expect(oas.paths['/pet'].post.requestBody).not.toStrictEqual({
+      expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
         $ref: '#/components/requestBodies/Pet',
       });
 
       await oas.dereference();
       expect(oas._dereferencing).toStrictEqual({ processing: false, complete: true });
-      expect(oas.paths['/pet'].post.requestBody).not.toStrictEqual({
+      expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
         $ref: '#/components/requestBodies/Pet',
       });
 

--- a/__tests__/lib/openapi-to-json-schema.test.js
+++ b/__tests__/lib/openapi-to-json-schema.test.js
@@ -803,7 +803,7 @@ describe('`example` / `examples` support', () => {
 
       await oas.dereference();
 
-      oas.paths['/pet'].post.requestBody.content['application/json'][exampleProp] = createExample({
+      oas.api.paths['/pet'].post.requestBody.content['application/json'][exampleProp] = createExample({
         id: 20,
         name: 'buster',
         photoUrls: ['https://example.com/dog.png'],

--- a/__tests__/operation.test.js
+++ b/__tests__/operation.test.js
@@ -1,5 +1,5 @@
-const Oas = require('..');
-const { Operation, Callback } = require('..');
+const Oas = require('../src');
+const { Operation, Callback } = require('../src');
 const petstore = require('@readme/oas-examples/3.0/json/petstore.json');
 const callbackSchema = require('./__datasets__/callbacks.json');
 const multipleSecurities = require('./__datasets__/multiple-securities.json');
@@ -439,7 +439,7 @@ describe('#prepareSecurity()', () => {
     const operation = oas.operation(path, method);
 
     expect(operation.prepareSecurity()).toStrictEqual({
-      Basic: [oas.components.securitySchemes.securityScheme],
+      Basic: [oas.api.components.securitySchemes.securityScheme],
     });
   });
 
@@ -453,7 +453,7 @@ describe('#prepareSecurity()', () => {
     const operation = oas.operation(path, method);
 
     expect(operation.prepareSecurity()).toStrictEqual({
-      Bearer: [oas.components.securitySchemes.securityScheme],
+      Bearer: [oas.api.components.securitySchemes.securityScheme],
     });
   });
 
@@ -467,7 +467,7 @@ describe('#prepareSecurity()', () => {
     const operation = oas.operation(path, method);
 
     expect(operation.prepareSecurity()).toStrictEqual({
-      Query: [oas.components.securitySchemes.securityScheme],
+      Query: [oas.api.components.securitySchemes.securityScheme],
     });
   });
 
@@ -481,7 +481,7 @@ describe('#prepareSecurity()', () => {
     const operation = oas.operation(path, method);
 
     expect(operation.prepareSecurity()).toStrictEqual({
-      Header: [oas.components.securitySchemes.securityScheme],
+      Header: [oas.api.components.securitySchemes.securityScheme],
     });
   });
 
@@ -495,7 +495,7 @@ describe('#prepareSecurity()', () => {
     const operation = oas.operation(path, method);
 
     expect(operation.prepareSecurity()).toStrictEqual({
-      Cookie: [oas.components.securitySchemes.securityScheme],
+      Cookie: [oas.api.components.securitySchemes.securityScheme],
     });
   });
 
@@ -558,7 +558,7 @@ describe('#getHeaders()', () => {
     const method = 'DELETE';
 
     const logOperation = oas.findOperation(uri, method);
-    const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+    const operation = new Operation(oas.api, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
     expect(operation.getHeaders()).toMatchObject({
       request: ['api_key'],
@@ -572,7 +572,7 @@ describe('#getHeaders()', () => {
     const method = 'POST';
 
     const logOperation = oas.findOperation(uri, method);
-    const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+    const operation = new Operation(oas.api, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
     expect(operation.getHeaders(true)).toMatchObject({
       request: ['Content-Type'],
@@ -586,7 +586,7 @@ describe('#getHeaders()', () => {
     const method = 'GET';
 
     const logOperation = oas.findOperation(uri, method);
-    const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+    const operation = new Operation(oas.api, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
     expect(operation.getHeaders(true)).toMatchObject({
       request: ['Accept'],
@@ -600,7 +600,7 @@ describe('#getHeaders()', () => {
     const method = 'POST';
 
     const logOperation = oas.findOperation(uri, method);
-    const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+    const operation = new Operation(oas.api, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
     expect(operation.getHeaders()).toMatchObject({
       request: ['testKey'],
@@ -614,7 +614,7 @@ describe('#getHeaders()', () => {
     const method = 'GET';
 
     const logOperation = oas.findOperation(uri, method);
-    const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+    const operation = new Operation(oas.api, logOperation.url.path, logOperation.url.method, logOperation.operation);
 
     expect(operation.getHeaders()).toMatchObject({
       request: ['Authorization', 'Cookie', 'Accept'],
@@ -628,7 +628,7 @@ describe('#getHeaders()', () => {
     const method = 'GET';
 
     const logOperation = oas.findOperation(uri, method);
-    const operation = new Operation(oas, logOperation.url.path, logOperation.url.method, logOperation.operation);
+    const operation = new Operation(oas.api, logOperation.url.path, logOperation.url.method, logOperation.operation);
     expect(operation.getHeaders()).toMatchObject({
       request: ['hostname', 'Accept'],
       response: ['Content-Type'],

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -240,7 +240,7 @@ describe('parameters', () => {
       const operation = oas.operation('/pet/{petId}', 'get');
 
       expect(operation.getParametersAsJsonSchema()[0].schema.properties.petId.description).toBe(
-        oas.paths['/pet/{petId}'].parameters[0].description
+        oas.api.paths['/pet/{petId}'].parameters[0].description
       );
     });
 
@@ -275,7 +275,7 @@ describe('parameters', () => {
 
       expect(
         oas.operation('/pet/{petId}', 'get').getParametersAsJsonSchema()[0].schema.properties.petId.description
-      ).toBe(oas.components.parameters.petId.description);
+      ).toBe(oas.api.components.parameters.petId.description);
     });
   });
 });

--- a/src/lib/get-auth.ts
+++ b/src/lib/get-auth.ts
@@ -66,18 +66,18 @@ function getByScheme(user: User, scheme = <SecurityScheme | any>{}, selectedApp?
 export { getByScheme };
 
 export default function getAuth(
-  oas: OpenAPIV3.Document | OpenAPIV3_1.Document,
+  api: OpenAPIV3.Document | OpenAPIV3_1.Document,
   user: User,
   selectedApp?: selectedAppType
 ): Record<string, unknown> {
-  return Object.keys(oas.components.securitySchemes)
+  return Object.keys(api.components.securitySchemes)
     .map(scheme => {
       return {
         [scheme]: getByScheme(
           user,
           {
             // This sucks but since we dereference we'll never a `$ref` pointer here with a `ReferenceObject` type.
-            ...(oas.components.securitySchemes[scheme] as SecuritySchemeObject),
+            ...(api.components.securitySchemes[scheme] as SecuritySchemeObject),
             _key: scheme,
           },
           selectedApp

--- a/src/lib/get-schema.js
+++ b/src/lib/get-schema.js
@@ -5,7 +5,7 @@ const findSchemaDefinition = require('./find-schema-definition').default;
 //
 // If the ref looks like a `requestBodies` reference, then do a lookup for the actual schema
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-8
-module.exports = function getSchema(pathOperation, oas) {
+module.exports = function getSchema(pathOperation, api) {
   try {
     if (pathOperation.requestBody.content) {
       const type = Object.keys(pathOperation.requestBody.content)[0];
@@ -18,7 +18,7 @@ module.exports = function getSchema(pathOperation, oas) {
 
     if (pathOperation.requestBody && pathOperation.requestBody.$ref.match(/^#\/components\/requestBodies\/.*$/)) {
       return getSchema({
-        requestBody: findSchemaDefinition(pathOperation.requestBody.$ref, oas),
+        requestBody: findSchemaDefinition(pathOperation.requestBody.$ref, api),
       });
     }
 

--- a/src/operation/get-parameters-as-json-schema.js
+++ b/src/operation/get-parameters-as-json-schema.js
@@ -21,11 +21,11 @@ function cloneObject(obj) {
 /**
  * @param {string} path
  * @param {Operation} operation
- * @param {Oas} oas
+ * @param {OpenAPI.Document} api
  * @param {Object} globalDefaults
  * @returns {array<object>}
  */
-module.exports = (path, operation, oas, globalDefaults = {}) => {
+module.exports = (path, operation, api, globalDefaults = {}) => {
   let hasCircularRefs = false;
 
   function refLogger() {
@@ -68,7 +68,7 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
   }
 
   function getRequestBody() {
-    const schema = getSchema(operation, oas);
+    const schema = getSchema(operation, api);
     if (!schema || !schema.schema) return null;
 
     const type = schema.type === 'application/x-www-form-urlencoded' ? 'formData' : 'body';
@@ -105,27 +105,27 @@ module.exports = (path, operation, oas, globalDefaults = {}) => {
   }
 
   function getCommonParams() {
-    if (oas && 'paths' in oas && path in oas.paths && 'parameters' in oas.paths[path]) {
-      return oas.paths[path].parameters;
+    if (api && 'paths' in api && path in api.paths && 'parameters' in api.paths[path]) {
+      return api.paths[path].parameters;
     }
 
     return [];
   }
 
   function getComponents() {
-    if (!('components' in oas)) {
+    if (!('components' in api)) {
       return false;
     }
 
     const components = {};
-    Object.keys(oas.components).forEach(componentType => {
-      if (typeof oas.components[componentType] === 'object' && !Array.isArray(oas.components[componentType])) {
+    Object.keys(api.components).forEach(componentType => {
+      if (typeof api.components[componentType] === 'object' && !Array.isArray(api.components[componentType])) {
         if (typeof components[componentType] === 'undefined') {
           components[componentType] = {};
         }
 
-        Object.keys(oas.components[componentType]).forEach(schemaName => {
-          const componentSchema = cloneObject(oas.components[componentType][schemaName]);
+        Object.keys(api.components[componentType]).forEach(schemaName => {
+          const componentSchema = cloneObject(api.components[componentType][schemaName]);
           components[componentType][schemaName] = toJSONSchema(componentSchema, { globalDefaults, refLogger });
         });
       }

--- a/src/operation/get-response-as-json-schema.js
+++ b/src/operation/get-response-as-json-schema.js
@@ -44,11 +44,11 @@ function buildHeadersSchema(response) {
  * Note: This expects a dereferenced schema.
  *
  * @param {Operation} operation
- * @param {Oas} oas
+ * @param {OpenAPI.Document} oas
  * @param {String} statusCode
  * @returns Array<{schema: Object, type: string, label: string}>
  */
-module.exports = function getResponseAsJsonSchema(operation, oas, statusCode) {
+module.exports = function getResponseAsJsonSchema(operation, api, statusCode) {
   const response = operation.getResponseByStatusCode(statusCode);
   const jsonSchema = [];
 
@@ -103,8 +103,8 @@ module.exports = function getResponseAsJsonSchema(operation, oas, statusCode) {
     // **isn't** circular adds a ton of bloat so it'd be cool if `components` was just the remaining `$ref` pointers
     // that are still being referenced.
     // @todo
-    if (hasCircularRefs && oas.components && schemaWrapper.schema) {
-      schemaWrapper.schema.components = oas.components;
+    if (hasCircularRefs && api.components && schemaWrapper.schema) {
+      schemaWrapper.schema.components = api.components;
     }
 
     jsonSchema.push(schemaWrapper);


### PR DESCRIPTION
## 🧰 Changes

This changes how the core `Oas` class internally stores its API definition from storing it as an extension of `this` (making the instance the API definition essentially) to storing that API definition inside of a new `api` property.

Why do this? As we're slowly typing the library with Typescript it's become more and more of a problem to type the this `Oas` class as a mix of `Oas` and `OpenAPI.Document`, and there are a lot of hoops, that are likely going to be flaky, that we've had to jump through to get it sort of functional. This refactor should make this Typescript transition a little smoother.

This will be a breaking change when it's eventually published.

## 🧬 QA & Testing

Tests all still pass?