### PR TITLE
fix: callbacks not having path-level data to retrieve common summaries

### DIFF
--- a/__tests__/__datasets__/callbacks.json
+++ b/__tests__/__datasets__/callbacks.json
@@ -24,6 +24,8 @@
           "myCallback": {
             "{$request.query.queryUrl}": {
               "post": {
+                "summary": "Callback summary",
+                "description": "Callback description",
                 "requestBody": {
                   "description": "Callback payload",
                   "content": {
@@ -81,6 +83,8 @@
               }
             },
             "{$request.multipleMethod.queryUrl}": {
+              "summary": "[common] callback summary",
+              "description": "[common] callback description",
               "post": {
                 "requestBody": {
                   "description": "Callback payload",

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -989,7 +989,7 @@ describe('#getCallback()', () => {
     expect(callback.path).toBe('{$request.multipleMethod.queryUrl}');
     expect(callback).toBeInstanceOf(Callback);
 
-    expect(callback.parent).toStrictEqual({
+    expect(callback.parentSchema).toStrictEqual({
       summary: '[common] callback summary',
       description: '[common] callback description',
       post: {

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -23,33 +23,62 @@ describe('#constructor', () => {
   });
 });
 
-describe('#getSummary()', () => {
-  it('should return a summary if present', () => {
-    expect(Oas.init(petstore).operation('/pet/findByTags', 'get').getSummary()).toBe('Finds Pets by tags');
-  });
+describe('#getSummary() + #getDescription()', () => {
+  it('should return if present', () => {
+    const operation = Oas.init(petstore).operation('/pet/findByTags', 'get');
 
-  it('should return nothing if not present', () => {
-    expect(Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get').getSummary()).toBeUndefined();
-  });
-
-  it('should allow a common summary to override the operation-level summary', () => {
-    expect(Oas.init(parametersCommon).operation('/anything/{id}', 'get').getSummary()).toBe('[common] Summary');
-  });
-});
-
-describe('#getDescription()', () => {
-  it('should return a description if present', () => {
-    expect(Oas.init(petstore).operation('/pet/findByTags', 'get').getDescription()).toBe(
+    expect(operation.getSummary()).toBe('Finds Pets by tags');
+    expect(operation.getDescription()).toBe(
       'Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
     );
   });
 
   it('should return nothing if not present', () => {
-    expect(Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get').getDescription()).toBeUndefined();
+    const operation = Oas.init(referenceSpec).operation('/2.0/users/{username}', 'get');
+
+    expect(operation.getSummary()).toBeUndefined();
+    expect(operation.getDescription()).toBeUndefined();
   });
 
-  it('should allow a common description to override the operation-level summary', () => {
-    expect(Oas.init(parametersCommon).operation('/anything/{id}', 'get').getDescription()).toBe('[common] Description');
+  it('should allow a common summary to override the operation-level summary', () => {
+    const operation = Oas.init(parametersCommon).operation('/anything/{id}', 'get');
+
+    expect(operation.getSummary()).toBe('[common] Summary');
+    expect(operation.getDescription()).toBe('[common] Description');
+  });
+
+  describe('callbacks', () => {
+    it('should return a summary if present', () => {
+      const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
+      const callback = operation.getCallback('myCallback', '{$request.query.queryUrl}', 'post') as Callback;
+
+      expect(callback.getSummary()).toBe('Callback summary');
+      expect(callback.getDescription()).toBe('Callback description');
+    });
+
+    it('should return nothing if present', () => {
+      const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
+      const callback = operation.getCallback(
+        'multipleCallback',
+        '{$request.multipleExpression.queryUrl}',
+        'post'
+      ) as Callback;
+
+      expect(callback.getSummary()).toBeUndefined();
+      expect(callback.getDescription()).toBeUndefined();
+    });
+
+    it('should allow a common summary to override the callback-level summary', () => {
+      const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
+      const callback = operation.getCallback(
+        'multipleCallback',
+        '{$request.multipleMethod.queryUrl}',
+        'post'
+      ) as Callback;
+
+      expect(callback.getSummary()).toBe('[common] callback summary');
+      expect(callback.getDescription()).toBe('[common] callback description');
+    });
   });
 });
 
@@ -949,12 +978,28 @@ describe('#hasCallbacks()', () => {
 describe('#getCallback()', () => {
   it('should return an operation from a callback if it exists', () => {
     const operation = Oas.init(callbackSchema).operation('/callbacks', 'get');
-    const callback = operation.getCallback('myCallback', '{$request.query.queryUrl}', 'post') as Callback;
+    const callback = operation.getCallback(
+      'multipleCallback',
+      '{$request.multipleMethod.queryUrl}',
+      'post'
+    ) as Callback;
 
-    expect(callback.identifier).toBe('myCallback');
+    expect(callback.identifier).toBe('multipleCallback');
     expect(callback.method).toBe('post');
-    expect(callback.path).toBe('{$request.query.queryUrl}');
+    expect(callback.path).toBe('{$request.multipleMethod.queryUrl}');
     expect(callback).toBeInstanceOf(Callback);
+
+    expect(callback.parent).toStrictEqual({
+      summary: '[common] callback summary',
+      description: '[common] callback description',
+      post: {
+        requestBody: expect.any(Object),
+        responses: expect.any(Object),
+      },
+      get: {
+        responses: expect.any(Object),
+      },
+    });
   });
 
   it('should return false if that callback doesnt exist', () => {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -515,7 +515,7 @@ export default class Operation {
       : false;
 
     if (!callback || !callback[method]) return false;
-    return new Callback(this.api, expression, method, callback[method], identifier);
+    return new Callback(this.api, expression, method, callback[method], identifier, callback);
   }
 
   /**
@@ -593,16 +593,23 @@ export class Callback extends Operation {
    */
   identifier: string;
 
+  /**
+   * The parent path item object that this Callback exists within.
+   */
+  parent: RMOAS.PathItemObject;
+
   constructor(
     oas: RMOAS.OASDocument,
     path: string,
     method: RMOAS.HttpMethods,
     operation: RMOAS.OperationObject,
-    identifier: string
+    identifier: string,
+    parentPathItem: RMOAS.PathItemObject
   ) {
     super(oas, path, method, operation);
 
     this.identifier = identifier;
+    this.parent = parentPathItem;
   }
 
   /**
@@ -614,6 +621,22 @@ export class Callback extends Operation {
    */
   getIdentifier(): string {
     return this.identifier;
+  }
+
+  getSummary(): string {
+    if (this.parent.summary) {
+      return this.parent.summary;
+    }
+
+    return this.schema?.summary ? this.schema.summary.trim() : undefined;
+  }
+
+  getDescription(): string {
+    if (this.parent.description) {
+      return this.parent.description;
+    }
+
+    return this.schema?.description ? this.schema.description.trim() : undefined;
   }
 }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -596,7 +596,7 @@ export class Callback extends Operation {
   /**
    * The parent path item object that this Callback exists within.
    */
-  parent: RMOAS.PathItemObject;
+  parentSchema: RMOAS.PathItemObject;
 
   constructor(
     oas: RMOAS.OASDocument,
@@ -609,7 +609,7 @@ export class Callback extends Operation {
     super(oas, path, method, operation);
 
     this.identifier = identifier;
-    this.parent = parentPathItem;
+    this.parentSchema = parentPathItem;
   }
 
   /**
@@ -624,16 +624,16 @@ export class Callback extends Operation {
   }
 
   getSummary(): string {
-    if (this.parent.summary) {
-      return this.parent.summary;
+    if (this.parentSchema.summary) {
+      return this.parentSchema.summary;
     }
 
     return this.schema?.summary ? this.schema.summary.trim() : undefined;
   }
 
   getDescription(): string {
-    if (this.parent.description) {
-      return this.parent.description;
+    if (this.parentSchema.description) {
+      return this.parentSchema.description;
     }
 
     return this.schema?.description ? this.schema.description.trim() : undefined;


### PR DESCRIPTION
## 🧰 Changes

This fixes a regression I introduced in #563 where if you execute either `getSummary()` or `getDescription()` on a `Callback` instance they would fail because the callback doesn't have access to the root `path` data for `this.api.paths`.

To fix this I've overridden the two methods in the `Callback` class to utilize a new `parent` data that the `Callback` constructor now requires so all callbacks have access to their immediate parent [path item object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#pathItemObject) where common summary and description information is stored.

This was a doozy to brain out.

## 🧬 QA & Testing

I've merged the `getSummary()` and `getDescription()` tests into a single block because they were both loading the same operations for their tests -- should hopefully make those tests a little cleaner.