### PR TITLE
refactor: use default for samples over generic type

### DIFF
--- a/__tests__/samples/index.test.ts
+++ b/__tests__/samples/index.test.ts
@@ -54,13 +54,14 @@ describe('sampleFromSchema', () => {
         readOnlyDog: {
           readOnly: true,
           type: 'string',
+          default: 'woof',
         },
       },
     };
 
     const expected = {
       id: 0,
-      readOnlyDog: 'string',
+      readOnlyDog: 'woof',
     };
 
     expect(sampleFromSchema(definition, { includeReadOnly: true })).toStrictEqual(expected);
@@ -289,6 +290,17 @@ describe('sampleFromSchema', () => {
 
         expect(sampleFromSchema(definition)).toStrictEqual(expected);
       });
+
+      it('returns a default value for a number with a default present', () => {
+        const definition: RMOAS.SchemaObject = {
+          type: 'number',
+          default: 123,
+        };
+
+        const expected = 123;
+
+        expect(sampleFromSchema(definition)).toStrictEqual(expected);
+      });
     });
 
     describe('type=string', () => {
@@ -368,6 +380,17 @@ describe('sampleFromSchema', () => {
         };
 
         const expected = 'user@example.com';
+
+        expect(sampleFromSchema(definition)).toStrictEqual(expected);
+      });
+
+      it('returns a default value for a string with a default present', () => {
+        const definition: RMOAS.SchemaObject = {
+          type: 'string',
+          default: 'test',
+        };
+
+        const expected = 'test';
 
         expect(sampleFromSchema(definition)).toStrictEqual(expected);
       });

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -9,20 +9,25 @@ import { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } f
 import memoize from 'memoizee';
 import mergeAllOf from 'json-schema-merge-allof';
 
+const sampleDefaults = (genericSample: string | number | boolean) => {
+  return (schema: RMOAS.SchemaObject): typeof genericSample =>
+    typeof schema.default === typeof genericSample ? schema.default : genericSample;
+};
+
 const primitives: Record<string, (arg: void | RMOAS.SchemaObject) => string | number | boolean> = {
-  string: () => 'string',
-  string_email: () => 'user@example.com',
-  'string_date-time': () => new Date().toISOString(),
-  string_date: () => new Date().toISOString().substring(0, 10),
-  'string_YYYY-MM-DD': () => new Date().toISOString().substring(0, 10),
-  string_uuid: () => '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-  string_hostname: () => 'example.com',
-  string_ipv4: () => '198.51.100.42',
-  string_ipv6: () => '2001:0db8:5b96:0000:0000:426f:8e17:642a',
-  number: () => 0,
-  number_float: () => 0.0,
-  integer: () => 0,
-  boolean: (schema: RMOAS.SchemaObject): boolean => (typeof schema.default === 'boolean' ? schema.default : true),
+  string: sampleDefaults('string'),
+  string_email: sampleDefaults('user@example.com'),
+  'string_date-time': sampleDefaults(new Date().toISOString()),
+  string_date: sampleDefaults(new Date().toISOString().substring(0, 10)),
+  'string_YYYY-MM-DD': sampleDefaults(new Date().toISOString().substring(0, 10)),
+  string_uuid: sampleDefaults('3fa85f64-5717-4562-b3fc-2c963f66afa6'),
+  string_hostname: sampleDefaults('example.com'),
+  string_ipv4: sampleDefaults('198.51.100.42'),
+  string_ipv6: sampleDefaults('2001:0db8:5b96:0000:0000:426f:8e17:642a'),
+  number: sampleDefaults(0),
+  number_float: sampleDefaults(0.0),
+  integer: sampleDefaults(0),
+  boolean: sampleDefaults(true),
 };
 
 const primitive = (schema: RMOAS.SchemaObject) => {


### PR DESCRIPTION
## 🧰 Changes

When there's no example present, right now we just autofill the example sample with the type. This will use the default if it exists before falling back to a generic type-based sample 

I used how we were taking the default for booleans over a generic value and turned it into a reusable function to either use the default if it 1) exists and 2) is the right type, otherwise it falls back onto a provided generic value 

The type check probably isn't super necessary, but on the off chance someone tries to use a wacky default hopefully it'll prevent something from breaking
## 🧬 QA & Testing
see tests 
