### PR TITLE
feat: adding a dereference option to preserve ref pointers as titles

### DIFF
--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,2079 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#dereference() should add metadata to components pre-dereferencing to preserve their lineage 1`] = `
+exports[`#dereference() should add metadata to components pre-dereferencing to preserve their lineage stored as \`title\` if the \`preserveRefAsJSONSchemaTitle\` option is supplied 1`] = `
+Object {
+  "/pet": Object {
+    "post": Object {
+      "description": "",
+      "operationId": "addPet",
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "properties": Object {
+                "category": Object {
+                  "properties": Object {
+                    "id": Object {
+                      "format": "int64",
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                  },
+                  "title": "Category",
+                  "type": "object",
+                  "x-readme-ref-name": "Category",
+                  "xml": Object {
+                    "name": "Category",
+                  },
+                },
+                "id": Object {
+                  "default": 40,
+                  "example": 25,
+                  "format": "int64",
+                  "readOnly": true,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "example": "https://example.com/photo.png",
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+                "tags": Object {
+                  "items": Object {
+                    "properties": Object {
+                      "id": Object {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "title": "Tag",
+                    "type": "object",
+                    "x-readme-ref-name": "Tag",
+                    "xml": Object {
+                      "name": "Tag",
+                    },
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "tag",
+                    "wrapped": true,
+                  },
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "title": "Pet",
+              "type": "object",
+              "x-readme-ref-name": "Pet",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+          "application/xml": Object {
+            "schema": Object {
+              "properties": Object {
+                "category": Object {
+                  "properties": Object {
+                    "id": Object {
+                      "format": "int64",
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                  },
+                  "title": "Category",
+                  "type": "object",
+                  "x-readme-ref-name": "Category",
+                  "xml": Object {
+                    "name": "Category",
+                  },
+                },
+                "id": Object {
+                  "default": 40,
+                  "example": 25,
+                  "format": "int64",
+                  "readOnly": true,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "example": "https://example.com/photo.png",
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+                "tags": Object {
+                  "items": Object {
+                    "properties": Object {
+                      "id": Object {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "title": "Tag",
+                    "type": "object",
+                    "x-readme-ref-name": "Tag",
+                    "xml": Object {
+                      "name": "Tag",
+                    },
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "tag",
+                    "wrapped": true,
+                  },
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "title": "Pet",
+              "type": "object",
+              "x-readme-ref-name": "Pet",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+        },
+        "description": "Pet object that needs to be added to the store",
+        "required": true,
+      },
+      "responses": Object {
+        "405": Object {
+          "description": "Invalid input",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Add a new pet to the store",
+      "tags": Array [
+        "pet",
+      ],
+    },
+    "put": Object {
+      "description": "",
+      "operationId": "updatePet",
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "properties": Object {
+                "category": Object {
+                  "properties": Object {
+                    "id": Object {
+                      "format": "int64",
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                  },
+                  "title": "Category",
+                  "type": "object",
+                  "x-readme-ref-name": "Category",
+                  "xml": Object {
+                    "name": "Category",
+                  },
+                },
+                "id": Object {
+                  "default": 40,
+                  "example": 25,
+                  "format": "int64",
+                  "readOnly": true,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "example": "https://example.com/photo.png",
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+                "tags": Object {
+                  "items": Object {
+                    "properties": Object {
+                      "id": Object {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "title": "Tag",
+                    "type": "object",
+                    "x-readme-ref-name": "Tag",
+                    "xml": Object {
+                      "name": "Tag",
+                    },
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "tag",
+                    "wrapped": true,
+                  },
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "title": "Pet",
+              "type": "object",
+              "x-readme-ref-name": "Pet",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+          "application/xml": Object {
+            "schema": Object {
+              "properties": Object {
+                "category": Object {
+                  "properties": Object {
+                    "id": Object {
+                      "format": "int64",
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "type": "string",
+                    },
+                  },
+                  "title": "Category",
+                  "type": "object",
+                  "x-readme-ref-name": "Category",
+                  "xml": Object {
+                    "name": "Category",
+                  },
+                },
+                "id": Object {
+                  "default": 40,
+                  "example": 25,
+                  "format": "int64",
+                  "readOnly": true,
+                  "type": "integer",
+                },
+                "name": Object {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "photoUrls": Object {
+                  "items": Object {
+                    "example": "https://example.com/photo.png",
+                    "type": "string",
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "photoUrl",
+                    "wrapped": true,
+                  },
+                },
+                "status": Object {
+                  "description": "pet status in the store",
+                  "enum": Array [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+                "tags": Object {
+                  "items": Object {
+                    "properties": Object {
+                      "id": Object {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "title": "Tag",
+                    "type": "object",
+                    "x-readme-ref-name": "Tag",
+                    "xml": Object {
+                      "name": "Tag",
+                    },
+                  },
+                  "type": "array",
+                  "xml": Object {
+                    "name": "tag",
+                    "wrapped": true,
+                  },
+                },
+              },
+              "required": Array [
+                "name",
+                "photoUrls",
+              ],
+              "title": "Pet",
+              "type": "object",
+              "x-readme-ref-name": "Pet",
+              "xml": Object {
+                "name": "Pet",
+              },
+            },
+          },
+        },
+        "description": "Pet object that needs to be added to the store",
+        "required": true,
+      },
+      "responses": Object {
+        "400": Object {
+          "description": "Invalid ID supplied",
+        },
+        "404": Object {
+          "description": "Pet not found",
+        },
+        "405": Object {
+          "description": "Validation exception",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Update an existing pet",
+      "tags": Array [
+        "pet",
+      ],
+    },
+  },
+  "/pet/findByStatus": Object {
+    "get": Object {
+      "description": "Multiple status values can be provided with comma separated strings",
+      "operationId": "findPetsByStatus",
+      "parameters": Array [
+        Object {
+          "description": "Status values that need to be considered for filter",
+          "explode": true,
+          "in": "query",
+          "name": "status",
+          "required": true,
+          "schema": Object {
+            "items": Object {
+              "default": "available",
+              "enum": Array [
+                "available",
+                "pending",
+                "sold",
+              ],
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+      ],
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "items": Object {
+                  "properties": Object {
+                    "category": Object {
+                      "properties": Object {
+                        "id": Object {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "title": "Category",
+                      "type": "object",
+                      "x-readme-ref-name": "Category",
+                      "xml": Object {
+                        "name": "Category",
+                      },
+                    },
+                    "id": Object {
+                      "default": 40,
+                      "example": 25,
+                      "format": "int64",
+                      "readOnly": true,
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "example": "doggie",
+                      "type": "string",
+                    },
+                    "photoUrls": Object {
+                      "items": Object {
+                        "example": "https://example.com/photo.png",
+                        "type": "string",
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "photoUrl",
+                        "wrapped": true,
+                      },
+                    },
+                    "status": Object {
+                      "description": "pet status in the store",
+                      "enum": Array [
+                        "available",
+                        "pending",
+                        "sold",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "id": Object {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                        },
+                        "title": "Tag",
+                        "type": "object",
+                        "x-readme-ref-name": "Tag",
+                        "xml": Object {
+                          "name": "Tag",
+                        },
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "tag",
+                        "wrapped": true,
+                      },
+                    },
+                  },
+                  "required": Array [
+                    "name",
+                    "photoUrls",
+                  ],
+                  "title": "Pet",
+                  "type": "object",
+                  "x-readme-ref-name": "Pet",
+                  "xml": Object {
+                    "name": "Pet",
+                  },
+                },
+                "type": "array",
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "items": Object {
+                  "properties": Object {
+                    "category": Object {
+                      "properties": Object {
+                        "id": Object {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "title": "Category",
+                      "type": "object",
+                      "x-readme-ref-name": "Category",
+                      "xml": Object {
+                        "name": "Category",
+                      },
+                    },
+                    "id": Object {
+                      "default": 40,
+                      "example": 25,
+                      "format": "int64",
+                      "readOnly": true,
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "example": "doggie",
+                      "type": "string",
+                    },
+                    "photoUrls": Object {
+                      "items": Object {
+                        "example": "https://example.com/photo.png",
+                        "type": "string",
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "photoUrl",
+                        "wrapped": true,
+                      },
+                    },
+                    "status": Object {
+                      "description": "pet status in the store",
+                      "enum": Array [
+                        "available",
+                        "pending",
+                        "sold",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "id": Object {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                        },
+                        "title": "Tag",
+                        "type": "object",
+                        "x-readme-ref-name": "Tag",
+                        "xml": Object {
+                          "name": "Tag",
+                        },
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "tag",
+                        "wrapped": true,
+                      },
+                    },
+                  },
+                  "required": Array [
+                    "name",
+                    "photoUrls",
+                  ],
+                  "title": "Pet",
+                  "type": "object",
+                  "x-readme-ref-name": "Pet",
+                  "xml": Object {
+                    "name": "Pet",
+                  },
+                },
+                "type": "array",
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+        "400": Object {
+          "description": "Invalid status value",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Finds Pets by status",
+      "tags": Array [
+        "pet",
+      ],
+    },
+  },
+  "/pet/findByTags": Object {
+    "get": Object {
+      "deprecated": true,
+      "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+      "operationId": "findPetsByTags",
+      "parameters": Array [
+        Object {
+          "description": "Tags to filter by",
+          "explode": true,
+          "in": "query",
+          "name": "tags",
+          "required": true,
+          "schema": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+      ],
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "items": Object {
+                  "properties": Object {
+                    "category": Object {
+                      "properties": Object {
+                        "id": Object {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "title": "Category",
+                      "type": "object",
+                      "x-readme-ref-name": "Category",
+                      "xml": Object {
+                        "name": "Category",
+                      },
+                    },
+                    "id": Object {
+                      "default": 40,
+                      "example": 25,
+                      "format": "int64",
+                      "readOnly": true,
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "example": "doggie",
+                      "type": "string",
+                    },
+                    "photoUrls": Object {
+                      "items": Object {
+                        "example": "https://example.com/photo.png",
+                        "type": "string",
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "photoUrl",
+                        "wrapped": true,
+                      },
+                    },
+                    "status": Object {
+                      "description": "pet status in the store",
+                      "enum": Array [
+                        "available",
+                        "pending",
+                        "sold",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "id": Object {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                        },
+                        "title": "Tag",
+                        "type": "object",
+                        "x-readme-ref-name": "Tag",
+                        "xml": Object {
+                          "name": "Tag",
+                        },
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "tag",
+                        "wrapped": true,
+                      },
+                    },
+                  },
+                  "required": Array [
+                    "name",
+                    "photoUrls",
+                  ],
+                  "title": "Pet",
+                  "type": "object",
+                  "x-readme-ref-name": "Pet",
+                  "xml": Object {
+                    "name": "Pet",
+                  },
+                },
+                "type": "array",
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "items": Object {
+                  "properties": Object {
+                    "category": Object {
+                      "properties": Object {
+                        "id": Object {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "title": "Category",
+                      "type": "object",
+                      "x-readme-ref-name": "Category",
+                      "xml": Object {
+                        "name": "Category",
+                      },
+                    },
+                    "id": Object {
+                      "default": 40,
+                      "example": 25,
+                      "format": "int64",
+                      "readOnly": true,
+                      "type": "integer",
+                    },
+                    "name": Object {
+                      "example": "doggie",
+                      "type": "string",
+                    },
+                    "photoUrls": Object {
+                      "items": Object {
+                        "example": "https://example.com/photo.png",
+                        "type": "string",
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "photoUrl",
+                        "wrapped": true,
+                      },
+                    },
+                    "status": Object {
+                      "description": "pet status in the store",
+                      "enum": Array [
+                        "available",
+                        "pending",
+                        "sold",
+                      ],
+                      "type": "string",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "properties": Object {
+                          "id": Object {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": Object {
+                            "type": "string",
+                          },
+                        },
+                        "title": "Tag",
+                        "type": "object",
+                        "x-readme-ref-name": "Tag",
+                        "xml": Object {
+                          "name": "Tag",
+                        },
+                      },
+                      "type": "array",
+                      "xml": Object {
+                        "name": "tag",
+                        "wrapped": true,
+                      },
+                    },
+                  },
+                  "required": Array [
+                    "name",
+                    "photoUrls",
+                  ],
+                  "title": "Pet",
+                  "type": "object",
+                  "x-readme-ref-name": "Pet",
+                  "xml": Object {
+                    "name": "Pet",
+                  },
+                },
+                "type": "array",
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+        "400": Object {
+          "description": "Invalid tag value",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Finds Pets by tags",
+      "tags": Array [
+        "pet",
+      ],
+    },
+  },
+  "/pet/{petId}": Object {
+    "delete": Object {
+      "description": "",
+      "operationId": "deletePet",
+      "parameters": Array [
+        Object {
+          "in": "header",
+          "name": "api_key",
+          "required": false,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+        Object {
+          "description": "Pet id to delete",
+          "in": "path",
+          "name": "petId",
+          "required": true,
+          "schema": Object {
+            "format": "int64",
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": Object {
+        "400": Object {
+          "description": "Invalid ID supplied",
+        },
+        "404": Object {
+          "description": "Pet not found",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Deletes a pet",
+      "tags": Array [
+        "pet",
+      ],
+    },
+    "get": Object {
+      "description": "Returns a single pet",
+      "operationId": "getPetById",
+      "parameters": Array [
+        Object {
+          "description": "ID of pet to return",
+          "in": "path",
+          "name": "petId",
+          "required": true,
+          "schema": Object {
+            "format": "int64",
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "category": Object {
+                    "properties": Object {
+                      "id": Object {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "title": "Category",
+                    "type": "object",
+                    "x-readme-ref-name": "Category",
+                    "xml": Object {
+                      "name": "Category",
+                    },
+                  },
+                  "id": Object {
+                    "default": 40,
+                    "example": 25,
+                    "format": "int64",
+                    "readOnly": true,
+                    "type": "integer",
+                  },
+                  "name": Object {
+                    "example": "doggie",
+                    "type": "string",
+                  },
+                  "photoUrls": Object {
+                    "items": Object {
+                      "example": "https://example.com/photo.png",
+                      "type": "string",
+                    },
+                    "type": "array",
+                    "xml": Object {
+                      "name": "photoUrl",
+                      "wrapped": true,
+                    },
+                  },
+                  "status": Object {
+                    "description": "pet status in the store",
+                    "enum": Array [
+                      "available",
+                      "pending",
+                      "sold",
+                    ],
+                    "type": "string",
+                  },
+                  "tags": Object {
+                    "items": Object {
+                      "properties": Object {
+                        "id": Object {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "title": "Tag",
+                      "type": "object",
+                      "x-readme-ref-name": "Tag",
+                      "xml": Object {
+                        "name": "Tag",
+                      },
+                    },
+                    "type": "array",
+                    "xml": Object {
+                      "name": "tag",
+                      "wrapped": true,
+                    },
+                  },
+                },
+                "required": Array [
+                  "name",
+                  "photoUrls",
+                ],
+                "title": "Pet",
+                "type": "object",
+                "x-readme-ref-name": "Pet",
+                "xml": Object {
+                  "name": "Pet",
+                },
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "properties": Object {
+                  "category": Object {
+                    "properties": Object {
+                      "id": Object {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": Object {
+                        "type": "string",
+                      },
+                    },
+                    "title": "Category",
+                    "type": "object",
+                    "x-readme-ref-name": "Category",
+                    "xml": Object {
+                      "name": "Category",
+                    },
+                  },
+                  "id": Object {
+                    "default": 40,
+                    "example": 25,
+                    "format": "int64",
+                    "readOnly": true,
+                    "type": "integer",
+                  },
+                  "name": Object {
+                    "example": "doggie",
+                    "type": "string",
+                  },
+                  "photoUrls": Object {
+                    "items": Object {
+                      "example": "https://example.com/photo.png",
+                      "type": "string",
+                    },
+                    "type": "array",
+                    "xml": Object {
+                      "name": "photoUrl",
+                      "wrapped": true,
+                    },
+                  },
+                  "status": Object {
+                    "description": "pet status in the store",
+                    "enum": Array [
+                      "available",
+                      "pending",
+                      "sold",
+                    ],
+                    "type": "string",
+                  },
+                  "tags": Object {
+                    "items": Object {
+                      "properties": Object {
+                        "id": Object {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": Object {
+                          "type": "string",
+                        },
+                      },
+                      "title": "Tag",
+                      "type": "object",
+                      "x-readme-ref-name": "Tag",
+                      "xml": Object {
+                        "name": "Tag",
+                      },
+                    },
+                    "type": "array",
+                    "xml": Object {
+                      "name": "tag",
+                      "wrapped": true,
+                    },
+                  },
+                },
+                "required": Array [
+                  "name",
+                  "photoUrls",
+                ],
+                "title": "Pet",
+                "type": "object",
+                "x-readme-ref-name": "Pet",
+                "xml": Object {
+                  "name": "Pet",
+                },
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+        "400": Object {
+          "description": "Invalid ID supplied",
+        },
+        "404": Object {
+          "description": "Pet not found",
+        },
+        "default": Object {
+          "description": "successful response",
+        },
+      },
+      "security": Array [
+        Object {
+          "api_key": Array [],
+        },
+      ],
+      "summary": "Find pet by ID",
+      "tags": Array [
+        "pet",
+      ],
+    },
+    "post": Object {
+      "description": "",
+      "operationId": "updatePetWithForm",
+      "parameters": Array [
+        Object {
+          "description": "ID of pet that needs to be updated",
+          "in": "path",
+          "name": "petId",
+          "required": true,
+          "schema": Object {
+            "format": "int64",
+            "type": "integer",
+          },
+        },
+      ],
+      "requestBody": Object {
+        "content": Object {
+          "application/x-www-form-urlencoded": Object {
+            "schema": Object {
+              "properties": Object {
+                "name": Object {
+                  "description": "Updated name of the pet",
+                  "type": "string",
+                },
+                "status": Object {
+                  "description": "Updated status of the pet",
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
+          },
+        },
+      },
+      "responses": Object {
+        "405": Object {
+          "description": "Invalid input",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Updates a pet in the store with form data",
+      "tags": Array [
+        "pet",
+      ],
+    },
+  },
+  "/pet/{petId}/uploadImage": Object {
+    "post": Object {
+      "description": "",
+      "operationId": "uploadFile",
+      "parameters": Array [
+        Object {
+          "description": "ID of pet to update",
+          "in": "path",
+          "name": "petId",
+          "required": true,
+          "schema": Object {
+            "format": "int64",
+            "type": "integer",
+          },
+        },
+      ],
+      "requestBody": Object {
+        "content": Object {
+          "multipart/form-data": Object {
+            "schema": Object {
+              "properties": Object {
+                "additionalMetadata": Object {
+                  "description": "Additional data to pass to server",
+                  "type": "string",
+                },
+                "file": Object {
+                  "description": "file to upload",
+                  "format": "binary",
+                  "type": "string",
+                },
+              },
+              "type": "object",
+            },
+          },
+        },
+      },
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "code": Object {
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "message": Object {
+                    "type": "string",
+                  },
+                  "type": Object {
+                    "type": "string",
+                  },
+                },
+                "title": "ApiResponse",
+                "type": "object",
+                "x-readme-ref-name": "ApiResponse",
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+      },
+      "security": Array [
+        Object {
+          "petstore_auth": Array [
+            "write:pets",
+            "read:pets",
+          ],
+        },
+      ],
+      "summary": "Uploads an image",
+      "tags": Array [
+        "pet",
+      ],
+    },
+  },
+  "/store/inventory": Object {
+    "get": Object {
+      "description": "Returns a map of status codes to quantities",
+      "operationId": "getInventory",
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "additionalProperties": Object {
+                  "format": "int32",
+                  "type": "integer",
+                },
+                "type": "object",
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+      },
+      "security": Array [
+        Object {
+          "api_key": Array [],
+        },
+      ],
+      "summary": "Returns pet inventories by status",
+      "tags": Array [
+        "store",
+      ],
+    },
+  },
+  "/store/order": Object {
+    "post": Object {
+      "description": "",
+      "operationId": "placeOrder",
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "properties": Object {
+                "complete": Object {
+                  "default": false,
+                  "type": "boolean",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "type": "integer",
+                },
+                "petId": Object {
+                  "format": "int64",
+                  "type": "integer",
+                },
+                "quantity": Object {
+                  "format": "int32",
+                  "type": "integer",
+                },
+                "shipDate": Object {
+                  "format": "date-time",
+                  "type": "string",
+                },
+                "status": Object {
+                  "description": "Order Status",
+                  "enum": Array [
+                    "placed",
+                    "approved",
+                    "delivered",
+                  ],
+                  "type": "string",
+                },
+              },
+              "title": "Order",
+              "type": "object",
+              "x-readme-ref-name": "Order",
+              "xml": Object {
+                "name": "Order",
+              },
+            },
+          },
+        },
+        "description": "order placed for purchasing the pet",
+        "required": true,
+      },
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "complete": Object {
+                    "default": false,
+                    "type": "boolean",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "petId": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "quantity": Object {
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "shipDate": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "status": Object {
+                    "description": "Order Status",
+                    "enum": Array [
+                      "placed",
+                      "approved",
+                      "delivered",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "title": "Order",
+                "type": "object",
+                "x-readme-ref-name": "Order",
+                "xml": Object {
+                  "name": "Order",
+                },
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "properties": Object {
+                  "complete": Object {
+                    "default": false,
+                    "type": "boolean",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "petId": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "quantity": Object {
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "shipDate": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "status": Object {
+                    "description": "Order Status",
+                    "enum": Array [
+                      "placed",
+                      "approved",
+                      "delivered",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "title": "Order",
+                "type": "object",
+                "x-readme-ref-name": "Order",
+                "xml": Object {
+                  "name": "Order",
+                },
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+        "400": Object {
+          "description": "Invalid Order",
+        },
+      },
+      "summary": "Place an order for a pet",
+      "tags": Array [
+        "store",
+      ],
+    },
+  },
+  "/store/order/{orderId}": Object {
+    "delete": Object {
+      "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+      "operationId": "deleteOrder",
+      "parameters": Array [
+        Object {
+          "description": "ID of the order that needs to be deleted",
+          "in": "path",
+          "name": "orderId",
+          "required": true,
+          "schema": Object {
+            "format": "int64",
+            "minimum": 1,
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": Object {
+        "400": Object {
+          "description": "Invalid ID supplied",
+        },
+        "404": Object {
+          "description": "Order not found",
+        },
+      },
+      "summary": "Delete purchase order by ID",
+      "tags": Array [
+        "store",
+      ],
+    },
+    "get": Object {
+      "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+      "operationId": "getOrderById",
+      "parameters": Array [
+        Object {
+          "description": "ID of pet that needs to be fetched",
+          "in": "path",
+          "name": "orderId",
+          "required": true,
+          "schema": Object {
+            "format": "int64",
+            "maximum": 10,
+            "minimum": 1,
+            "type": "integer",
+          },
+        },
+      ],
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "complete": Object {
+                    "default": false,
+                    "type": "boolean",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "petId": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "quantity": Object {
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "shipDate": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "status": Object {
+                    "description": "Order Status",
+                    "enum": Array [
+                      "placed",
+                      "approved",
+                      "delivered",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "title": "Order",
+                "type": "object",
+                "x-readme-ref-name": "Order",
+                "xml": Object {
+                  "name": "Order",
+                },
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "properties": Object {
+                  "complete": Object {
+                    "default": false,
+                    "type": "boolean",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "petId": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "quantity": Object {
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "shipDate": Object {
+                    "format": "date-time",
+                    "type": "string",
+                  },
+                  "status": Object {
+                    "description": "Order Status",
+                    "enum": Array [
+                      "placed",
+                      "approved",
+                      "delivered",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "title": "Order",
+                "type": "object",
+                "x-readme-ref-name": "Order",
+                "xml": Object {
+                  "name": "Order",
+                },
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+        "400": Object {
+          "description": "Invalid ID supplied",
+        },
+        "404": Object {
+          "description": "Order not found",
+        },
+      },
+      "summary": "Find purchase order by ID",
+      "tags": Array [
+        "store",
+      ],
+    },
+  },
+  "/user": Object {
+    "post": Object {
+      "description": "This can only be done by the logged in user.",
+      "operationId": "createUser",
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "properties": Object {
+                "email": Object {
+                  "type": "string",
+                },
+                "firstName": Object {
+                  "type": "string",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "type": "integer",
+                },
+                "lastName": Object {
+                  "type": "string",
+                },
+                "password": Object {
+                  "type": "string",
+                },
+                "phone": Object {
+                  "type": "string",
+                },
+                "userStatus": Object {
+                  "description": "User Status",
+                  "format": "int32",
+                  "type": "integer",
+                },
+                "username": Object {
+                  "type": "string",
+                },
+              },
+              "title": "User",
+              "type": "object",
+              "x-readme-ref-name": "User",
+              "xml": Object {
+                "name": "User",
+              },
+            },
+          },
+        },
+        "description": "Created user object",
+        "required": true,
+      },
+      "responses": Object {
+        "default": Object {
+          "description": "successful operation",
+        },
+      },
+      "summary": "Create user",
+      "tags": Array [
+        "user",
+      ],
+    },
+  },
+  "/user/createWithArray": Object {
+    "post": Object {
+      "description": "",
+      "operationId": "createUsersWithArrayInput",
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "items": Object {
+                "properties": Object {
+                  "email": Object {
+                    "type": "string",
+                  },
+                  "firstName": Object {
+                    "type": "string",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "lastName": Object {
+                    "type": "string",
+                  },
+                  "password": Object {
+                    "type": "string",
+                  },
+                  "phone": Object {
+                    "type": "string",
+                  },
+                  "userStatus": Object {
+                    "description": "User Status",
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "username": Object {
+                    "type": "string",
+                  },
+                },
+                "title": "User",
+                "type": "object",
+                "x-readme-ref-name": "User",
+                "xml": Object {
+                  "name": "User",
+                },
+              },
+              "type": "array",
+            },
+          },
+        },
+        "description": "List of user object",
+        "required": true,
+      },
+      "responses": Object {
+        "default": Object {
+          "description": "successful operation",
+        },
+      },
+      "summary": "Creates list of users with given input array",
+      "tags": Array [
+        "user",
+      ],
+    },
+  },
+  "/user/createWithList": Object {
+    "post": Object {
+      "description": "",
+      "operationId": "createUsersWithListInput",
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "items": Object {
+                "properties": Object {
+                  "email": Object {
+                    "type": "string",
+                  },
+                  "firstName": Object {
+                    "type": "string",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "lastName": Object {
+                    "type": "string",
+                  },
+                  "password": Object {
+                    "type": "string",
+                  },
+                  "phone": Object {
+                    "type": "string",
+                  },
+                  "userStatus": Object {
+                    "description": "User Status",
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "username": Object {
+                    "type": "string",
+                  },
+                },
+                "title": "User",
+                "type": "object",
+                "x-readme-ref-name": "User",
+                "xml": Object {
+                  "name": "User",
+                },
+              },
+              "type": "array",
+            },
+          },
+        },
+        "description": "List of user object",
+        "required": true,
+      },
+      "responses": Object {
+        "default": Object {
+          "description": "successful operation",
+        },
+      },
+      "summary": "Creates list of users with given input array",
+      "tags": Array [
+        "user",
+      ],
+    },
+  },
+  "/user/login": Object {
+    "get": Object {
+      "description": "",
+      "operationId": "loginUser",
+      "parameters": Array [
+        Object {
+          "description": "The user name for login",
+          "in": "query",
+          "name": "username",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+        Object {
+          "description": "The password for login in clear text",
+          "in": "query",
+          "name": "password",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ],
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "type": "string",
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "type": "string",
+              },
+            },
+          },
+          "description": "successful operation",
+          "headers": Object {
+            "X-Expires-After": Object {
+              "description": "date in UTC when token expires",
+              "schema": Object {
+                "format": "date-time",
+                "type": "string",
+              },
+            },
+            "X-Rate-Limit": Object {
+              "description": "calls per hour allowed by the user",
+              "schema": Object {
+                "format": "int32",
+                "type": "integer",
+              },
+            },
+          },
+        },
+        "400": Object {
+          "description": "Invalid username/password supplied",
+        },
+      },
+      "summary": "Logs user into the system",
+      "tags": Array [
+        "user",
+      ],
+    },
+  },
+  "/user/logout": Object {
+    "get": Object {
+      "description": "",
+      "operationId": "logoutUser",
+      "responses": Object {
+        "default": Object {
+          "description": "successful operation",
+        },
+      },
+      "summary": "Logs out current logged in user session",
+      "tags": Array [
+        "user",
+      ],
+    },
+  },
+  "/user/{username}": Object {
+    "delete": Object {
+      "description": "This can only be done by the logged in user.",
+      "operationId": "deleteUser",
+      "parameters": Array [
+        Object {
+          "description": "The name that needs to be deleted",
+          "in": "path",
+          "name": "username",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ],
+      "responses": Object {
+        "400": Object {
+          "description": "Invalid username supplied",
+        },
+        "404": Object {
+          "description": "User not found",
+        },
+      },
+      "summary": "Delete user",
+      "tags": Array [
+        "user",
+      ],
+    },
+    "get": Object {
+      "description": "",
+      "operationId": "getUserByName",
+      "parameters": Array [
+        Object {
+          "description": "The name that needs to be fetched. Use user1 for testing. ",
+          "in": "path",
+          "name": "username",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ],
+      "responses": Object {
+        "200": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "email": Object {
+                    "type": "string",
+                  },
+                  "firstName": Object {
+                    "type": "string",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "lastName": Object {
+                    "type": "string",
+                  },
+                  "password": Object {
+                    "type": "string",
+                  },
+                  "phone": Object {
+                    "type": "string",
+                  },
+                  "userStatus": Object {
+                    "description": "User Status",
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "username": Object {
+                    "type": "string",
+                  },
+                },
+                "title": "User",
+                "type": "object",
+                "x-readme-ref-name": "User",
+                "xml": Object {
+                  "name": "User",
+                },
+              },
+            },
+            "application/xml": Object {
+              "schema": Object {
+                "properties": Object {
+                  "email": Object {
+                    "type": "string",
+                  },
+                  "firstName": Object {
+                    "type": "string",
+                  },
+                  "id": Object {
+                    "format": "int64",
+                    "type": "integer",
+                  },
+                  "lastName": Object {
+                    "type": "string",
+                  },
+                  "password": Object {
+                    "type": "string",
+                  },
+                  "phone": Object {
+                    "type": "string",
+                  },
+                  "userStatus": Object {
+                    "description": "User Status",
+                    "format": "int32",
+                    "type": "integer",
+                  },
+                  "username": Object {
+                    "type": "string",
+                  },
+                },
+                "title": "User",
+                "type": "object",
+                "x-readme-ref-name": "User",
+                "xml": Object {
+                  "name": "User",
+                },
+              },
+            },
+          },
+          "description": "successful operation",
+        },
+        "400": Object {
+          "description": "Invalid username supplied",
+        },
+        "404": Object {
+          "description": "User not found",
+        },
+      },
+      "summary": "Get user by user name",
+      "tags": Array [
+        "user",
+      ],
+    },
+    "put": Object {
+      "description": "This can only be done by the logged in user.",
+      "operationId": "updateUser",
+      "parameters": Array [
+        Object {
+          "description": "name that need to be updated",
+          "in": "path",
+          "name": "username",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ],
+      "requestBody": Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "properties": Object {
+                "email": Object {
+                  "type": "string",
+                },
+                "firstName": Object {
+                  "type": "string",
+                },
+                "id": Object {
+                  "format": "int64",
+                  "type": "integer",
+                },
+                "lastName": Object {
+                  "type": "string",
+                },
+                "password": Object {
+                  "type": "string",
+                },
+                "phone": Object {
+                  "type": "string",
+                },
+                "userStatus": Object {
+                  "description": "User Status",
+                  "format": "int32",
+                  "type": "integer",
+                },
+                "username": Object {
+                  "type": "string",
+                },
+              },
+              "title": "User",
+              "type": "object",
+              "x-readme-ref-name": "User",
+              "xml": Object {
+                "name": "User",
+              },
+            },
+          },
+        },
+        "description": "Updated user object",
+        "required": true,
+      },
+      "responses": Object {
+        "400": Object {
+          "description": "Invalid user supplied",
+        },
+        "404": Object {
+          "description": "User not found",
+        },
+      },
+      "summary": "Updated user",
+      "tags": Array [
+        "user",
+      ],
+    },
+  },
+}
+`;
+
+exports[`#dereference() should add metadata to components pre-dereferencing to preserve their lineage stored as \`x-readme-ref-name 1`] = `
 Object {
   "/multischema/of-everything": Object {
     "post": Object {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1246,13 +1246,12 @@ describe('#dereference()', () => {
       const oas = Oas.init(complexNesting);
       await oas.dereference();
 
-      expect(
-        (
-          (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject).content[
-            'application/json'
-          ].schema as RMOAS.SchemaObject
-        )['x-readme-ref-name']
-      ).toBe('MultischemaOfEverything');
+      const schema = (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject).content[
+        'application/json'
+      ].schema as RMOAS.SchemaObject;
+
+      expect(schema.title).toBeUndefined();
+      expect(schema['x-readme-ref-name']).toBe('MultischemaOfEverything');
 
       expect(oas.api.paths).toMatchSnapshot();
     });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1241,19 +1241,34 @@ describe('#dereference()', () => {
     });
   });
 
-  it('should add metadata to components pre-dereferencing to preserve their lineage', async () => {
-    const oas = Oas.init(complexNesting);
-    await oas.dereference();
+  describe('should add metadata to components pre-dereferencing to preserve their lineage', () => {
+    it('stored as `x-readme-ref-name', async () => {
+      const oas = Oas.init(complexNesting);
+      await oas.dereference();
 
-    expect(
-      (
-        (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject).content[
-          'application/json'
-        ].schema as RMOAS.SchemaObject
-      )['x-readme-ref-name']
-    ).toBe('MultischemaOfEverything');
+      expect(
+        (
+          (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject).content[
+            'application/json'
+          ].schema as RMOAS.SchemaObject
+        )['x-readme-ref-name']
+      ).toBe('MultischemaOfEverything');
 
-    expect(oas.api.paths).toMatchSnapshot();
+      expect(oas.api.paths).toMatchSnapshot();
+    });
+
+    it('stored as `title` if the `preserveRefAsJSONSchemaTitle` option is supplied', async () => {
+      const oas = Oas.init(petstore);
+      await oas.dereference({ preserveRefAsJSONSchemaTitle: true });
+
+      const schema = (oas.api.paths['/pet'].post.requestBody as RMOAS.RequestBodyObject).content['application/json']
+        .schema as RMOAS.SchemaObject;
+
+      expect(schema.title).toBe('Pet');
+      expect(schema['x-readme-ref-name']).toBe('Pet');
+
+      expect(oas.api.paths).toMatchSnapshot();
+    });
   });
 
   it('should retain the user object when dereferencing', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -704,8 +704,9 @@ export default class Oas {
    * Dereference the current OAS definition so it can be parsed free of worries of `$ref` schemas and circular
    * structures.
    *
+   * @param opts
    */
-  async dereference() {
+  async dereference(opts = { preserveRefAsJSONSchemaTitle: false }) {
     if (this.dereferencing.complete) {
       return new Promise(resolve => {
         resolve(true);
@@ -727,6 +728,13 @@ export default class Oas {
     // dereferencing happens below those names will be preserved.
     if (api && api.components && api.components.schemas && typeof api.components.schemas === 'object') {
       Object.keys(api.components.schemas).forEach(schemaName => {
+        if (opts.preserveRefAsJSONSchemaTitle) {
+          // This may result in some data loss if there's already a `title` present, but in the case
+          // where we want to generate code for the API definition (see http://npm.im/api), we'd
+          // prefer to retain original reference name as a title for any generated types.
+          (api.components.schemas[schemaName] as RMOAS.SchemaObject).title = schemaName;
+        }
+
         (api.components.schemas[schemaName] as RMOAS.SchemaObject)['x-readme-ref-name'] = schemaName;
       });
     }


### PR DESCRIPTION
## 🧰 Changes

In working on codegen in [api](https://npm.im/api) I want to generate Typescript types with the original `$ref` names but the library I'm using [json-schema-to-typescript](https://npm.im/json-schema-to-typescript) doesn't offer any flexibility other than using the `title` present in the JSON Schema; and since we're preserving `$ref` pointers during the dereference process to an `x-readme-ref-name` extension I can't use this data.

This adds a new option to the `dereference` method to allow me to override any present `title` in schemas with the original `$ref` name. It may result in some data loss but in the end I think that with this codegen the types will be cleaner with the original ref names than whatever `title` was originally present within the schema.

## 🧬 QA & Testing

See tests.