### PR TITLE
fix: show response headers w/o mediaType content

### DIFF
--- a/__tests__/__datasets__/operation-examples.json
+++ b/__tests__/__datasets__/operation-examples.json
@@ -691,15 +691,6 @@
                 "name": "Test user name"
               }
             }
-          },
-          "headers": {
-            "request-header": {
-              "description": "A request header",
-              "style": "simple",
-              "schema": {
-                "type": "string"
-              }
-            }
           }
         },
         "responses": {

--- a/__tests__/__datasets__/operation-examples.json
+++ b/__tests__/__datasets__/operation-examples.json
@@ -681,8 +681,17 @@
     },
     "/headers-but-no-content": {
       "post": {
-        "description": "This operation has request and response headers but no content or media types",
+        "description": "This operation has response headers but no response content or media types",
         "requestBody": {
+          "content": {
+            "*/*": {
+              "example": {
+                "id": 12343354,
+                "email": "test@example.com",
+                "name": "Test user name"
+              }
+            }
+          },
           "headers": {
             "request-header": {
               "description": "A request header",

--- a/__tests__/__datasets__/operation-examples.json
+++ b/__tests__/__datasets__/operation-examples.json
@@ -55,8 +55,7 @@
               "application/xml": {
                 "examples": {
                   "response": {
-                    "value":
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                    "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
                   }
                 }
               }
@@ -109,8 +108,7 @@
                       "application/xml": {
                         "examples": {
                           "response": {
-                            "value":
-                              "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                            "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
                           }
                         }
                       }
@@ -240,8 +238,7 @@
               "application/xml": {
                 "examples": {
                   "response": {
-                    "value":
-                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                    "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
                   }
                 }
               }
@@ -286,8 +283,7 @@
               "application/xml": {
                 "examples": {
                   "response": {
-                    "value":
-                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                    "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
                   }
                 }
               }
@@ -366,8 +362,7 @@
               "application/xml": {
                 "examples": {
                   "response": {
-                    "value":
-                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                    "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
                   }
                 }
               }
@@ -415,8 +410,7 @@
                       "application/xml": {
                         "examples": {
                           "response": {
-                            "value":
-                            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                            "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
                           }
                         }
                       }
@@ -684,6 +678,36 @@
           }
         }
       }
+    },
+    "/headers-but-no-content": {
+      "post": {
+        "description": "This operation has request and response headers but no content or media types",
+        "requestBody": {
+          "headers": {
+            "request-header": {
+              "description": "A request header",
+              "style": "simple",
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Location": {
+                "description": "A response header",
+                "style": "simple",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -703,8 +727,7 @@
           "application/xml": {
             "examples": {
               "response": {
-                "value":
-                  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
+                "value": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>"
               }
             }
           }

--- a/__tests__/operation/get-response-examples.test.ts
+++ b/__tests__/operation/get-response-examples.test.ts
@@ -77,6 +77,18 @@ test('should do its best at handling circular schemas', async () => {
   ]);
 });
 
+test('should return an empty object example if headers exist on a response with no content', () => {
+  const operation = oas.operation('/headers-but-no-content', 'post');
+  expect(operation.getResponseExamples()).toStrictEqual([
+    {
+      status: '200',
+      mediaTypes: {
+        'application/json': [{ value: {} }],
+      },
+    },
+  ]);
+});
+
 describe('no curated examples present', () => {
   it('should not generate an example schema if there is no documented schema and an empty example', () => {
     const operation = oas.operation('/emptyexample', 'post');

--- a/__tests__/operation/get-response-examples.test.ts
+++ b/__tests__/operation/get-response-examples.test.ts
@@ -77,14 +77,15 @@ test('should do its best at handling circular schemas', async () => {
   ]);
 });
 
-test('should return an empty object example if headers exist on a response with no content', () => {
+test('should return an empty example if headers exist on a response with no content', () => {
   const operation = oas.operation('/headers-but-no-content', 'post');
   expect(operation.getResponseExamples()).toStrictEqual([
     {
       status: '200',
       mediaTypes: {
-        'application/json': [{ value: {} }],
+        '*/*': [],
       },
+      onlyHeaders: true,
     },
   ]);
 });

--- a/src/operation/get-response-examples.ts
+++ b/src/operation/get-response-examples.ts
@@ -39,6 +39,10 @@ export default function getResponseExamples(operation: RMOAS.OperationObject) {
         }
       });
 
+      // If the response has no content, but has headers, hardcode an empty example so the headers modal will still display
+      if (response.headers && Object.keys(response.headers).length && !Object.keys(mediaTypes).length)
+        mediaTypes['application/json'] = [{ value: {} }];
+
       if (!Object.keys(mediaTypes).length) {
         return false;
       }

--- a/src/operation/get-response-examples.ts
+++ b/src/operation/get-response-examples.ts
@@ -18,6 +18,7 @@ export default function getResponseExamples(operation: RMOAS.OperationObject) {
   return Object.keys(operation.responses || {})
     .map(status => {
       const response = operation.responses[status];
+      let onlyHeaders = false;
 
       // If we have a $ref here that means that this was a circular ref so we should ignore it.
       if (isRef(response)) {
@@ -40,8 +41,10 @@ export default function getResponseExamples(operation: RMOAS.OperationObject) {
       });
 
       // If the response has no content, but has headers, hardcode an empty example so the headers modal will still display
-      if (response.headers && Object.keys(response.headers).length && !Object.keys(mediaTypes).length)
-        mediaTypes['application/json'] = [{ value: {} }];
+      if (response.headers && Object.keys(response.headers).length && !Object.keys(mediaTypes).length) {
+        mediaTypes['*/*'] = [];
+        onlyHeaders = true;
+      }
 
       if (!Object.keys(mediaTypes).length) {
         return false;
@@ -50,6 +53,7 @@ export default function getResponseExamples(operation: RMOAS.OperationObject) {
       return {
         status,
         mediaTypes,
+        ...(onlyHeaders ? { onlyHeaders } : {}),
       };
     })
     .filter(Boolean) as ResponseExamples;


### PR DESCRIPTION
## 🧰 Changes

If we're creating response examples and there's no examples/we can't generate examples because there's no content but there's headers
- Status codes without content that have headers now get an empty `mediaType ` with the type of wildcard `*/*`
- A boolean will get passed on these statuses indicating that they only have headers (which will be used on the front end)

The handling of populating an example for these using the status code + status message [will take place in our Response react component](https://github.com/readmeio/readme/pull/6101) 👍 This PR is to just get the data there 


## 🧬 QA & Testing
Tests are passing
