### PR TITLE
feat: adding accessors for operation summary and description

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -22,6 +22,28 @@ describe('#constructor', () => {
   });
 });
 
+describe('#getSummary()', () => {
+  it('should return a summary if present', () => {
+    expect(Oas.init(petstore).operation('/pet/findByTags', 'get').getSummary()).toBe('Finds Pets by tags');
+  });
+
+  it('should return nothing if not present', () => {
+    expect(Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get').getSummary()).toBeUndefined();
+  });
+});
+
+describe('#getDescription()', () => {
+  it('should return a description if present', () => {
+    expect(Oas.init(petstore).operation('/pet/findByTags', 'get').getDescription()).toBe(
+      'Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+    );
+  });
+
+  it('should return nothing if not present', () => {
+    expect(Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get').getDescription()).toBeUndefined();
+  });
+});
+
 describe('#getContentType()', () => {
   it('should return the content type on an operation', () => {
     expect(Oas.init(petstore).operation('/pet', 'post').getContentType()).toBe('application/json');

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -75,6 +75,14 @@ export default class Operation {
     this.callbackExamples = undefined;
   }
 
+  getSummary(): string {
+    return this.schema?.summary;
+  }
+
+  getDescription(): string {
+    return this.schema?.description;
+  }
+
   getContentType(): string {
     if (this.contentType) {
       return this.contentType;

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -76,11 +76,11 @@ export default class Operation {
   }
 
   getSummary(): string {
-    return this.schema?.summary;
+    return this.schema?.summary ? this.schema.summary.trim() : undefined;
   }
 
   getDescription(): string {
-    return this.schema?.description;
+    return this.schema?.description ? this.schema.description.trim() : undefined;
   }
 
   getContentType(): string {


### PR DESCRIPTION
## 🧰 Changes

Adds two new accessors to `Operation` (and `Callback`) instances: 

* [x] `getSummary()`
* [x] `getDescription()`
