### PR TITLE
feat: adding new accessors for determining if an operation has required params

### DIFF
--- a/src/operation.ts
+++ b/src/operation.ts
@@ -2,6 +2,7 @@ import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import type { RequestBodyExamples } from './operation/get-requestbody-examples';
 import type { CallbackExamples } from './operation/get-callback-examples';
 import type { ResponseExamples } from './operation/get-response-examples';
+import type { SchemaWrapper } from './operation/get-parameters-as-json-schema';
 
 import * as RMOAS from './rmoas.types';
 import dedupeCommonParameters from './lib/dedupe-common-parameters';
@@ -64,6 +65,11 @@ export default class Operation {
     request: string[];
     response: string[];
   };
+
+  /**
+   * All parameters and request bodies converted into JSON Schema.
+   */
+  parameterJsonSchema: SchemaWrapper[];
 
   constructor(api: RMOAS.OASDocument, path: string, method: RMOAS.HttpMethods, operation: RMOAS.OperationObject) {
     this.schema = operation;
@@ -436,7 +442,12 @@ export default class Operation {
    * @param globalDefaults Contains an object of user defined schema defaults.
    */
   getParametersAsJsonSchema(globalDefaults?: Record<string, unknown>) {
-    return getParametersAsJsonSchema(this, this.api, globalDefaults);
+    if (this.parameterJsonSchema) {
+      return this.parameterJsonSchema;
+    }
+
+    this.parameterJsonSchema = getParametersAsJsonSchema(this, this.api, globalDefaults);
+    return this.parameterJsonSchema;
   }
 
   /**

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -485,6 +485,10 @@ export default class Operation {
     return Object.keys(requestBody.content);
   }
 
+  /**
+   * Determine if this operation has a required request body.
+   *
+   */
   hasRequiredRequestBody() {
     if (!this.hasRequestBody()) {
       return false;


### PR DESCRIPTION
## 🧰 Changes

This adds two new Operation accessors:

* [x] `hasRequiredParameters`
* [x] `hasRequiredRequestBody`

`hasRequiredParameters` simply looks at the operations parameters (or common parameters if they're present) and reports back if any of them contain `required: true`. `hasRequiredRequestBody` does the same, but handles a couple situations:

1. If a [Request Body Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#requestBodyObject) has `required: true` we'll report that its request body is required.
2. If that [Request Body Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#requestBodyObject) has `required: false` but the [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject) within its primary [Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject) has any required properties we'll report that the request body is required. We're doing this because the OpenAPI spec isn't clear on the differentiation between the two, and I'd rather have a quality of life for this accessor for telling you if the schema of a request body is required even if the root-level [Request Body Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#requestBodyObject) says otherwise.

## 🧬 QA & Testing

I refactored the `operation.test.ts` file a bit so we aren't constantly attempting to dereference the Petstore example that we use in multiple tests, but check out the tests I added for these two new accessors there.