### PR TITLE
fix: exposing response header descriptions in response json schema

### DIFF
--- a/__tests__/operation/get-response-as-json-schema.test.js
+++ b/__tests__/operation/get-response-as-json-schema.test.js
@@ -196,13 +196,14 @@ describe('content type handling', () => {
 
 describe('`headers` support', () => {
   // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responseObject
-  it('should include headers (OAS 3.0.3) if they exist', () => {
+  it('should include headers if they exist', () => {
     const oas = createOas({
       responses: {
         200: {
           description: 'response level description',
           headers: {
             foo: {
+              description: 'this is a description for the foo header',
               schema: { type: 'string' },
             },
             bar: {
@@ -218,7 +219,18 @@ describe('`headers` support', () => {
         label: 'Headers',
         description: 'response level description',
         type: 'object',
-        schema: simpleObjectSchema(),
+        schema: {
+          type: 'object',
+          properties: {
+            foo: {
+              description: 'this is a description for the foo header',
+              type: 'string',
+            },
+            bar: {
+              type: 'number',
+            },
+          },
+        },
       },
     ]);
   });

--- a/src/operation/get-response-as-json-schema.js
+++ b/src/operation/get-response-as-json-schema.js
@@ -25,6 +25,9 @@ function buildHeadersSchema(response) {
       //    This means they can have content instead of schema.
       //    We should probably support that in the future
       headersSchema.properties[key] = toJSONSchema(headers[key].schema);
+      if (headers[key].description) {
+        headersSchema.properties[key].description = headers[key].description;
+      }
     }
   });
 


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug in our `getResponseAsJsonSchema()` library where if a [response header](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#headerObject) had a description it wouldn't get picked up into the compiled JSON Schema representation.

Fix in support of RM-2778.

## 🧬 QA & Testing

See tests.