### PR TITLE
feat: addition of a getRequestBody accessor

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -933,6 +933,56 @@ describe('#hasRequestBody()', () => {
   });
 });
 
+describe('#getRequestBody()', () => {
+  it('should return false on an operation without a requestBody', async () => {
+    const oas = Oas.init(petstore);
+    await oas.dereference();
+
+    const operation = oas.operation('/pet/findByStatus', 'get');
+    expect(operation.getRequestBody('application/json')).toBe(false);
+  });
+
+  it('should return false on an operation without the specified requestBody media type', async () => {
+    const oas = Oas.init(petstore);
+    await oas.dereference();
+
+    const operation = oas.operation('/pet', 'put');
+    expect(operation.getRequestBody('text/xml')).toBe(false);
+  });
+
+  it('should return the specified requestBody media type', async () => {
+    const oas = Oas.init(petstore);
+    await oas.dereference();
+
+    const operation = oas.operation('/pet', 'put');
+    expect(operation.getRequestBody('application/json')).toStrictEqual({
+      schema: {
+        properties: {
+          category: expect.objectContaining({ 'x-readme-ref-name': 'Category' }),
+          id: expect.any(Object),
+          name: expect.any(Object),
+          photoUrls: expect.any(Object),
+          status: expect.any(Object),
+          tags: {
+            items: expect.objectContaining({ 'x-readme-ref-name': 'Tag' }),
+            type: 'array',
+            xml: {
+              name: 'tag',
+              wrapped: true,
+            },
+          },
+        },
+        required: ['name', 'photoUrls'],
+        type: 'object',
+        xml: {
+          name: 'Pet',
+        },
+        'x-readme-ref-name': 'Pet',
+      },
+    });
+  });
+});
+
 describe('#getResponseByStatusCode()', () => {
   it('should return false if the status code doesnt exist', () => {
     const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -950,6 +950,47 @@ describe('#getRequestBody()', () => {
     expect(operation.getRequestBody('text/xml')).toBe(false);
   });
 
+  it('should return false on an operation with a non-dereferenced $ref pointer', () => {
+    const oas = Oas.init({
+      openapi: '3.1.0',
+      info: {
+        title: 'testing',
+        version: '1.0.0',
+      },
+      components: {
+        requestBodies: {
+          Pet: {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Pet',
+                },
+              },
+            },
+            required: true,
+          },
+        },
+        schemas: {
+          Pet: {
+            type: 'string',
+          },
+        },
+      },
+      paths: {
+        '/anything': {
+          post: {
+            requestBody: {
+              $ref: '#/components/requestBodies/Pet',
+            },
+          },
+        },
+      },
+    });
+
+    const operation = oas.operation('/anything', 'post');
+    expect(operation.getRequestBody('application/json')).toBe(false);
+  });
+
   it('should return the specified requestBody media type', async () => {
     const oas = Oas.init(petstore);
     await oas.dereference();

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -989,28 +989,27 @@ describe('#getResponseByStatusCode()', () => {
     expect(operation.getResponseByStatusCode(202)).toBe(false);
   });
 
-  it('should return the response', () => {
-    const operation = Oas.init(petstore).operation('/pet/findByStatus', 'get');
+  it('should return the response', async () => {
+    const oas = Oas.init(petstore);
+    await oas.dereference();
+
+    const operation = oas.operation('/pet/findByStatus', 'get');
     expect(operation.getResponseByStatusCode(200)).toStrictEqual({
+      description: 'successful operation',
       content: {
         'application/json': {
           schema: {
-            items: {
-              $ref: '#/components/schemas/Pet',
-            },
             type: 'array',
+            items: expect.any(Object),
           },
         },
         'application/xml': {
           schema: {
-            items: {
-              $ref: '#/components/schemas/Pet',
-            },
             type: 'array',
+            items: expect.any(Object),
           },
         },
       },
-      description: 'successful operation',
     });
   });
 });

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -419,11 +419,29 @@ export default class Operation {
   }
 
   /**
-   * Determine if the operation has a request body.
+   * Determine if the operation has any request bodies.
    *
    */
   hasRequestBody(): boolean {
     return !!this.schema.requestBody;
+  }
+
+  /**
+   * Retrieve a specific request body content schema off this operation.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject}
+   * @param mediaType Specific request body media type to retrieve if present.
+   */
+  getRequestBody(mediaType: string) {
+    const requestBody = this.schema.requestBody;
+    if (!requestBody || RMOAS.isRef(requestBody) || RMOAS.isRef(requestBody.content)) {
+      return false;
+    } else if (!(mediaType in requestBody.content)) {
+      return false;
+    }
+
+    return requestBody.content[mediaType];
   }
 
   /**

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -434,10 +434,12 @@ export default class Operation {
    * @param mediaType Specific request body media type to retrieve if present.
    */
   getRequestBody(mediaType: string) {
-    const requestBody = this.schema.requestBody;
-    if (!requestBody || RMOAS.isRef(requestBody) || RMOAS.isRef(requestBody.content)) {
+    if (!this.hasRequestBody()) {
       return false;
-    } else if (!(mediaType in requestBody.content)) {
+    }
+
+    const requestBody = this.schema.requestBody;
+    if (RMOAS.isRef(requestBody) || !(mediaType in requestBody.content)) {
       return false;
     }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -440,6 +440,8 @@ export default class Operation {
 
     const requestBody = this.schema.requestBody;
     if (RMOAS.isRef(requestBody) || !(mediaType in requestBody.content)) {
+      // If the request body is still a `$ref` pointer we should return false because this library assumes that you've
+      // run dereferencing beforehand.
       return false;
     }
 


### PR DESCRIPTION
## 🧰 Changes

Adds a new `getRequestBody` accessor on the `Operation` object that pulls back a request body [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject) for any specific media type that's present on the operation.

This isn't going to be used anywhere just yet but when we refactor/rewrite the `getSchema()` library here it can be used there.

## 🧬 QA & Testing

See tests.