### PR TITLE
fix: improved support for common params

### DIFF
--- a/__tests__/__datasets__/parameters-common.json
+++ b/__tests__/__datasets__/parameters-common.json
@@ -1,0 +1,75 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Common parameters",
+    "description": "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#path-item-object",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything/{id}": {
+      "summary": "[common] Summary",
+      "description": "[common] Description",
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "schema": {
+            "type": "number"
+          },
+          "required": true
+        },
+        {
+          "in": "header",
+          "name": "x-extra-id",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "[get] Summary",
+        "description": "[get] Description",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "summary": "[post] Summary",
+        "description": "[post] Description",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "limitParam": {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 20
+        },
+        "description": "The numbers of items to return."
+      }
+    }
+  }
+}

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -5,6 +5,7 @@ import callbackSchema from './__datasets__/callbacks.json';
 import multipleSecurities from './__datasets__/multiple-securities.json';
 import referenceSpec from './__datasets__/local-link.json';
 import deprecatedSchema from './__datasets__/schema-deprecated.json';
+import parametersCommon from './__datasets__/parameters-common.json';
 
 describe('#constructor', () => {
   const oas = Oas.init(petstore);
@@ -30,6 +31,10 @@ describe('#getSummary()', () => {
   it('should return nothing if not present', () => {
     expect(Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get').getSummary()).toBeUndefined();
   });
+
+  it('should allow a common summary to override the operation-level summary', () => {
+    expect(Oas.init(parametersCommon).operation('/anything/{id}', 'get').getSummary()).toBe('[common] Summary');
+  });
 });
 
 describe('#getDescription()', () => {
@@ -41,6 +46,10 @@ describe('#getDescription()', () => {
 
   it('should return nothing if not present', () => {
     expect(Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get').getDescription()).toBeUndefined();
+  });
+
+  it('should allow a common description to override the operation-level summary', () => {
+    expect(Oas.init(parametersCommon).operation('/anything/{id}', 'get').getDescription()).toBe('[common] Description');
   });
 });
 

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -976,7 +976,7 @@ describe('#getCallbacks()', () => {
     expect(operation.getCallbacks()).toBe(false);
   });
 
-  it("should return an empty object for the operation if only only callbacks present aren't supported HTTP methods", () => {
+  it("should return an empty object for the operation if only callbacks present aren't supported HTTP methods", () => {
     const oas = Oas.init({
       openapi: '3.1.0',
       info: {

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -989,6 +989,8 @@ describe('#getCallbacks()', () => {
             callbacks: {
               batchSuccess: {
                 '{$url}': {
+                  // Instead of `post`, `get`, etc being here we just have `summary` and since that isn't a valid HTTP
+                  // method we don't have any usable callbacks here to pull back with `getCallbacks`().
                   summary: 'Batch call webhook',
                 },
               },

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -966,6 +966,31 @@ describe('#getCallbacks()', () => {
     const operation = Oas.init(petstore).operation('/pet', 'put');
     expect(operation.getCallbacks()).toBe(false);
   });
+
+  it("should return an empty object for the operation if only only callbacks present aren't supported HTTP methods", () => {
+    const oas = Oas.init({
+      openapi: '3.1.0',
+      info: {
+        version: '1.0.0',
+        title: 'operation with just common param callbacks',
+      },
+      paths: {
+        '/anything': {
+          post: {
+            callbacks: {
+              batchSuccess: {
+                '{$url}': {
+                  summary: 'Batch call webhook',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(oas.operation('/anything', 'post').getCallbacks()).toStrictEqual([]);
+  });
 });
 
 describe('#getCallbackExamples()', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { pathToRegexp, match } from 'path-to-regexp';
 import getAuth from './lib/get-auth';
 import getUserVariable from './lib/get-user-variable';
 import Operation, { Callback, Webhook } from './operation';
-import utils from './utils';
+import utils, { supportedMethods } from './utils';
 
 type PathMatch = {
   url: {
@@ -640,7 +640,6 @@ export default class Oas {
     // the paths object that isn't a known HTTP method.
     // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-7
     // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-7
-    const supportedMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
     const paths: Record<string, Record<RMOAS.HttpMethods, Operation | Webhook>> = {};
 
     Object.keys(this.api.paths ? this.api.paths : []).forEach(path => {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -77,10 +77,18 @@ export default class Operation {
   }
 
   getSummary(): string {
+    if (this.api.paths[this.path].summary) {
+      return this.api.paths[this.path].summary;
+    }
+
     return this.schema?.summary ? this.schema.summary.trim() : undefined;
   }
 
   getDescription(): string {
+    if (this.api.paths[this.path].description) {
+      return this.api.paths[this.path].description;
+    }
+
     return this.schema?.description ? this.schema.description.trim() : undefined;
   }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -11,6 +11,7 @@ import getRequestBodyExamples from './operation/get-requestbody-examples';
 import getCallbackExamples from './operation/get-callback-examples';
 import getResponseExamples from './operation/get-response-examples';
 import matchesMimeType from './lib/matches-mimetype';
+import { supportedMethods } from './utils';
 
 type SecurityType = 'Basic' | 'Bearer' | 'Query' | 'Header' | 'Cookie' | 'OAuth2' | 'http' | 'apiKey';
 
@@ -527,6 +528,8 @@ export default class Operation {
 
           if (!RMOAS.isRef(exp)) {
             Object.keys(exp).forEach((method: RMOAS.HttpMethods) => {
+              if (!supportedMethods.has(method)) return;
+
               callbackOperations.push(this.getCallback(callback, expression, method));
             });
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,13 @@ import getSchema from './lib/get-schema';
 import matchesMimeType from './lib/matches-mimetype';
 import { types as jsonSchemaTypes } from './operation/get-parameters-as-json-schema';
 
+const supportedMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+
 export default {
   findSchemaDefinition,
   getSchema,
   jsonSchemaTypes,
   matchesMimeType,
 };
+
+export { supportedMethods };


### PR DESCRIPTION
## 🧰 Changes

* [x] Updates our `getCallbacks()` accessor to stop including non-method items (like common parameters) from being returned as a callback.
* [x] Updates our `getSummary()` and `getDescription()` accessors to allow commonly set summary and descriptions to override those at the path item level.

## 🧬 QA & Testing

See tests.