### PR TITLE
feat: merging down callbacks work in v17 to the 14.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 14.9.0 (2021-11-09)
+
+* feat: replaying callback work on top of the 14.8 release series ([930120d](https://github.com/readmeio/oas/commit/930120d))
+
+
+
 ## <small>14.8.2 (2021-10-29)</small>
 
 * refactor: don't pull required deprecated params out to deprecatedProps (#531) ([c15e6e5](https://github.com/readmeio/oas/commit/c15e6e5)), closes [#531](https://github.com/readmeio/oas/issues/531)

--- a/__tests__/__datasets__/callbacks.json
+++ b/__tests__/__datasets__/callbacks.json
@@ -1,0 +1,146 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Support for callbacks",
+    "description": "https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject\n\nhttps://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object\n\nhttps://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/callbacks": {
+      "get": {
+        "summary": "Utilizes callbacks.",
+        "description": "https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callbackObject",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "requestBody": {
+                  "description": "Callback payload",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/dog"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed",
+                    "content": {
+                      "application/json": {
+                        "example": {
+                          "id": 1,
+                          "name": "Pug",
+                          "is_a_good_dog": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "multipleCallback": {
+            "{$request.multipleExpression.queryUrl}": {
+              "post": {
+                "requestBody": {
+                  "description": "Callback payload",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/dog"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed",
+                    "content": {
+                      "application/json": {
+                        "example": {
+                          "id": 1,
+                          "name": "Pug",
+                          "is_a_good_dog": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "{$request.multipleMethod.queryUrl}": {
+              "post": {
+                "requestBody": {
+                  "description": "Callback payload",
+                  "content": {
+                    "application/json": {
+                      "schema": {
+                        "$ref": "#/components/schemas/dog"
+                      }
+                    }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed"
+                  }
+                }
+              },
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "callback successfully processed",
+                    "content": {
+                      "application/json": {
+                        "example": {
+                          "id": 1,
+                          "name": "Pug",
+                          "is_a_good_dog": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "dog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "is_a_good_dog": {
+            "type": "boolean"
+          }
+        },
+        "example": {
+          "id": 1,
+          "name": "Pug",
+          "is_a_good_dog": true
+        }
+      }
+    }
+  }
+}

--- a/__tests__/__datasets__/operation-examples.json
+++ b/__tests__/__datasets__/operation-examples.json
@@ -80,6 +80,46 @@
               }
             }
           }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "application/json": {
+                        "examples": {
+                          "response": {
+                            "value": {
+                              "user": {
+                                "email": "test@example.com",
+                                "name": "Test user name"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "400": {
+                    "description": "Validation failed",
+                    "content": {
+                      "application/xml": {
+                        "examples": {
+                          "response": {
+                            "value":
+                              "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -333,6 +373,59 @@
               }
             }
           }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "text/plain": {
+                        "examples": {
+                          "response": {
+                            "value": "OK"
+                          }
+                        }
+                      },
+                      "application/json": {
+                        "examples": {
+                          "cat": {
+                            "summary": "An example of a cat",
+                            "value": {
+                              "name": "Fluffy",
+                              "petType": "Cat"
+                            }
+                          },
+                          "dog": {
+                            "summary": "An example of a dog with a cat's name",
+                            "value": {
+                              "name": "Puma",
+                              "petType": "Dog"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "400": {
+                    "description": "Validation failed",
+                    "content": {
+                      "application/xml": {
+                        "examples": {
+                          "response": {
+                            "value":
+                            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -358,6 +451,27 @@
           },
           "204": {
             "description": "No content"
+          }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "application/json": {
+                        "examples": {}
+                      }
+                    }
+                  },
+                  "204": {
+                    "description": "No content"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -391,13 +505,38 @@
               }
             }
           }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/tag"
+                          }
+                        },
+                        "examples": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
     "/nothing": {
       "get": {
         "description": "This operation has neither a requestBody or response schema, but also no examples for either.",
-        "responses": {}
+        "responses": {},
+        "callbacks": {}
       }
     },
     "/no-response-schemas": {
@@ -406,6 +545,19 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -464,6 +616,36 @@
                         "name": "Test user name"
                       }
                     }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "callbacks": {
+          "myCallback": {
+            "{$request.query.queryUrl}": {
+              "post": {
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "application/json": {
+                        "examples": {
+                          "response": {
+                            "value": {
+                              "user": {
+                                "email": "test@example.com",
+                                "name": "Test user name"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "400": {
+                    "$ref": "#/components/responses/400-Response-Ref"
                   }
                 }
               }

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -727,6 +727,7 @@ Object {
 
 exports[`#operation() should return a default when no operation 1`] = `
 Operation {
+  "callbackExamples": undefined,
   "contentType": undefined,
   "method": "get",
   "oas": Oas {

--- a/__tests__/operation/__snapshots__/get-callback-examples.test.js.snap
+++ b/__tests__/operation/__snapshots__/get-callback-examples.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return examples for multiple expressions and methods within a callback 1`] = `
+Array [
+  Object {
+    "example": Array [
+      Object {
+        "mediaTypes": Object {
+          "application/json": Array [
+            Object {
+              "value": Object {
+                "id": 1,
+                "is_a_good_dog": true,
+                "name": "Pug",
+              },
+            },
+          ],
+        },
+        "status": "200",
+      },
+    ],
+    "expression": "{$request.query.queryUrl}",
+    "identifier": "myCallback",
+    "method": "post",
+  },
+  Object {
+    "example": Array [
+      Object {
+        "mediaTypes": Object {
+          "application/json": Array [
+            Object {
+              "value": Object {
+                "id": 1,
+                "is_a_good_dog": true,
+                "name": "Pug",
+              },
+            },
+          ],
+        },
+        "status": "200",
+      },
+    ],
+    "expression": "{$request.multipleExpression.queryUrl}",
+    "identifier": "multipleCallback",
+    "method": "post",
+  },
+  Object {
+    "example": Array [
+      Object {
+        "mediaTypes": Object {
+          "application/json": Array [
+            Object {
+              "value": Object {
+                "id": 1,
+                "is_a_good_dog": true,
+                "name": "Pug",
+              },
+            },
+          ],
+        },
+        "status": "200",
+      },
+    ],
+    "expression": "{$request.multipleMethod.queryUrl}",
+    "identifier": "multipleCallback",
+    "method": "get",
+  },
+]
+`;

--- a/__tests__/operation/get-callback-examples.test.js
+++ b/__tests__/operation/get-callback-examples.test.js
@@ -1,0 +1,181 @@
+const Oas = require('../../src');
+const operationExamples = require('../__datasets__/operation-examples.json');
+const callbacks = require('../__datasets__/callbacks.json');
+
+const oas = new Oas(operationExamples);
+const oas2 = new Oas(callbacks);
+
+beforeAll(async () => {
+  await oas.dereference();
+  await oas2.dereference();
+});
+
+test('should handle if there are no callbacks', () => {
+  const operation = oas.operation('/nothing', 'get');
+  expect(operation.getCallbackExamples()).toStrictEqual([]);
+});
+
+test('should handle if there are no callback schemas', () => {
+  const operation = oas.operation('/no-response-schemas', 'get');
+  expect(operation.getCallbackExamples()).toStrictEqual([]);
+});
+
+describe('no curated examples present', () => {
+  it('should not generate an example schema if there is no documented schema and an empty example', () => {
+    const operation = oas.operation('/emptyexample', 'post');
+    expect(operation.getCallbackExamples()).toStrictEqual([
+      {
+        identifier: 'myCallback',
+        expression: '{$request.query.queryUrl}',
+        method: 'post',
+        example: [
+          {
+            status: '200',
+            mediaTypes: {
+              'application/json': [],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should generate examples if an `examples` property is present but empty', () => {
+    const operation = oas.operation('/emptyexample-with-schema', 'post');
+    expect(operation.getCallbackExamples()).toStrictEqual([
+      {
+        identifier: 'myCallback',
+        expression: '{$request.query.queryUrl}',
+        method: 'post',
+        example: [
+          {
+            status: '200',
+            mediaTypes: {
+              'application/json': [
+                {
+                  value: [
+                    {
+                      id: 0,
+                      name: 'string',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe('`examples`', () => {
+  it.each([
+    ['should return examples', oas.operation('/examples-at-mediaType-level', 'post')],
+    [
+      'should return examples if there are examples for the operation, and one of the examples is a $ref',
+      oas.operation('/ref-examples', 'post'),
+    ],
+  ])('%s', (tc, operation) => {
+    expect(operation.getCallbackExamples()).toStrictEqual([
+      {
+        identifier: 'myCallback',
+        expression: '{$request.query.queryUrl}',
+        method: 'post',
+        example: [
+          {
+            status: '200',
+            mediaTypes: {
+              'application/json': [
+                {
+                  summary: 'response',
+                  title: 'response',
+                  value: {
+                    user: {
+                      email: 'test@example.com',
+                      name: 'Test user name',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          {
+            status: '400',
+            mediaTypes: {
+              'application/xml': [
+                {
+                  summary: 'response',
+                  title: 'response',
+                  value:
+                    '<?xml version="1.0" encoding="UTF-8"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don\'t forget me this weekend!</body></note>',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should return multiple nested examples if there are multiple media types types for the operation', () => {
+    const operation = oas.operation('/multi-media-types-multiple-examples', 'post');
+    expect(operation.getCallbackExamples()).toStrictEqual([
+      {
+        identifier: 'myCallback',
+        expression: '{$request.query.queryUrl}',
+        method: 'post',
+        example: [
+          {
+            status: '200',
+            mediaTypes: {
+              'text/plain': [
+                {
+                  summary: 'response',
+                  title: 'response',
+                  value: 'OK',
+                },
+              ],
+              'application/json': [
+                {
+                  summary: 'An example of a cat',
+                  title: 'cat',
+                  value: {
+                    name: 'Fluffy',
+                    petType: 'Cat',
+                  },
+                },
+                {
+                  summary: "An example of a dog with a cat's name",
+                  title: 'dog',
+                  value: {
+                    name: 'Puma',
+                    petType: 'Dog',
+                  },
+                },
+              ],
+            },
+          },
+          {
+            status: '400',
+            mediaTypes: {
+              'application/xml': [
+                {
+                  summary: 'response',
+                  title: 'response',
+                  value:
+                    '<?xml version="1.0" encoding="UTF-8"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don\'t forget me this weekend!</body></note>',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+test('should return examples for multiple expressions and methods within a callback', () => {
+  const operation = oas2.operation('/callbacks', 'get');
+  expect(operation.getCallbackExamples()).toMatchSnapshot();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oas",
-  "version": "14.8.2",
+  "version": "14.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oas",
-      "version": "14.8.2",
+      "version": "14.9.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "14.8.2",
+  "version": "14.9.0",
   "description": "Working with OpenAPI definitions is hard. This makes it easier.",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const getAuth = require('./lib/get-auth');
 const getPathOperation = require('./lib/get-path-operation');
 const getUserVariable = require('./lib/get-user-variable');
 const Operation = require('./operation');
+const { Callback } = require('./operation');
 
 function ensureProtocol(url) {
   // Add protocol to urls starting with // e.g. //example.com
@@ -534,3 +535,4 @@ class Oas {
 
 module.exports = Oas;
 module.exports.Operation = Operation;
+module.exports.Callback = Callback;

--- a/src/operation/get-callback-examples.js
+++ b/src/operation/get-callback-examples.js
@@ -1,0 +1,30 @@
+const getResponseExamples = require('./get-response-examples');
+
+/**
+ * @param {object} operation
+ */
+module.exports = operation => {
+  // spreads the contents of the map for each callback so there's not nested arrays returned
+  return [].concat(
+    ...Object.keys(operation.callbacks || {}).map(identifier => {
+      // spreads the contents again so there's not nested arrays returned
+      return []
+        .concat(
+          ...Object.keys(operation.callbacks[identifier]).map(expression => {
+            return Object.keys(operation.callbacks[identifier][expression]).map(method => {
+              const example = getResponseExamples(operation.callbacks[identifier][expression][method]);
+              if (example.length === 0) return false;
+
+              return {
+                identifier,
+                expression,
+                method,
+                example,
+              };
+            });
+          })
+        )
+        .filter(Boolean);
+    })
+  );
+};


### PR DESCRIPTION
## 🧰 Changes

Because upgrading our implementation of this library is taking a bit longer than I had hoped I'm pulling down the callbacks work we did in https://github.com/readmeio/oas/pull/515 and https://github.com/readmeio/oas/pull/528 to the 14.x release series so @julshotal won't be blocked by me anymore.

**Do not merge this.** I am planning on tagging a release directly from this branch.

## 🧬 QA & Testing

* [ ] Do all tests pass?
* [ ] Is everything here that needs to be?