### PR TITLE
test: colocating the testing tsconfig with the tests

### DIFF
--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "es6",
+    "moduleResolution": "node",
+    "noImplicitAny": false
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/dist', '/node_modules', '/__tests__/__fixtures__/', '/__tests__/(.*)/__fixtures__/'],
   globals: {
     'ts-jest': {
-      tsconfig: 'tsconfig.test.json',
+      tsconfig: '__tests__/tsconfig.json',
     },
   },
   modulePaths: ['<rootDir>'],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "es6",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-  },
-  "include": ["src/**/*", "__tests__/**/*"]
-}


### PR DESCRIPTION
VSCode doesn't support `testconfig.*.json` configs but colocating our testing tsconfig with tests seems to make it work.