### PR TITLE
fix(jsonschema): move the  version identifier to a better location

### DIFF
--- a/__tests__/__snapshots__/operation.test.ts.snap
+++ b/__tests__/__snapshots__/operation.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`#getParametersAsJsonSchema() should return json schema 1`] = `
 Array [
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Body Params",
     "schema": Object {
       "$ref": "#/components/schemas/Pet",
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
         "requestBodies": Object {
           "Pet": Object {

--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -925,6 +925,7 @@ describe('`example` / `examples` support', () => {
 
     const schema: SchemaObject = oas.operation('/', 'post').getParametersAsJsonSchema();
     expect(schema[0].schema).toStrictEqual({
+      $schema: 'http://json-schema.org/draft-04/schema#',
       type: 'object',
       properties: {
         taxInfo: {
@@ -983,6 +984,10 @@ describe('`example` / `examples` support', () => {
     });
 
     const schema: SchemaObject = oas.operation('/', 'post').getParametersAsJsonSchema();
-    expect(schema[0].schema).toStrictEqual({ type: 'object', properties: { limit: { type: 'integer' } } });
+    expect(schema[0].schema).toStrictEqual({
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'object',
+      properties: { limit: { type: 'integer' } },
+    });
   });
 });

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.js.snap
@@ -97,6 +97,7 @@ Array [
   Object {
     "deprecatedProps": Object {
       "schema": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "properties": Object {
           "filterLegacy": Object {
             "$schema": "http://json-schema.org/draft-04/schema#",
@@ -154,9 +155,9 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paramet
     "type": "query",
   },
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "deprecatedProps": Object {
       "schema": Object {
+        "$schema": "http://json-schema.org/draft-04/schema#",
         "properties": Object {
           "category_alt": Object {
             "deprecated": true,
@@ -233,6 +234,7 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-
     },
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "category": Object {
           "properties": Object {
@@ -437,9 +439,9 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-
 exports[`deprecated polymorphism should pass through deprecated on an allOf schema 1`] = `
 Array [
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "allOf": Array [
         Object {
           "properties": Object {
@@ -511,9 +513,9 @@ Array [
 exports[`polymorphism / discriminators should retain discriminator \`mapping\` refs when present 1`] = `
 Array [
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
         "schemas": Object {
           "OptionOneNoDisc": Object {
@@ -596,9 +598,9 @@ Array [
 exports[`request bodies should convert request bodies to JSON schema (application/json) 1`] = `
 Array [
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "category": Object {
           "properties": Object {
@@ -697,9 +699,9 @@ Array [
     "type": "path",
   },
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Form Data",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "name": Object {
           "description": "Updated name of the pet",
@@ -748,9 +750,9 @@ Array [
     "type": "query",
   },
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Body Params",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "a": Object {
           "type": "string",
@@ -836,9 +838,9 @@ Array [
     "type": "cookie",
   },
   Object {
-    "$schema": "http://json-schema.org/draft-04/schema#",
     "label": "Form Data",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "properties": Object {
         "a": Object {
           "type": "string",

--- a/__tests__/operation/get-parameters-as-json-schema.test.js
+++ b/__tests__/operation/get-parameters-as-json-schema.test.js
@@ -621,6 +621,7 @@ describe('deprecated', () => {
             type: 'header',
             schema: {
               type: 'object',
+              $schema: 'http://json-schema.org/draft-04/schema#',
               properties: {
                 Accept: {
                   $schema: 'http://json-schema.org/draft-04/schema#',
@@ -671,6 +672,7 @@ describe('deprecated', () => {
       await oas.dereference();
       expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].deprecatedProps.schema).toStrictEqual({
         type: 'object',
+        $schema: 'http://json-schema.org/draft-04/schema#',
         properties: {
           pathId: {
             $schema: 'http://json-schema.org/draft-04/schema#',
@@ -737,15 +739,16 @@ describe('deprecated', () => {
           type: 'body',
           label: 'Body Params',
           schema: {
+            $schema: 'http://json-schema.org/draft-04/schema#',
             properties: {
               uri: { type: 'string', format: 'uri' },
             },
             type: 'object',
           },
-          $schema: 'http://json-schema.org/draft-04/schema#',
           deprecatedProps: {
             type: 'body',
             schema: {
+              $schema: 'http://json-schema.org/draft-04/schema#',
               properties: {
                 messages: {
                   type: 'array',

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -119,7 +119,10 @@ export default (path: string, operation: OperationObject, api: OASDocument, glob
 
     return {
       type,
-      schema: deprecatedSchema,
+      schema: {
+        ...deprecatedSchema,
+        $schema: getSchemaVersionString(deprecatedSchema, api),
+      },
     };
   }
 
@@ -156,10 +159,12 @@ export default (path: string, operation: OperationObject, api: OASDocument, glob
     }
 
     return {
-      $schema: getSchemaVersionString(cleanedSchema, api),
       type,
       label: types[type],
-      schema: cleanedSchema,
+      schema: {
+        ...cleanedSchema,
+        $schema: getSchemaVersionString(cleanedSchema, api),
+      },
       deprecatedProps: getDeprecated(cleanedSchema, type),
     };
   }


### PR DESCRIPTION
## 🧰 Changes

This moves the `$schema` identifier applied to json schemas to a more accessible location for the frontend.
It also adds it to deprecated params

## 🧬 QA & Testing

Tests
