### PR TITLE
feat: upgrading swagger-inline and adding new `pathGlob` and `pattern` options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "oas-normalize": "^5.1.1",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
-        "swagger-inline": "^5.0.2"
+        "swagger-inline": "^5.1.0"
       },
       "bin": {
         "oas": "bin/oas"
@@ -8704,9 +8704,9 @@
       }
     },
     "node_modules/swagger-inline": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.4.tgz",
-      "integrity": "sha512-cKaOXvLjYIxWCjAr8gWKLSIAZXS8/grdk1DvpJBkFhNaJXUOmnpKvs5XGMclDk9o+WpUbum+WH3zY09rRfVkHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.1.0.tgz",
+      "integrity": "sha512-1Z5RkU5p8eES9o1Jr0XBXfbIOugce2Jmx9L7sudcWgBVdHnD6O5y54ZoLlKRqXPgYuziaZfHLLZHiP4Wp/84LA==",
       "dependencies": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",
@@ -16066,9 +16066,9 @@
       }
     },
     "swagger-inline": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.0.4.tgz",
-      "integrity": "sha512-cKaOXvLjYIxWCjAr8gWKLSIAZXS8/grdk1DvpJBkFhNaJXUOmnpKvs5XGMclDk9o+WpUbum+WH3zY09rRfVkHQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/swagger-inline/-/swagger-inline-5.1.0.tgz",
+      "integrity": "sha512-1Z5RkU5p8eES9o1Jr0XBXfbIOugce2Jmx9L7sudcWgBVdHnD6O5y54ZoLlKRqXPgYuziaZfHLLZHiP4Wp/84LA==",
       "requires": {
         "commander": "^6.0.0",
         "globby": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "oas-normalize": "^5.1.1",
     "openapi-types": "^10.0.0",
     "path-to-regexp": "^6.2.0",
-    "swagger-inline": "^5.0.2"
+    "swagger-inline": "^5.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.0.1",

--- a/src/cli/lib/utils.js
+++ b/src/cli/lib/utils.js
@@ -44,17 +44,20 @@ exports.findSwagger = async function (info, cb) {
     process.exit(1);
   }
 
-  let pathGlob = '**/*';
+  let pathGlob = info.opts.pathGlob || '**/*';
   if (info.opts.path) {
     pathGlob = `${info.opts.path.replace(/\/$/, '')}/*`;
   }
 
-  const generatedDefinition = await swaggerInline(pathGlob, { format: '.json', scope: info.opts.scope, base }).catch(
-    err => {
-      console.error(err);
-      process.exit(1);
-    }
-  );
+  const generatedDefinition = await swaggerInline(pathGlob, {
+    format: '.json',
+    scope: info.opts.scope,
+    base,
+    pattern: info.ops.pattern || null,
+  }).catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
 
   let oas = new OASNormalize(generatedDefinition);
   const bundledDefinition = await oas.bundle().catch(err => {


### PR DESCRIPTION
## 🧰 Changes

Incorporating the work that @garret-wade did in https://github.com/readmeio/swagger-inline/pull/249 the `oas` now has the ability to specify custom [multilang-extract-comments](https://npm.im/multilang-extract-comments) with a `--pattern` argument as well as a new `--pathGlob` argument for customizing where to look for an OAS file.

Resolves https://github.com/readmeio/oas/issues/603