### PR TITLE
feat: addition of an `init` and methods for pulling spec extensions

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1411,3 +1411,23 @@ describe('#getTags()', () => {
     });
   });
 });
+
+describe('#getExtension()', () => {
+  it('should return the extension if it exists', () => {
+    const oas = Oas.init({
+      ...petstore,
+      'x-readme': {
+        'proxy-enabled': true,
+      },
+    });
+
+    expect(oas.getExtension('x-readme')).toStrictEqual({
+      'proxy-enabled': true,
+    });
+  });
+
+  it("should return nothing if the extension doesn't exist", () => {
+    const oas = Oas.init(petstore);
+    expect(oas.getExtension('x-readme')).toBeUndefined();
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -21,69 +21,78 @@ test('should export utils', () => {
 });
 
 test('should be able to access properties on the class instance', () => {
-  expect(new Oas(petstore as RMOAS.OASDocument).api.info.version).toBe('1.0.0');
+  expect(Oas.init(petstore).api.info.version).toBe('1.0.0');
+});
+
+test('should be able to accept an `RMOAS.OASDocument` in the constructor', () => {
+  expect(new Oas(webhooks as RMOAS.OASDocument).getVersion()).toBe('3.1.0');
+});
+
+describe('#init()', () => {
+  it('should return an instance of Oas with a user', () => {
+    const user = { username: 'buster' };
+    const oas = Oas.init(petstore, user);
+
+    expect(oas).toBeInstanceOf(Oas);
+    expect(oas.api).toStrictEqual(petstore);
+    expect(oas.user).toStrictEqual(user);
+  });
 });
 
 describe('#getVersion()', () => {
   it('should be able to identify an OpenAPI definition', () => {
-    expect(new Oas(petstore as RMOAS.OASDocument).getVersion()).toBe('3.0.0');
-    expect(new Oas(webhooks as RMOAS.OASDocument).getVersion()).toBe('3.1.0');
+    expect(Oas.init(petstore).getVersion()).toBe('3.0.0');
+    expect(Oas.init(webhooks).getVersion()).toBe('3.1.0');
   });
 
   it('should throw an error if unable to identify', () => {
     expect(() => {
-      return new Oas({} as RMOAS.OASDocument).getVersion();
+      return Oas.init({}).getVersion();
     }).toThrow('Unable to recognize what specification version this API definition conforms to.');
   });
 });
 
 describe('#url([selected])', () => {
   it('should trim surrounding whitespace from the url', () => {
-    expect(new Oas({ servers: [{ url: '  http://example.com/' }] } as RMOAS.OASDocument).url()).toBe(
-      'http://example.com'
-    );
+    expect(Oas.init({ servers: [{ url: '  http://example.com/' }] }).url()).toBe('http://example.com');
   });
 
   it('should remove end slash from the server URL', () => {
-    expect(new Oas({ servers: [{ url: 'http://example.com/' }] } as RMOAS.OASDocument).url()).toBe(
-      'http://example.com'
-    );
+    expect(Oas.init({ servers: [{ url: 'http://example.com/' }] }).url()).toBe('http://example.com');
   });
 
   it('should default missing servers array to example.com', () => {
-    expect(new Oas({} as RMOAS.OASDocument).url()).toBe('https://example.com');
+    expect(Oas.init({}).url()).toBe('https://example.com');
   });
 
   it('should default empty servers array to example.com', () => {
-    expect(new Oas({ servers: [] } as RMOAS.OASDocument).url()).toBe('https://example.com');
+    expect(Oas.init({ servers: [] }).url()).toBe('https://example.com');
   });
 
   it('should default empty server object to example.com', () => {
-    expect(new Oas({ servers: [{}] } as RMOAS.OASDocument).url()).toBe('https://example.com');
+    expect(Oas.init({ servers: [{}] }).url()).toBe('https://example.com');
   });
 
   it('should add https:// if url starts with //', () => {
-    expect(new Oas({ servers: [{ url: '//example.com' }] } as RMOAS.OASDocument).url()).toBe('https://example.com');
+    expect(Oas.init({ servers: [{ url: '//example.com' }] }).url()).toBe('https://example.com');
   });
 
   it('should add https:// if url does not start with a protocol', () => {
-    expect(new Oas({ servers: [{ url: 'example.com' }] } as RMOAS.OASDocument).url()).toBe('https://example.com');
+    expect(Oas.init({ servers: [{ url: 'example.com' }] }).url()).toBe('https://example.com');
   });
 
   it('should accept an index for servers selection', () => {
-    expect(
-      new Oas({ servers: [{ url: 'example.com' }, { url: 'https://api.example.com' }] } as RMOAS.OASDocument).url(1)
-    ).toBe('https://api.example.com');
-  });
-
-  it('should default to first if selected is not valid', () => {
-    expect(new Oas({ servers: [{ url: 'https://example.com' }] } as RMOAS.OASDocument).url(10)).toBe(
-      'https://example.com'
+    expect(Oas.init({ servers: [{ url: 'example.com' }, { url: 'https://api.example.com' }] }).url(1)).toBe(
+      'https://api.example.com'
     );
   });
 
+  it('should default to first if selected is not valid', () => {
+    expect(Oas.init({ servers: [{ url: 'https://example.com' }] }).url(10)).toBe('https://example.com');
+  });
+
   it('should make example.com the origin if none is present', () => {
-    expect(new Oas({ servers: [{ url: '/api/v3' }] } as RMOAS.OASDocument).url()).toBe('https://example.com/api/v3');
+    expect(Oas.init({ servers: [{ url: '/api/v3' }] }).url()).toBe('https://example.com/api/v3');
   });
 
   describe('server variables', () => {
@@ -189,9 +198,7 @@ describe('#url([selected])', () => {
 
     // Test encodeURI
     it('should pass through if no default set', () => {
-      expect(new Oas({ servers: [{ url: 'https://example.com/{path}' }] } as RMOAS.OASDocument).url()).toBe(
-        'https://example.com/{path}'
-      );
+      expect(Oas.init({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe('https://example.com/{path}');
     });
   });
 });
@@ -200,17 +207,17 @@ describe('#replaceUrl()', () => {
   const url = 'https://{name}.example.com:{port}/{basePath}';
 
   it('should pull data from user variables', () => {
-    const oas = new Oas({} as RMOAS.OASDocument, { name: 'mysubdomain', port: '8000', basePath: 'v5' });
+    const oas = Oas.init({}, { name: 'mysubdomain', port: '8000', basePath: 'v5' });
     expect(oas.replaceUrl(url)).toBe('https://mysubdomain.example.com:8000/v5');
   });
 
   it('should use template names as variables if no variables are supplied', () => {
-    expect(new Oas({} as RMOAS.OASDocument).replaceUrl(url)).toBe(url);
+    expect(Oas.init({}).replaceUrl(url)).toBe(url);
   });
 
   it('should allow variables to come in as an object of defaults from `oas.defaultVariables`', () => {
     expect(
-      new Oas({} as RMOAS.OASDocument).replaceUrl(url, {
+      Oas.init({}).replaceUrl(url, {
         name: {
           default: 'demo',
         },
@@ -226,7 +233,7 @@ describe('#replaceUrl()', () => {
 
   it('should allow variable key-value pairs to be supplied', () => {
     expect(
-      new Oas({} as RMOAS.OASDocument).replaceUrl(url, {
+      Oas.init({}).replaceUrl(url, {
         name: 'subdomain',
         port: '8080',
         basePath: 'v3',
@@ -236,7 +243,7 @@ describe('#replaceUrl()', () => {
 
   it('should not fail if the variable objects are in weird shapes', () => {
     expect(
-      new Oas({} as RMOAS.OASDocument).replaceUrl(url, {
+      Oas.init({}).replaceUrl(url, {
         name: {
           // This would normally have something like `default: 'demo'` but we're testing a weird case here.
         },
@@ -250,9 +257,9 @@ describe('#replaceUrl()', () => {
 describe('#splitUrl()', () => {
   it('should split url into chunks', () => {
     expect(
-      new Oas({
+      Oas.init({
         servers: [{ url: 'https://example.com/{path}' }],
-      } as RMOAS.OASDocument).splitUrl()
+      }).splitUrl()
     ).toStrictEqual([
       { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
       { key: 'path-1', type: 'variable', value: 'path', description: undefined, enum: undefined },
@@ -261,23 +268,23 @@ describe('#splitUrl()', () => {
 
   it('should work for multiple path params', () => {
     expect(
-      new Oas({
+      Oas.init({
         servers: [{ url: 'https://example.com/{a}/{b}/c' }],
-      } as RMOAS.OASDocument).splitUrl()
+      }).splitUrl()
     ).toHaveLength(5);
 
     expect(
-      new Oas({
+      Oas.init({
         servers: [{ url: 'https://example.com/v1/flight/{FlightID}/sitezonetargeting/{SiteZoneTargetingID}' }],
-      } as RMOAS.OASDocument).splitUrl()
+      }).splitUrl()
     ).toHaveLength(4);
   });
 
   it('should create unique keys for duplicate values', () => {
     expect(
-      new Oas({
+      Oas.init({
         servers: [{ url: 'https://example.com/{test}/{test}' }],
-      } as RMOAS.OASDocument).splitUrl()
+      }).splitUrl()
     ).toStrictEqual([
       { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
       { key: 'test-1', type: 'variable', value: 'test', description: undefined, enum: undefined },
@@ -316,16 +323,16 @@ describe('#splitUrl()', () => {
 
 describe('#splitVariables()', () => {
   it('should return false if no match was found', () => {
-    expect(new Oas({} as RMOAS.OASDocument).splitVariables('https://local.dev')).toBe(false);
+    expect(Oas.init({}).splitVariables('https://local.dev')).toBe(false);
   });
 
   it('should not return any variables for a server url that has none', () => {
-    expect(
-      new Oas({ servers: [{ url: 'https://example.com' }] } as RMOAS.OASDocument).splitVariables('https://example.com')
-    ).toStrictEqual({
-      selected: 0,
-      variables: {},
-    });
+    expect(Oas.init({ servers: [{ url: 'https://example.com' }] }).splitVariables('https://example.com')).toStrictEqual(
+      {
+        selected: 0,
+        variables: {},
+      }
+    );
   });
 
   it('should find and return variables', () => {
@@ -488,7 +495,7 @@ describe('#defaultVariables([selected])', () => {
 
 describe('#operation()', () => {
   it('should return an Operation object', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'post');
+    const operation = Oas.init(petstore).operation('/pet', 'post');
 
     expect(operation).toBeInstanceOf(Operation);
     expect(operation.path).toBe('/pet');
@@ -506,7 +513,7 @@ describe('#operation()', () => {
   });
 
   it('should return a Webhook object for a webhook', () => {
-    const operation = new Oas(webhooks as RMOAS.OASDocument).operation('newPet', 'post', { isWebhook: true });
+    const operation = Oas.init(webhooks).operation('newPet', 'post', { isWebhook: true });
 
     expect(operation).toBeInstanceOf(Webhook);
     expect(operation.path).toBe('newPet');
@@ -520,23 +527,23 @@ describe('#operation()', () => {
   });
 
   it('should return a default when no operation', () => {
-    expect(new Oas({} as RMOAS.OASDocument).operation('/unknown', 'get')).toMatchSnapshot();
+    expect(Oas.init({}).operation('/unknown', 'get')).toMatchSnapshot();
   });
 
   it('should return an operation object with security if it has security', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'put');
+    const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.getSecurity()).toStrictEqual([{ petstore_auth: ['write:pets', 'read:pets'] }]);
   });
 
   it("should still return an operation object if the operation isn't found", () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'patch');
+    const operation = Oas.init(petstore).operation('/pet', 'patch');
     expect(operation.schema).toBeDefined();
   });
 });
 
 describe('#findOperation()', () => {
   it('should return undefined if no server found', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://localhost:3000/pet/1';
     const method = 'delete';
 
@@ -545,7 +552,7 @@ describe('#findOperation()', () => {
   });
 
   it('should return undefined if origin is correct but unable to extract path', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/';
     const method = 'get';
 
@@ -554,7 +561,7 @@ describe('#findOperation()', () => {
   });
 
   it('should return undefined if no path matches found', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/search';
     const method = 'get';
 
@@ -563,7 +570,7 @@ describe('#findOperation()', () => {
   });
 
   it('should return undefined if no matching methods in path', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/pet/1';
     const method = 'patch';
 
@@ -572,7 +579,7 @@ describe('#findOperation()', () => {
   });
 
   it('should return a result if found', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/pet/1';
     const method = 'delete';
 
@@ -590,7 +597,7 @@ describe('#findOperation()', () => {
   });
 
   it('should return normally if path is formatted poorly', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/pet/1/';
     const method = 'delete';
 
@@ -608,7 +615,7 @@ describe('#findOperation()', () => {
   });
 
   it('should return object if query string is included', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/pet/findByStatus?test=2';
     const method = 'get';
 
@@ -744,7 +751,7 @@ describe('#findOperation()', () => {
   });
 
   it('should render any target server variable defaults', () => {
-    const oas = new Oas(petstoreServerVars as RMOAS.OASDocument);
+    const oas = Oas.init(petstoreServerVars);
     const uri = 'http://petstore.swagger.io/v2/pet';
     const method = 'post';
 
@@ -840,7 +847,7 @@ describe('#findOperation()', () => {
     });
 
     it('should return result if path contains non-variabled colons', () => {
-      const oas = new Oas(pathVariableQuirks as RMOAS.OASDocument);
+      const oas = Oas.init(pathVariableQuirks);
       const uri = 'https://api.example.com/people/GWID:3';
       const method = 'post';
 
@@ -956,7 +963,7 @@ describe('#findOperation()', () => {
 // we need to know is that if findOperation fails this fails, as well as the reverse.
 describe('#getOperation()', () => {
   it('should return undefined if #findOperation returns undefined', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://localhost:3000/pet/1';
     const method = 'delete';
 
@@ -964,7 +971,7 @@ describe('#getOperation()', () => {
   });
 
   it('should return a result if found', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/pet/1';
     const method = 'delete';
 
@@ -976,7 +983,7 @@ describe('#getOperation()', () => {
   });
 
   it('should have security present on an operation that has it', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const security = [{ petstore_auth: ['write:pets', 'read:pets'] }];
 
     expect(petstore.paths['/pet'].put.security).toStrictEqual(security);
@@ -986,7 +993,7 @@ describe('#getOperation()', () => {
   });
 
   it('should handle paths with uri templates', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const operation = oas.getOperation('http://petstore.swagger.io/v2/store/order/1234', 'get');
 
     expect(operation.schema.parameters).toHaveLength(1);
@@ -1109,7 +1116,7 @@ describe('#getOperation()', () => {
     });
 
     it('should be able to find a match on a url that contains colons', () => {
-      const oas = new Oas(pathVariableQuirks as RMOAS.OASDocument);
+      const oas = Oas.init(pathVariableQuirks);
       const source = {
         url: 'https://api.example.com/people/GWID:3',
         method: 'post' as RMOAS.HttpMethods,
@@ -1126,7 +1133,7 @@ describe('#getOperation()', () => {
 
 describe('#findOperationWithoutMethod()', () => {
   it('should return undefined if no server found', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://localhost:3000/pet/1';
 
     const res = oas.findOperationWithoutMethod(uri);
@@ -1134,7 +1141,7 @@ describe('#findOperationWithoutMethod()', () => {
   });
 
   it('should return undefined if origin is correct but unable to extract path', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/';
 
     const res = oas.findOperationWithoutMethod(uri);
@@ -1142,7 +1149,7 @@ describe('#findOperationWithoutMethod()', () => {
   });
 
   it('should return undefined if no path matches found', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/search';
 
     const res = oas.findOperationWithoutMethod(uri);
@@ -1150,7 +1157,7 @@ describe('#findOperationWithoutMethod()', () => {
   });
 
   it('should return all results for valid path match', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = 'http://petstore.swagger.io/v2/pet/1';
 
     const res = oas.findOperationWithoutMethod(uri);
@@ -1183,7 +1190,7 @@ describe('#findOperationWithoutMethod()', () => {
 
 describe('#dereference()', () => {
   it('should not fail on an empty OAS', () => {
-    const oas = new Oas({} as RMOAS.OASDocument);
+    const oas = Oas.init({});
 
     expect(async () => {
       await oas.dereference();
@@ -1191,7 +1198,7 @@ describe('#dereference()', () => {
   });
 
   it('should dereference the current OAS', async () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
 
     expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
       $ref: '#/components/requestBodies/Pet',
@@ -1214,7 +1221,7 @@ describe('#dereference()', () => {
   });
 
   it('should add metadata to components pre-dereferencing to preserve their lineage', async () => {
-    const oas = new Oas(complexNesting as RMOAS.OASDocument);
+    const oas = Oas.init(complexNesting);
     await oas.dereference();
 
     expect(
@@ -1229,7 +1236,7 @@ describe('#dereference()', () => {
   });
 
   it('should retain the user object when dereferencing', async () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument, {
+    const oas = Oas.init(petstore, {
       username: 'buster',
     });
 
@@ -1252,7 +1259,7 @@ describe('#dereference()', () => {
   });
 
   it('should be able to handle a circular schema without erroring', async () => {
-    const oas = new Oas(circular as RMOAS.OASDocument);
+    const oas = Oas.init(circular);
 
     await oas.dereference();
 
@@ -1326,7 +1333,7 @@ describe('#dereference()', () => {
 
 describe('#getPaths()', () => {
   it('should all paths if paths are present', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const paths = oas.getPaths();
 
     expect(Object.keys(paths)).toHaveLength(14);
@@ -1337,13 +1344,13 @@ describe('#getPaths()', () => {
   });
 
   it('should return an empty object if no paths are present', () => {
-    const oas = new Oas(webhooks as RMOAS.OASDocument);
+    const oas = Oas.init(webhooks);
 
     expect(oas.getPaths()).toStrictEqual({});
   });
 
   it("should return an empty object for the path if only only properties present aren't supported HTTP methods", () => {
-    const oas = new Oas({
+    const oas = Oas.init({
       openapi: '3.0.0',
       info: {
         version: '1.0.0',
@@ -1355,7 +1362,7 @@ describe('#getPaths()', () => {
           'x-deprecated': true,
         },
       },
-    } as RMOAS.OASDocument);
+    });
 
     expect(oas.getPaths()).toStrictEqual({
       '/post': {},
@@ -1365,7 +1372,7 @@ describe('#getPaths()', () => {
 
 describe('#getWebhooks()', () => {
   it('should all paths if paths are present', () => {
-    const oas = new Oas(webhooks as RMOAS.OASDocument);
+    const oas = Oas.init(webhooks);
     const hooks = oas.getWebhooks();
 
     expect(Object.keys(hooks)).toHaveLength(1);
@@ -1377,7 +1384,7 @@ describe('#getWebhooks()', () => {
   });
 
   it('should return an empty object if no webhooks are present', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
 
     expect(oas.getWebhooks()).toStrictEqual({});
   });
@@ -1385,7 +1392,7 @@ describe('#getWebhooks()', () => {
 
 describe('#getTags()', () => {
   it('should all tags that are present in a definition', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
 
     expect(oas.getTags()).toStrictEqual(['pet', 'store', 'user']);
   });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1412,6 +1412,22 @@ describe('#getTags()', () => {
   });
 });
 
+describe('#hasExtension()', () => {
+  it('should return true if the extension exists', () => {
+    const oas = Oas.init({
+      ...petstore,
+      'x-samples-languages': false,
+    });
+
+    expect(oas.hasExtension('x-samples-languages')).toBe(true);
+  });
+
+  it("should return false if the extension doesn't exist", () => {
+    const oas = Oas.init(petstore);
+    expect(oas.hasExtension('x-readme')).toBe(false);
+  });
+});
+
 describe('#getExtension()', () => {
   it('should return the extension if it exists', () => {
     const oas = Oas.init({

--- a/__tests__/lib/get-auth.test.ts
+++ b/__tests__/lib/get-auth.test.ts
@@ -1,4 +1,3 @@
-import type * as RMOAS from '../../src/rmoas.types';
 import Oas from '../../src';
 import { getByScheme } from '../../src/lib/get-auth';
 
@@ -6,7 +5,7 @@ import multipleSecurities from '../__datasets__/multiple-securities.json';
 
 // We need to forcetype this definition to an OASDocument because it's got weird use cases in it and isn't actually
 // a valid to the spec.
-const oas = new Oas(multipleSecurities as RMOAS.OASDocument);
+const oas = Oas.init(multipleSecurities);
 
 test('should fetch all auths from the OAS files', () => {
   expect(oas.getAuth({ oauthScheme: 'oauth', apiKeyScheme: 'apikey' })).toStrictEqual({
@@ -38,15 +37,15 @@ test('should not error if oas.components is not set', () => {
   const user = { oauthScheme: 'oauth', apiKeyScheme: 'apikey' };
 
   expect(() => {
-    new Oas({} as RMOAS.OASDocument).getAuth(user);
+    Oas.init({}).getAuth(user);
   }).not.toThrow();
 
   expect(() => {
-    new Oas({ components: {} } as RMOAS.OASDocument).getAuth(user);
+    Oas.init({ components: {} }).getAuth(user);
   }).not.toThrow();
 
   expect(() => {
-    new Oas({ components: { schemas: {} } } as RMOAS.OASDocument).getAuth(user);
+    Oas.init({ components: { schemas: {} } }).getAuth(user);
   }).not.toThrow();
 });
 

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -958,6 +958,20 @@ describe('#getCallbackExamples()', () => {
   });
 });
 
+describe('#hasExtension()', () => {
+  it('should return true if the extension exists', () => {
+    const operation = Oas.init(petstore).operation('/pet', 'put');
+    operation.schema['x-samples-languages'] = false;
+
+    expect(operation.hasExtension('x-samples-languages')).toBe(true);
+  });
+
+  it("should return false if the extension doesn't exist", () => {
+    const operation = Oas.init(deprecatedSchema).operation('/pet', 'put');
+    expect(operation.hasExtension('x-readme')).toBe(false);
+  });
+});
+
 describe('#getExtension()', () => {
   it('should return the extension if it exists', () => {
     const oas = Oas.init({

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -6,14 +6,30 @@ import multipleSecurities from './__datasets__/multiple-securities.json';
 import referenceSpec from './__datasets__/local-link.json';
 import deprecatedSchema from './__datasets__/schema-deprecated.json';
 
+describe('#constructor', () => {
+  const oas = Oas.init(petstore);
+
+  it('should accept an Oas instance into a definition to be used', () => {
+    const operation = new Operation(oas, '/test', 'get', { summary: 'operation summary' });
+    expect(operation.schema).toStrictEqual({ summary: 'operation summary' });
+    expect(operation.api).toStrictEqual(petstore);
+  });
+
+  it('should accept an API definition', () => {
+    const operation = new Operation(oas.getDefinition(), '/test', 'get', { summary: 'operation summary' });
+    expect(operation.schema).toStrictEqual({ summary: 'operation summary' });
+    expect(operation.api).toStrictEqual(petstore);
+  });
+});
+
 describe('#getContentType()', () => {
   it('should return the content type on an operation', () => {
-    expect(new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'post').getContentType()).toBe('application/json');
+    expect(Oas.init(petstore).operation('/pet', 'post').getContentType()).toBe('application/json');
   });
 
   it('should prioritise json if it exists', () => {
     expect(
-      new Operation(petstore as RMOAS.OASDocument, '/body', 'get', {
+      new Operation(Oas.init(petstore), '/body', 'get', {
         requestBody: {
           content: {
             'text/xml': {
@@ -48,7 +64,7 @@ describe('#getContentType()', () => {
 
   it('should fetch the type from the first requestBody if it is not JSON-like', () => {
     expect(
-      new Operation(petstore as RMOAS.OASDocument, '/body', 'get', {
+      new Operation(Oas.init(petstore), '/body', 'get', {
         requestBody: {
           content: {
             'text/xml': {
@@ -71,7 +87,7 @@ describe('#getContentType()', () => {
 
   it('should handle cases where the requestBody is a $ref', () => {
     const op = new Operation(
-      {
+      Oas.init({
         ...petstore,
         components: {
           requestBodies: {
@@ -93,7 +109,7 @@ describe('#getContentType()', () => {
             },
           },
         },
-      } as RMOAS.OASDocument,
+      }),
       '/body',
       'post',
       {
@@ -109,7 +125,7 @@ describe('#getContentType()', () => {
 
 describe('#isFormUrlEncoded()', () => {
   it('should identify `application/x-www-form-urlencoded`', () => {
-    const op = new Operation(petstore as RMOAS.OASDocument, '/form-urlencoded', 'get', {
+    const op = new Operation(Oas.init(petstore), '/form-urlencoded', 'get', {
       requestBody: {
         content: {
           'application/x-www-form-urlencoded': {
@@ -131,7 +147,7 @@ describe('#isFormUrlEncoded()', () => {
 
 describe('#isMultipart()', () => {
   it('should identify `multipart/form-data`', () => {
-    const op = new Operation(petstore as RMOAS.OASDocument, '/multipart', 'get', {
+    const op = new Operation(Oas.init(petstore), '/multipart', 'get', {
       requestBody: {
         content: {
           'multipart/form-data': {
@@ -156,7 +172,7 @@ describe('#isMultipart()', () => {
 
 describe('#isJson()', () => {
   it('should identify `application/json`', () => {
-    const op = new Operation(petstore as RMOAS.OASDocument, '/json', 'get', {
+    const op = new Operation(Oas.init(petstore), '/json', 'get', {
       requestBody: {
         content: {
           'application/json': {
@@ -178,7 +194,7 @@ describe('#isJson()', () => {
 
 describe('#isXml()', () => {
   it('should identify `application/xml`', () => {
-    const op = new Operation(petstore as RMOAS.OASDocument, '/xml', 'get', {
+    const op = new Operation(Oas.init(petstore), '/xml', 'get', {
       requestBody: {
         content: {
           'application/xml': {
@@ -209,7 +225,7 @@ describe('#getSecurity()', () => {
 
   it('should return the security on this operation', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -227,7 +243,7 @@ describe('#getSecurity()', () => {
         components: {
           securitySchemes,
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurity()
     ).toBe(security);
@@ -235,7 +251,7 @@ describe('#getSecurity()', () => {
 
   it('should fallback to global security', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -253,7 +269,7 @@ describe('#getSecurity()', () => {
         components: {
           securitySchemes,
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurity()
     ).toBe(security);
@@ -261,7 +277,7 @@ describe('#getSecurity()', () => {
 
   it('should default to empty array if no security object defined', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -275,7 +291,7 @@ describe('#getSecurity()', () => {
             },
           },
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurity()
     ).toStrictEqual([]);
@@ -283,7 +299,7 @@ describe('#getSecurity()', () => {
 
   it('should default to empty array if no securitySchemes are defined', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -299,7 +315,7 @@ describe('#getSecurity()', () => {
           },
         },
         components: {},
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurity()
     ).toStrictEqual([]);
@@ -343,7 +359,7 @@ describe('#getSecurityWithTypes()', () => {
 
   it('should return the array of securities on this operation', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -361,7 +377,7 @@ describe('#getSecurityWithTypes()', () => {
         components: {
           securitySchemes,
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurityWithTypes()
     ).toStrictEqual(securitiesWithTypes);
@@ -369,7 +385,7 @@ describe('#getSecurityWithTypes()', () => {
 
   it('should return the filtered array if filter flag is set to true', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -387,7 +403,7 @@ describe('#getSecurityWithTypes()', () => {
         components: {
           securitySchemes,
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurityWithTypes(true)
     ).toStrictEqual(filteredSecuritiesWithTypes);
@@ -395,7 +411,7 @@ describe('#getSecurityWithTypes()', () => {
 
   it('should fallback to global security', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -413,7 +429,7 @@ describe('#getSecurityWithTypes()', () => {
         components: {
           securitySchemes,
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurityWithTypes()
     ).toStrictEqual(securitiesWithTypes);
@@ -421,7 +437,7 @@ describe('#getSecurityWithTypes()', () => {
 
   it('should default to empty array if no security object defined', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -435,7 +451,7 @@ describe('#getSecurityWithTypes()', () => {
             },
           },
         },
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurityWithTypes()
     ).toStrictEqual([]);
@@ -443,7 +459,7 @@ describe('#getSecurityWithTypes()', () => {
 
   it('should default to empty array if no securitySchemes are defined', () => {
     expect(
-      new Oas({
+      Oas.init({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0' },
         paths: {
@@ -459,7 +475,7 @@ describe('#getSecurityWithTypes()', () => {
           },
         },
         components: {},
-      } as RMOAS.OASDocument)
+      })
         .operation('/things', 'post')
         .getSecurityWithTypes()
     ).toStrictEqual([]);
@@ -481,7 +497,7 @@ describe('#prepareSecurity()', () => {
       return { [scheme]: [] };
     });
 
-    return new Oas({
+    return Oas.init({
       openapi: '3.0.0',
       info: {
         title: 'testing',
@@ -500,7 +516,7 @@ describe('#prepareSecurity()', () => {
           },
         },
       },
-    } as RMOAS.OASDocument);
+    });
   }
 
   it('http/basic: should return with a type of Basic', () => {
@@ -577,32 +593,32 @@ describe('#prepareSecurity()', () => {
   });
 
   it('should work for petstore', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'post');
+    const operation = Oas.init(petstore).operation('/pet', 'post');
 
     expect(operation.prepareSecurity()).toMatchSnapshot();
   });
 
   it('should work for multiple securities (||)', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/or-security', 'post');
+    const operation = Oas.init(multipleSecurities).operation('/or-security', 'post');
 
     expect(Object.keys(operation.prepareSecurity())).toHaveLength(2);
   });
 
   it('should work for multiple securities (&&)', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/and-security', 'post');
+    const operation = Oas.init(multipleSecurities).operation('/and-security', 'post');
 
     expect(Object.keys(operation.prepareSecurity())).toHaveLength(2);
   });
 
   it('should work for multiple securities (&& and ||)', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/and-or-security', 'post');
+    const operation = Oas.init(multipleSecurities).operation('/and-or-security', 'post');
 
     expect(operation.prepareSecurity().OAuth2).toHaveLength(2);
     expect(operation.prepareSecurity().Header).toHaveLength(1);
   });
 
   it('should dedupe securities in within an && and || situation', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/multiple-combo-auths-duped', 'get');
+    const operation = Oas.init(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
 
     expect(operation.prepareSecurity().Bearer).toHaveLength(1);
     expect(operation.prepareSecurity().Header).toHaveLength(2);
@@ -613,24 +629,24 @@ describe('#prepareSecurity()', () => {
   it.todo('should throw if attempting to use a non-existent scheme');
 
   it('should return empty object if no security', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/no-auth', 'post');
+    const operation = Oas.init(multipleSecurities).operation('/no-auth', 'post');
     expect(Object.keys(operation.prepareSecurity())).toHaveLength(0);
   });
 
   it('should return empty object if security scheme doesnt exist', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/unknown-scheme', 'post');
+    const operation = Oas.init(multipleSecurities).operation('/unknown-scheme', 'post');
     expect(Object.keys(operation.prepareSecurity())).toHaveLength(0);
   });
 
   it('should return empty if security scheme type doesnt exist', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/unknown-auth-type', 'post');
+    const operation = Oas.init(multipleSecurities).operation('/unknown-auth-type', 'post');
     expect(Object.keys(operation.prepareSecurity())).toHaveLength(0);
   });
 });
 
 describe('#getHeaders()', () => {
   it('should return an object containing request headers if params exist', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = `http://petstore.swagger.io/v2/pet/1`;
     const method = 'DELETE' as RMOAS.HttpMethods;
 
@@ -644,7 +660,7 @@ describe('#getHeaders()', () => {
   });
 
   it('should return an object containing content-type request header if media types exist in request body', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = `http://petstore.swagger.io/v2/pet`;
     const method = 'POST' as RMOAS.HttpMethods;
 
@@ -658,7 +674,7 @@ describe('#getHeaders()', () => {
   });
 
   it('should return an object containing accept and content-type headers if media types exist in response', () => {
-    const oas = new Oas(petstore as RMOAS.OASDocument);
+    const oas = Oas.init(petstore);
     const uri = `http://petstore.swagger.io/v2/pet/findByStatus`;
     const method = 'GET' as RMOAS.HttpMethods;
 
@@ -672,7 +688,7 @@ describe('#getHeaders()', () => {
   });
 
   it('should return an object containing request headers if security exists', () => {
-    const oas = new Oas(multipleSecurities as RMOAS.OASDocument);
+    const oas = Oas.init(multipleSecurities);
     const uri = 'http://example.com/multiple-combo-auths';
     const method = 'POST' as RMOAS.HttpMethods;
 
@@ -686,7 +702,7 @@ describe('#getHeaders()', () => {
   });
 
   it('should return a Cookie header if security is located in cookie scheme', () => {
-    const oas = new Oas(referenceSpec as RMOAS.OASDocument);
+    const oas = Oas.init(referenceSpec);
     const uri = 'http://local-link.com/2.0/users/johnSmith';
     const method = 'GET' as RMOAS.HttpMethods;
 
@@ -700,7 +716,7 @@ describe('#getHeaders()', () => {
   });
 
   it('should target parameter refs and return names if applicable', async () => {
-    const oas = new Oas(referenceSpec as RMOAS.OASDocument);
+    const oas = Oas.init(referenceSpec);
     await oas.dereference();
 
     const uri = 'http://local-link.com/2.0/repositories/janeDoe/oas/pullrequests';
@@ -717,31 +733,31 @@ describe('#getHeaders()', () => {
 
 describe('#hasOperationId()', () => {
   it('should return true if one exists', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/{petId}', 'delete');
+    const operation = Oas.init(petstore).operation('/pet/{petId}', 'delete');
     expect(operation.hasOperationId()).toBe(true);
   });
 
   it('should return false if one does not exist', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/multiple-combo-auths-duped', 'get');
+    const operation = Oas.init(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
     expect(operation.hasOperationId()).toBe(false);
   });
 });
 
 describe('#getOperationId()', () => {
   it('should return an operation id if one exists', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/{petId}', 'delete');
+    const operation = Oas.init(petstore).operation('/pet/{petId}', 'delete');
     expect(operation.getOperationId()).toBe('deletePet');
   });
 
   it('should create one if one does not exist', () => {
-    const operation = new Oas(multipleSecurities as RMOAS.OASDocument).operation('/multiple-combo-auths-duped', 'get');
+    const operation = Oas.init(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
     expect(operation.getOperationId()).toBe('get_multiple-combo-auths-duped');
   });
 });
 
 describe('#getTags()', () => {
   it('should return tags if tags exist', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'post');
+    const operation = Oas.init(petstore).operation('/pet', 'post');
 
     expect(operation.getTags()).toStrictEqual([
       {
@@ -753,7 +769,7 @@ describe('#getTags()', () => {
   });
 
   it("should not return any tag metadata with the tag if it isn't defined at the OAS level", () => {
-    const spec = new Oas({
+    const spec = Oas.init({
       openapi: '3.0.0',
       info: {
         title: 'testing',
@@ -771,14 +787,14 @@ describe('#getTags()', () => {
           },
         },
       },
-    } as RMOAS.OASDocument);
+    });
 
     const operation = spec.operation('/', 'get');
     expect(operation.getTags()).toStrictEqual([{ name: 'dogs' }]);
   });
 
   it('should return an empty array if no tags are present', () => {
-    const spec = new Oas({
+    const spec = Oas.init({
       openapi: '3.0.0',
       info: { title: 'testing', version: '1.0.0' },
       paths: {
@@ -792,7 +808,7 @@ describe('#getTags()', () => {
           },
         },
       },
-    } as RMOAS.OASDocument);
+    });
 
     const operation = spec.operation('/', 'get');
     expect(operation.getTags()).toHaveLength(0);
@@ -801,56 +817,55 @@ describe('#getTags()', () => {
 
 describe('#isDeprecated()', () => {
   it('should return deprecated flag if present', () => {
-    const operation = new Oas(deprecatedSchema as RMOAS.OASDocument).operation('/anything', 'post');
+    const operation = Oas.init(deprecatedSchema).operation('/anything', 'post');
     expect(operation.isDeprecated()).toBe(true);
   });
 
   it('should return false if no deprecated flag is present', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/{petId}', 'delete');
+    const operation = Oas.init(petstore).operation('/pet/{petId}', 'delete');
     expect(operation.isDeprecated()).toBe(false);
   });
 });
 
 describe('#getParameters()', () => {
   it('should return parameters', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/{petId}', 'delete');
+    const operation = Oas.init(petstore).operation('/pet/{petId}', 'delete');
     expect(operation.getParameters()).toHaveLength(2);
   });
 
   it('should return an empty array if there are none', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'put');
+    const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.getParameters()).toHaveLength(0);
   });
 });
 
 describe('#getParametersAsJsonSchema()', () => {
   it('should return json schema', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'put');
-
+    const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
   });
 });
 
 describe('#hasRequestBody()', () => {
   it('should return true on an operation with a requestBody', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'put');
+    const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.hasRequestBody()).toBe(true);
   });
 
   it('should return false on an operation without a requestBody', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/findByStatus', 'get');
+    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');
     expect(operation.hasRequestBody()).toBe(false);
   });
 });
 
 describe('#getResponseByStatusCode()', () => {
   it('should return false if the status code doesnt exist', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/findByStatus', 'get');
+    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');
     expect(operation.getResponseByStatusCode(202)).toBe(false);
   });
 
   it('should return the response', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/findByStatus', 'get');
+    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');
     expect(operation.getResponseByStatusCode(200)).toStrictEqual({
       content: {
         'application/json': {
@@ -877,32 +892,32 @@ describe('#getResponseByStatusCode()', () => {
 
 describe('#getResponseStatusCodes()', () => {
   it('should return all valid status codes for a response', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/findByStatus', 'get');
+    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');
     expect(operation.getResponseStatusCodes()).toStrictEqual(['200', '400']);
   });
 
   it('should return an empty array if there are no responses', () => {
     // @ts-expect-error The easiest way to test this is to create an `Operation` instance of no data, which this does.
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/findByStatus', 'doesnotexist');
+    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'doesnotexist');
     expect(operation.getResponseStatusCodes()).toStrictEqual([]);
   });
 });
 
 describe('#hasCallbacks()', () => {
   it('should return true on an operation with callbacks', () => {
-    const operation = new Oas(callbackSchema as RMOAS.OASDocument).operation('/callbacks', 'get');
+    const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
     expect(operation.hasCallbacks()).toBe(true);
   });
 
   it('should return false on an operation without callbacks', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet/findByStatus', 'get');
+    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');
     expect(operation.hasCallbacks()).toBe(false);
   });
 });
 
 describe('#getCallback()', () => {
   it('should return an operation from a callback if it exists', () => {
-    const operation = new Oas(callbackSchema as RMOAS.OASDocument).operation('/callbacks', 'get');
+    const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
     const callback = operation.getCallback('myCallback', '{$request.query.queryUrl}', 'post') as Callback;
 
     expect(callback.identifier).toBe('myCallback');
@@ -912,33 +927,33 @@ describe('#getCallback()', () => {
   });
 
   it('should return false if that callback doesnt exist', () => {
-    const operation = new Oas(callbackSchema as RMOAS.OASDocument).operation('/callbacks', 'get');
+    const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
     expect(operation.getCallback('fakeCallback', 'doesntExist', 'get')).toBe(false);
   });
 });
 
 describe('#getCallbacks()', () => {
   it('should return an array of operations created from each callback', () => {
-    const operation = new Oas(callbackSchema as RMOAS.OASDocument).operation('/callbacks', 'get');
+    const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
     const callbacks = operation.getCallbacks() as Array<Callback>;
     expect(callbacks).toHaveLength(4);
     callbacks.forEach(callback => expect(callback).toBeInstanceOf(Callback));
   });
 
   it('should return false if theres no callbacks', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'put');
+    const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.getCallbacks()).toBe(false);
   });
 });
 
 describe('#getCallbackExamples()', () => {
   it('should return an array of examples for each callback that has them', () => {
-    const operation = new Oas(callbackSchema as RMOAS.OASDocument).operation('/callbacks', 'get');
+    const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
     expect(operation.getCallbackExamples()).toHaveLength(3);
   });
 
   it('should an empty array if there are no callback examples', () => {
-    const operation = new Oas(petstore as RMOAS.OASDocument).operation('/pet', 'put');
+    const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.getCallbackExamples()).toHaveLength(0);
   });
 });

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -957,3 +957,29 @@ describe('#getCallbackExamples()', () => {
     expect(operation.getCallbackExamples()).toHaveLength(0);
   });
 });
+
+describe('#getExtension()', () => {
+  it('should return the extension if it exists', () => {
+    const oas = Oas.init({
+      ...petstore,
+      'x-readme': {
+        'samples-languages': ['js', 'python'],
+      },
+    });
+
+    const operation = oas.operation('/pet', 'put');
+    operation.schema['x-readme'] = {
+      'samples-languages': ['php', 'go'],
+    };
+
+    expect(operation.getExtension('x-readme')).toStrictEqual({
+      'samples-languages': ['php', 'go'],
+    });
+  });
+
+  it("should return nothing if the extension doesn't exist", () => {
+    const operation = Oas.init(deprecatedSchema).operation('/pet', 'put');
+
+    expect(operation.getExtension('x-readme')).toBeUndefined();
+  });
+});

--- a/__tests__/operation/get-callback-examples.test.ts
+++ b/__tests__/operation/get-callback-examples.test.ts
@@ -1,10 +1,9 @@
-import type * as RMOAS from '../../src/rmoas.types';
 import Oas from '../../src';
 import operationExamples from '../__datasets__/operation-examples.json';
 import callbacks from '../__datasets__/callbacks.json';
 
-const oas = new Oas(operationExamples as RMOAS.OASDocument);
-const oas2 = new Oas(callbacks as RMOAS.OASDocument);
+const oas = Oas.init(operationExamples);
+const oas2 = Oas.init(callbacks);
 
 beforeAll(async () => {
   await oas.dereference();

--- a/__tests__/operation/get-requestbody-examples.test.ts
+++ b/__tests__/operation/get-requestbody-examples.test.ts
@@ -1,4 +1,3 @@
-import type * as RMOAS from '../../src/rmoas.types';
 import Oas from '../../src';
 import operationExamples from '../__datasets__/operation-examples.json';
 import petstore from '@readme/oas-examples/3.0/json/petstore.json';
@@ -7,8 +6,8 @@ import deprecated from '../__datasets__/deprecated.json';
 
 import cleanStringify from '../__fixtures__/json-stringify-clean';
 
-const oas = new Oas(operationExamples as RMOAS.OASDocument);
-const oas2 = new Oas(petstore as RMOAS.OASDocument);
+const oas = Oas.init(operationExamples);
+const oas2 = Oas.init(petstore);
 
 beforeAll(async () => {
   await oas.dereference();
@@ -275,7 +274,7 @@ describe('defined within response `content`', () => {
 
 describe('readOnly / writeOnly handling', () => {
   it('should exclude `readOnly` schemas and include `writeOnly`', () => {
-    const spec = new Oas(exampleRoWo as RMOAS.OASDocument);
+    const spec = Oas.init(exampleRoWo);
     const operation = spec.operation('/', 'put');
 
     expect(operation.getRequestBodyExamples()).toStrictEqual([
@@ -294,7 +293,7 @@ describe('readOnly / writeOnly handling', () => {
   });
 
   it('should retain `readOnly` and `writeOnly` settings when merging an allOf', async () => {
-    const spec = new Oas(exampleRoWo as RMOAS.OASDocument);
+    const spec = Oas.init(exampleRoWo);
     await spec.dereference();
 
     const operation = spec.operation('/allOf', 'post');
@@ -320,7 +319,7 @@ describe('readOnly / writeOnly handling', () => {
 
 describe('deprecated handling', () => {
   it('should include deprecated properties in examples', async () => {
-    const spec = new Oas(deprecated as RMOAS.OASDocument);
+    const spec = Oas.init(deprecated);
     await spec.dereference();
 
     const operation = spec.operation('/', 'post');
@@ -340,7 +339,7 @@ describe('deprecated handling', () => {
   });
 
   it('should pass through deprecated properties in examples on allOf schemas', async () => {
-    const spec = new Oas(deprecated as RMOAS.OASDocument);
+    const spec = Oas.init(deprecated);
     await spec.dereference();
 
     const operation = spec.operation('/allof-schema', 'post');

--- a/__tests__/operation/get-response-examples.test.ts
+++ b/__tests__/operation/get-response-examples.test.ts
@@ -1,4 +1,3 @@
-import type * as RMOAS from '../../src/rmoas.types';
 import Oas from '../../src';
 import operationExamples from '../__datasets__/operation-examples.json';
 import petstore from '@readme/oas-examples/3.0/json/petstore.json';
@@ -7,8 +6,8 @@ import circular from '../__datasets__/circular.json';
 import deprecated from '../__datasets__/deprecated.json';
 import cleanStringify from '../__fixtures__/json-stringify-clean';
 
-const oas = new Oas(operationExamples as RMOAS.OASDocument);
-const oas2 = new Oas(petstore as RMOAS.OASDocument);
+const oas = Oas.init(operationExamples);
+const oas2 = Oas.init(petstore);
 
 beforeAll(async () => {
   await oas.dereference();
@@ -46,7 +45,7 @@ test('should support */* media types', () => {
 });
 
 test('should do its best at handling circular schemas', async () => {
-  const circularOas = new Oas(circular as RMOAS.OASDocument);
+  const circularOas = Oas.init(circular);
   await circularOas.dereference();
 
   const operation = circularOas.operation('/', 'get');
@@ -442,7 +441,7 @@ describe('defined within response `content`', () => {
 
 describe('readOnly / writeOnly handling', () => {
   it('should include `readOnly` schemas and exclude `writeOnly`', () => {
-    const spec = new Oas(exampleRoWo as RMOAS.OASDocument);
+    const spec = Oas.init(exampleRoWo);
     const operation = spec.operation('/', 'put');
 
     expect(operation.getResponseExamples()).toStrictEqual([
@@ -463,7 +462,7 @@ describe('readOnly / writeOnly handling', () => {
   });
 
   it('should retain `readOnly` and `writeOnly` settings when merging an allOf', async () => {
-    const spec = new Oas(exampleRoWo as RMOAS.OASDocument);
+    const spec = Oas.init(exampleRoWo);
     await spec.dereference();
 
     const operation = spec.operation('/allOf', 'post');
@@ -494,7 +493,7 @@ describe('readOnly / writeOnly handling', () => {
 
 describe('deprecated handling', () => {
   it('should include deprecated properties in examples', async () => {
-    const spec = new Oas(deprecated as RMOAS.OASDocument);
+    const spec = Oas.init(deprecated);
     await spec.dereference();
 
     const operation = spec.operation('/', 'post');
@@ -509,7 +508,7 @@ describe('deprecated handling', () => {
   });
 
   it('should pass through deprecated properties in examples on allOf schemas', async () => {
-    const spec = new Oas(deprecated as RMOAS.OASDocument);
+    const spec = Oas.init(deprecated);
     await spec.dereference();
 
     const operation = spec.operation('/allof-schema', 'post');
@@ -525,7 +524,7 @@ describe('deprecated handling', () => {
 });
 
 test('sample generation should not corrupt the supplied operation', async () => {
-  const spec = new Oas(exampleRoWo as RMOAS.OASDocument);
+  const spec = Oas.init(exampleRoWo);
   await spec.dereference();
 
   const operation = spec.operation('/', 'post');

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepack": "npm run build",
     "prepare": "husky install",
     "pretest": "npm run lint",
-    "prettier": "prettier --list-different --write \"./**/**.js\"",
+    "prettier": "prettier --list-different --write \"./**/**.{js,ts}\"",
     "release": "npx conventional-changelog-cli -i CHANGELOG.md -s && git add CHANGELOG.md",
     "test": "tsc; jest --coverage",
     "test-watch": "tsc; jest --watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -711,7 +711,19 @@ export default class Oas {
   }
 
   /**
-   * Retrieve a custom specification extension off of teh API definition.
+   * Determine if a given a custom specification extension exists within the API definition.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @param extension Specification extension to lookup.
+   * @returns The extension exists.
+   */
+  hasExtension(extension: string) {
+    return extension in this.api;
+  }
+
+  /**
+   * Retrieve a custom specification extension off of the API definition.
    *
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}

--- a/src/index.ts
+++ b/src/index.ts
@@ -705,6 +705,18 @@ export default class Oas {
   }
 
   /**
+   * Retrieve a custom specification extension off of teh API definition.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @param extension Specification extension to lookup.
+   * @returns The extension contents if it was found.
+   */
+  getExtension(extension: string) {
+    return this.api?.[extension];
+  }
+
+  /**
    * Dereference the current OAS definition so it can be parsed free of worries of `$ref` schemas and circular
    * structures.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,10 @@ export default class Oas {
     complete: boolean;
   };
 
+  /**
+   * @param oas An OpenAPI definition.
+   * @param user The information about a user that we should use when pulling auth tokens from security schemes.
+   */
   constructor(oas: RMOAS.OASDocument, user?: RMOAS.User) {
     // @todo throw an exception here instead of allowing an empty oas
     this.api = oas;
@@ -252,12 +256,29 @@ export default class Oas {
     };
   }
 
+  /**
+   * This will initialize a new instance of the `Oas` class. This method is useful if you're using Typescript and are
+   * attempting to supply an untyped JSON object into `Oas` as it will force-type that object to an `OASDocument` for
+   * you.
+   *
+   * @param oas An OpenAPI definition.
+   * @param user The information about a user that we should use when pulling auth tokens from security schemes.
+   * @returns An instance of the Oas class.
+   */
+  static init(oas: Record<string, unknown> | RMOAS.OASDocument, user?: RMOAS.User) {
+    return new Oas(oas as RMOAS.OASDocument, user);
+  }
+
   getVersion() {
     if (this.api.openapi) {
       return this.api.openapi;
     }
 
     throw new Error('Unable to recognize what specification version this API definition conforms to.');
+  }
+
+  getDefinition() {
+    return this.api;
   }
 
   url(selected = 0, variables?: Variables) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,7 +210,7 @@ function findTargetPath(pathMatches: Array<{ url: PathMatch['url']; operation: R
 
 export default class Oas {
   /**
-   * OpenAPI API Definition that this instance should use.
+   * An OpenAPI API Definition.
    */
   api: RMOAS.OASDocument;
 
@@ -269,6 +269,9 @@ export default class Oas {
     return new Oas(oas as RMOAS.OASDocument, user);
   }
 
+  /**
+   * @returns The OpenAPI version that this API definition is targeted for.
+   */
   getVersion() {
     if (this.api.openapi) {
       return this.api.openapi;
@@ -277,6 +280,9 @@ export default class Oas {
     throw new Error('Unable to recognize what specification version this API definition conforms to.');
   }
 
+  /**
+   * @returns The current OpenAPI API Definition.
+   */
   getDefinition() {
     return this.api;
   }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -514,6 +514,18 @@ export default class Operation {
     this.callbackExamples = getCallbackExamples(this.schema);
     return this.callbackExamples;
   }
+
+  /**
+   * Retrieve a custom specification extension off of teh API definition.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @param extension Specification extension to lookup.
+   * @returns The extension contents if it was found.
+   */
+  getExtension(extension: string) {
+    return this.schema?.[extension];
+  }
 }
 
 export class Callback extends Operation {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -4,6 +4,7 @@ import type { RequestBodyExamples } from './operation/get-requestbody-examples';
 import type { CallbackExamples } from './operation/get-callback-examples';
 import type { ResponseExamples } from './operation/get-response-examples';
 
+import Oas from '.';
 import { isRef } from './rmoas.types';
 import findSchemaDefinition from './lib/find-schema-definition';
 import getParametersAsJsonSchema from './operation/get-parameters-as-json-schema';
@@ -64,9 +65,9 @@ export default class Operation {
     response: Array<string>;
   };
 
-  constructor(api: RMOAS.OASDocument, path: string, method: RMOAS.HttpMethods, operation: RMOAS.OperationObject) {
+  constructor(api: Oas | RMOAS.OASDocument, path: string, method: RMOAS.HttpMethods, operation: RMOAS.OperationObject) {
     this.schema = operation;
-    this.api = api;
+    this.api = api instanceof Oas ? api.getDefinition() : api;
     this.path = path;
     this.method = method;
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -516,7 +516,19 @@ export default class Operation {
   }
 
   /**
-   * Retrieve a custom specification extension off of teh API definition.
+   * Determine if a given a custom specification extension exists within the operation.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @param extension Specification extension to lookup.
+   * @returns The extension exists.
+   */
+  hasExtension(extension: string) {
+    return extension in this.schema;
+  }
+
+  /**
+   * Retrieve a custom specification extension off of the operation.
    *
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}

--- a/src/rmoas.types.ts
+++ b/src/rmoas.types.ts
@@ -32,7 +32,9 @@ export type HttpMethods =
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasObject}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasObject}
  */
-export type OASDocument = OpenAPIV3.Document | OpenAPIV3_1.Document;
+export type OASDocument = (OpenAPIV3.Document | OpenAPIV3_1.Document) & {
+  [extension: string]: unknown;
+};
 
 /**
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverObject}
@@ -71,7 +73,9 @@ export type PathItemObject = OpenAPIV3.PathItemObject | OpenAPIV3_1.PathItemObje
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject}
  */
-export type OperationObject = OpenAPIV3.OperationObject | OpenAPIV3_1.OperationObject;
+export type OperationObject = (OpenAPIV3.OperationObject | OpenAPIV3_1.OperationObject) & {
+  [extension: string]: unknown;
+};
 
 /**
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject}


### PR DESCRIPTION
## 🧰 Changes

* [x] Creates a static `Oas.init()` method that will do type transformation on raw JSON objects before it's sent into the `Oas` constructor. This helps so that we don't need to export `RMOAS.OASDocument` and you can do `new Oas(petstore)` out of the box.
* [x] Adds `hasExtension()` and `getExtension()` methods to both `Oas` and `Operation` for [spec extensions](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions) lookups. We can use this in [@readme/oas-extensions](https://npm.im/@readme/oas-extensions) to clean up some work there.

## 🧬 QA & Testing

See tests.