### PR TITLE
fix: backport a typescript compat fix that fixed enum array spreading

### DIFF
--- a/src/lib/openapi-to-json-schema.js
+++ b/src/lib/openapi-to-json-schema.js
@@ -468,7 +468,9 @@ function toJSONSchema(data, opts = {}) {
 
   // Enums should not have duplicated items as those will break AJV validation.
   if ('enum' in schema && Array.isArray(schema.enum)) {
-    schema.enum = [...new Set(schema.enum)];
+    // If we ever target ES6 for typescript we can drop this array.from.
+    // https://stackoverflow.com/questions/33464504/using-spread-syntax-and-new-set-with-typescript/56870548
+    schema.enum = Array.from(new Set(schema.enum));
   }
 
   // Clean up any remaining `items` or `properties` schema fragments lying around if there's also polymorphism present.


### PR DESCRIPTION
## 🧰 Changes

This backports a Typescript compatibility fix that was made in https://github.com/readmeio/oas/pull/530 ([specific line here](https://github.com/readmeio/oas/blame/main/src/lib/openapi-to-json-schema.ts#L510-L511)) with regard to how we were using the spread operator with `Set()`. With our current Typescript config doing `[...new Set(['1', '2'])]` generates an empty array because TS can't convert the Set object into an array. This is easily resolved by changing that line to `Array.from(new Set(['1', '2']))`.

🚨 This is currently killing all enums in production right now. 🚨

I've created this branch off the 17.1.6 release that we're running in production so when this fix is OK'd I'm going to tag a 17.1.7 release off this branch.

## 🧬 QA & Testing

Since this problem only surfaces itself in the compiled TS code you can run the following code to see the before and after of the fix. In order to see the before/broken state with this code you might want to check out 17.1.6 first, run an `npm run build` and then run this code. After checking into this branch fix run `npm run build` again to compile the fix.

```js
const Oas = require('.').default;

const spec = {
  openapi: '3.0.0',
  info: {
    title: 'fixed enums',
    version: '1.0.0',
  },
  servers: [{ url: 'https://httpbin.org' }],
  paths: {
    '/anything': {
      post: {
        requestBody: {
          content: {
            'application/json': {
              schema: {
                type: 'object',
                properties: {
                  enumType: {
                    enum: ['pug', 'cat'],
                    type: 'string',
                  },
                },
              },
            },
          },
        },
        responses: {
          200: {
            description: 'OK',
          },
        },
      },
    },
  },
};

(async () => {
  const oas = new Oas(spec);
  await oas.dereference();

  console.log(oas.operation('/anything', 'post').getParametersAsJsonSchema()[0].schema.properties.enumType);
})();
```

You should see this:

```js
{ enum: [ 'pug', 'cat' ], type: 'string' }
```

Not this:

```js
{ enum: [ ], type: 'string' }
```