### PR TITLE
feat: optionally generate friendlier operationIds

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -833,7 +833,7 @@ describe('#getOperationId()', () => {
   describe('`shouldCamelCase` option', () => {
     it('should create a camel cased operation ID if one does not exist', () => {
       const operation = Oas.init(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
-      expect(operation.getOperationId(true)).toBe('getMultipleComboAuthsDuped');
+      expect(operation.getOperationId({ camelCase: true })).toBe('getMultipleComboAuthsDuped');
     });
 
     it('should not double up on a method prefix if the path starts with the method', () => {
@@ -858,7 +858,7 @@ describe('#getOperationId()', () => {
       });
 
       const operation = spec.operation('/get-pets', 'get');
-      expect(operation.getOperationId(true)).toBe('getPets');
+      expect(operation.getOperationId({ camelCase: true })).toBe('getPets');
     });
   });
 });

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -829,6 +829,38 @@ describe('#getOperationId()', () => {
     const operation = Oas.init(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
     expect(operation.getOperationId()).toBe('get_multiple-combo-auths-duped');
   });
+
+  describe('`shouldCamelCase` option', () => {
+    it('should create a camel cased operation ID if one does not exist', () => {
+      const operation = Oas.init(multipleSecurities).operation('/multiple-combo-auths-duped', 'get');
+      expect(operation.getOperationId(true)).toBe('getMultipleComboAuthsDuped');
+    });
+
+    it('should not double up on a method prefix if the path starts with the method', () => {
+      const spec = Oas.init({
+        openapi: '3.0.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        paths: {
+          '/get-pets': {
+            get: {
+              tags: ['dogs'],
+              responses: {
+                200: {
+                  description: 'OK',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const operation = spec.operation('/get-pets', 'get');
+      expect(operation.getOperationId(true)).toBe('getPets');
+    });
+  });
 });
 
 describe('#getTags()', () => {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -323,12 +323,13 @@ export default class Operation {
   }
 
   /**
-   * Get an `operationId` for this operation. If one is not present (it's not required by the spec!) a hash of the path
-   * and method will be returned instead.
+   * Get an `operationId` for this operation. If one is not present (it's not required by the spec!)
+   * a hash of the path and method will be returned instead.
    *
-   * @param shouldCamelCase Generate a JS method-friendly operation ID when an `operationId` isn't present.
+   * @param opts
+   * @param opts.camelCase Generate a JS method-friendly operation ID when one isn't present.
    */
-  getOperationId(shouldCamelCase = false): string {
+  getOperationId(opts?: { camelCase: boolean }): string {
     if ('operationId' in this.schema) {
       return this.schema.operationId;
     }
@@ -340,7 +341,7 @@ export default class Operation {
       .replace(/--+/g, '-') // Remove double --'s
       .toLowerCase();
 
-    if (shouldCamelCase) {
+    if (opts?.camelCase) {
       operationId = operationId.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
 
       // If the generated operationId already starts with the method (eg. `getPets`) we don't want

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -326,19 +326,34 @@ export default class Operation {
    * Get an `operationId` for this operation. If one is not present (it's not required by the spec!) a hash of the path
    * and method will be returned instead.
    *
+   * @param shouldCamelCase Generate a JS method-friendly operation ID when an `operationId` isn't present.
    */
-  getOperationId(): string {
+  getOperationId(shouldCamelCase = false): string {
     if ('operationId' in this.schema) {
       return this.schema.operationId;
     }
 
-    const url = this.path
+    const method = this.method.toLowerCase();
+    let operationId = this.path
       .replace(/[^a-zA-Z0-9]/g, '-') // Remove weird characters
       .replace(/^-|-$/g, '') // Don't start or end with -
       .replace(/--+/g, '-') // Remove double --'s
       .toLowerCase();
 
-    return `${this.method.toLowerCase()}_${url}`;
+    if (shouldCamelCase) {
+      operationId = operationId.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
+
+      // If the generated operationId already starts with the method (eg. `getPets`) we don't want
+      // to double it up into `getGetPets`.
+      if (operationId.startsWith(method)) {
+        return operationId;
+      }
+
+      operationId = operationId.charAt(0).toUpperCase() + operationId.slice(1);
+      return `${method}${operationId}`;
+    }
+
+    return `${method}_${operationId}`;
   }
 
   /**


### PR DESCRIPTION
## 🧰 Changes

We're currently generating URL slug-like operation IDs when one isn't present, and we use this work in `api` and for operations that don't have an operation ID it makes the UX of calling one of these operations really gnarly:

```js
api['get-pets']().then(res => console.log('json response:', res))
```

With this work we'll be able to generate friendlier ones:

```js
api.getPets().then(res => console.log('json response:', res))
```

## 🧬 QA & Testing

See tests.