### PR TITLE
fix: funky typing with how we extract examples during JSON Schema generation

### DIFF
--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -703,12 +703,12 @@ describe('`example` / `examples` support', () => {
       }
 
       return {
-        distinctName: {
-          value,
-        },
         // Since this doesn't have a `value` that we can use we should ignore it.
-        distinctName2: {
+        distinctExternal: {
           externalValue: 'https://example.com/example.example',
+        },
+        distinctExample: {
+          value,
         },
       };
     }

--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -706,6 +706,10 @@ describe('`example` / `examples` support', () => {
         distinctName: {
           value,
         },
+        // Since this doesn't have a `value` that we can use we should ignore it.
+        distinctName2: {
+          externalValue: 'https://example.com/example.example',
+        },
       };
     }
 

--- a/__tests__/samples/index.test.ts
+++ b/__tests__/samples/index.test.ts
@@ -310,12 +310,8 @@ describe('sampleFromSchema', () => {
           format: 'date-time',
         };
 
-        // 0-20 chops off milliseconds
-        // necessary because test latency can cause failures
-        // it would be better to mock Date globally and expect a string - KS 11/18
-        const expected = new Date().toISOString().substring(0, 20);
-
-        expect(sampleFromSchema(definition)).toContain(expected);
+        // 2022-01-24T21:26:50.058Z
+        expect(sampleFromSchema(definition)).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/);
       });
 
       it('returns a date for a string with format=date', () => {

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -150,21 +150,12 @@ function searchForExampleByPointer(pointer: string, examples: PrevSchemasType = 
       if ('example' in schema) {
         schema = schema.example;
       } else {
-        const keys = Object.keys(schema.examples);
-        if (!keys.length) {
+        if (!Array.isArray(schema.examples) || !schema.examples.length) {
           continue;
         }
 
         // Prevent us from crashing if `examples` is a completely empty object.
-        const ex = schema.examples[keys.shift() as unknown as number];
-
-        if (typeof ex !== 'object' || Array.isArray(ex)) {
-          continue;
-        } else if (!('value' in ex)) {
-          continue;
-        }
-
-        schema = ex.value;
+        schema = schema.examples.shift();
       }
 
       try {
@@ -376,7 +367,11 @@ export default function toJSONSchema(
               examples.push(example.value[0]);
               reshapedExamples = true;
             } else {
-              prevSchemas.push({ examples: schema.examples });
+              // If this example is neither a primitive or an array we should dump it into the `prevSchemas` array
+              // because we might be able to extract an example from it further downstream.
+              prevSchemas.push({
+                example: example.value,
+              });
             }
           }
         });

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -128,18 +128,21 @@ export default function getParametersAsJsonSchema(operation: Operation, api: OAS
       return null;
     }
 
-    // @todo this `examples` array be `Array<RMOAS.SchemaObject>` but that doesn't like the `examples` schema
-    const examples = [] as Array<any>;
+    const prevSchemas = [] as Array<RMOAS.SchemaObject>;
     if ('example' in mediaTypeObject) {
-      examples.push({ example: mediaTypeObject.example });
+      prevSchemas.push({ example: mediaTypeObject.example });
     } else if ('examples' in mediaTypeObject) {
-      examples.push({ examples: mediaTypeObject.examples });
+      prevSchemas.push({
+        examples: Object.values(mediaTypeObject.examples)
+          .map((example: RMOAS.ExampleObject) => example.value)
+          .filter(val => val !== undefined),
+      });
     }
 
     // We're cloning the request schema because we've had issues with request schemas that were dereferenced being
     // processed multiple times because their component is also processed.
     const requestSchema = cloneObject(mediaTypeObject.schema);
-    const cleanedSchema = toJSONSchema(requestSchema, { globalDefaults, prevSchemas: examples, refLogger });
+    const cleanedSchema = toJSONSchema(requestSchema, { globalDefaults, prevSchemas, refLogger });
 
     // If this schema is **still** empty, don't bother returning it.
     if (!Object.keys(cleanedSchema).length) {


### PR DESCRIPTION
## 🧰 Changes

This doesn't fix any bugs but rather a type issue discovered in #581 where when we store examples in the `openapi-to-json-schema` `prevSchemas` object we were storing them as the OpenAPI Schema Object, which is an object of objects, when it was actually expecting an array of objects.

It's difficult to properly explain but check out https://github.com/readmeio/oas/pull/581#discussion_r785599642 for the TS error that uncovered this.