### PR TITLE
fix: upgrading oas-normalize to fix a rare npm installation issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^5.0.2"
@@ -1165,6 +1165,14 @@
         "node": ">=10.10.0"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
+      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA==",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -1771,12 +1779,13 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
-      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
+      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -1823,34 +1832,10 @@
         "prettier": "^2.0.2"
       }
     },
-    "node_modules/@readme/oas-examples": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
-      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
-      "dev": true
-    },
-    "node_modules/@readme/openapi-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.1.0.tgz",
-      "integrity": "sha512-gGoZk7yZ1MIFaFYgqm6HVaXgeIs4hCvVLys801llZF9CcXXE4DWBrpUk1VgU94cA08th6GWBLcMHiREr65Cw1A==",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-        "@apidevtools/openapi-schemas": "^2.1.0",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.1.0",
-        "ajv": "^8.6.3",
-        "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "license": "MIT",
+    "node_modules/@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -1858,40 +1843,12 @@
         "js-yaml": "^4.1.0"
       }
     },
-    "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/ajv-draft-04": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-      "peerDependencies": {
-        "ajv": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/argparse": {
+    "node_modules/@readme/json-schema-ref-parser/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/@readme/openapi-parser/node_modules/js-yaml": {
+    "node_modules/@readme/json-schema-ref-parser/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
@@ -1902,10 +1859,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/@readme/openapi-parser/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    "node_modules/@readme/oas-examples": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
+      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -8247,17 +8205,63 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.3.tgz",
-      "integrity": "sha512-9LTMftmjA1YI2I8L1liwkW276zUoyyRTBOBxA1Q9iOiIiHwXtU65nIe6zsNVzwCYWA1NQdEjpEnagSVN+ZHwng==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "dependencies": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
+      }
+    },
+    "node_modules/oas-normalize/node_modules/@readme/openapi-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+      "dependencies": {
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/oas-normalize/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/oas-normalize/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/oas-normalize/node_modules/argparse": {
@@ -8275,6 +8279,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/oas-normalize/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
@@ -11197,6 +11206,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "@humanwhocodes/momoa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.2.tgz",
+      "integrity": "sha512-mkMcsshJ7L17AyntqpyjLiGqhbG62w93B0StW+HSNVJ1WUeVFA2uPssV/GufEfDqN6lRKI1I+uDzBUw83C0VuA=="
+    },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
@@ -11705,12 +11719,13 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.1.1.tgz",
-      "integrity": "sha512-3FmPBv2fYj2Qgvg8Qq3wEL7CxLPA6nwkVGafdEfS/85DIUx9z0iZcHu48no/l0HOk9PCKUDqpinN6bTtLxD0og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.3.0.tgz",
+      "integrity": "sha512-9yDff0hkbJJ/KaT+pVdHi6+2FeHsaImOz/LGqYp/auMBFSzUcP+y2kcte0pHrnePHgPp+Lt5H91RS5unwM++6Q==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
         "@babel/runtime": "^7.16.0",
+        "@humanwhocodes/momoa": "^2.0.2",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
         "jsonpointer": "^5.0.0",
@@ -11743,54 +11758,17 @@
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
-    "@readme/oas-examples": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
-      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
-      "dev": true
-    },
-    "@readme/openapi-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.1.0.tgz",
-      "integrity": "sha512-gGoZk7yZ1MIFaFYgqm6HVaXgeIs4hCvVLys801llZF9CcXXE4DWBrpUk1VgU94cA08th6GWBLcMHiREr65Cw1A==",
+    "@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-        "@apidevtools/openapi-schemas": "^2.1.0",
-        "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.1.0",
-        "ajv": "^8.6.3",
-        "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       },
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-          "version": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-          "from": "@apidevtools/json-schema-ref-parser@github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-          "requires": {
-            "@jsdevtools/ono": "^7.1.3",
-            "@types/json-schema": "^7.0.6",
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^4.1.0"
-          }
-        },
-        "ajv": {
-          "version": "8.6.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-          "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-draft-04": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
-          "requires": {}
-        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -11803,13 +11781,14 @@
           "requires": {
             "argparse": "^2.0.1"
           }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
+    },
+    "@readme/oas-examples": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
+      "integrity": "sha512-zEK4w0BtSc5f4To7LyFOyGdv/El2oOy/xbU3KW3kzmbH3P4ZFYAHpMrXViZYsKjUZJ5w8VGNJeVfTXVs89eZkA==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -16724,16 +16703,48 @@
       }
     },
     "oas-normalize": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.3.tgz",
-      "integrity": "sha512-9LTMftmjA1YI2I8L1liwkW276zUoyyRTBOBxA1Q9iOiIiHwXtU65nIe6zsNVzwCYWA1NQdEjpEnagSVN+ZHwng==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "requires": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
       },
       "dependencies": {
+        "@readme/openapi-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+          "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+          "requires": {
+            "@apidevtools/openapi-schemas": "^2.1.0",
+            "@apidevtools/swagger-methods": "^3.0.2",
+            "@jsdevtools/ono": "^7.1.3",
+            "@readme/better-ajv-errors": "^1.1.0",
+            "@readme/json-schema-ref-parser": "^1.0.0",
+            "ajv": "^8.6.3",
+            "ajv-draft-04": "^1.0.0",
+            "call-me-maybe": "^1.0.1"
+          }
+        },
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-draft-04": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+          "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+          "requires": {}
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -16746,6 +16757,11 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jsonpointer": "^5.0.0",
     "memoizee": "^0.4.14",
     "minimist": "^1.2.0",
-    "oas-normalize": "^5.0.1",
+    "oas-normalize": "^5.0.5",
     "openapi-types": "^9.3.0",
     "path-to-regexp": "^6.2.0",
     "swagger-inline": "^5.0.2"


### PR DESCRIPTION
## 🧰 Changes

Upgrades `oas-normalize` and its dependency on `@readme/openapi-parser` to fix a rare NPM installation issue where Git might not be available.

Fix in support of https://github.com/readmeio/rdme/issues/401.

## 🧬 QA & Testing

If tests still all pass this is good to go.