### PR TITLE
feat: adding new options to `getParametersAsJsonSchema`

### DIFF
--- a/__tests__/__fixtures__/create-oas.ts
+++ b/__tests__/__fixtures__/create-oas.ts
@@ -6,7 +6,7 @@ import Oas from '../../src';
  * @param components Schema components to add into the fake API definition.
  * @returns An instance of the Oas class.
  */
-export default function createOas(operation: RMOAS.OperationObject, components: RMOAS.ComponentsObject) {
+export default function createOas(operation: RMOAS.OperationObject, components?: RMOAS.ComponentsObject) {
   const schema = {
     openapi: '3.0.3',
     info: { title: 'testing', version: '1.0.0' },

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -448,6 +448,82 @@ Array [
 ]
 `;
 
+exports[`options mergeIntoBodyAndMetadata retainDeprecatedProperties (default behavior) should support merging \`deprecatedProps\` together 1`] = `
+Array [
+  Object {
+    "deprecatedProps": Object {
+      "schema": Object {
+        "allOf": Array [
+          Object {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": Object {
+              "Accept": Object {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "deprecated": true,
+                "type": "string",
+              },
+            },
+            "required": Array [],
+            "type": "object",
+          },
+        ],
+      },
+      "type": "metadata",
+    },
+    "label": "Metadata",
+    "schema": Object {
+      "allOf": Array [
+        Object {
+          "properties": Object {},
+          "required": Array [],
+          "type": "object",
+        },
+      ],
+    },
+    "type": "metadata",
+  },
+]
+`;
+
+exports[`options mergeIntoBodyAndMetadata should merge params categorized as metadata into a single block 1`] = `
+Array [
+  Object {
+    "label": "Metadata",
+    "schema": Object {
+      "allOf": Array [
+        Object {
+          "properties": Object {
+            "petId": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "description": "Pet id to delete",
+              "format": "int64",
+              "maximum": 9223372036854776000,
+              "minimum": -9223372036854776000,
+              "type": "integer",
+            },
+          },
+          "required": Array [
+            "petId",
+          ],
+          "type": "object",
+        },
+        Object {
+          "properties": Object {
+            "api_key": Object {
+              "$schema": "http://json-schema.org/draft-04/schema#",
+              "type": "string",
+            },
+          },
+          "required": Array [],
+          "type": "object",
+        },
+      ],
+    },
+    "type": "metadata",
+  },
+]
+`;
+
 exports[`parameters polymorphism should merge allOf schemas together 1`] = `
 Array [
   Object {

--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -792,17 +792,16 @@ describe('options', () => {
         ],
       });
 
-      expect(oas.operation('/', 'get').getParametersAsJsonSchema({ retainDeprecatedProperties: true })).toStrictEqual([
-        {
-          type: 'header',
-          label: 'Headers',
-          schema: {
-            type: 'object',
-            properties: expect.any(Object),
-            required: [],
-          },
+      const jsonSchema = oas.operation('/', 'get').getParametersAsJsonSchema({ retainDeprecatedProperties: true });
+      expect(jsonSchema[0].schema).toStrictEqual({
+        type: 'object',
+        properties: {
+          Accept: expect.any(Object),
         },
-      ]);
+        required: [],
+      });
+
+      expect(jsonSchema[0].deprecatedProps).toBeUndefined();
     });
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -8,5 +8,6 @@ test('should expose `jsonSchemaTypes`', () => {
     cookie: 'Cookie Params',
     formData: 'Form Data',
     header: 'Headers',
+    metadata: 'Metadata',
   });
 });

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -2,7 +2,6 @@ import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import type { RequestBodyExamples } from './operation/get-requestbody-examples';
 import type { CallbackExamples } from './operation/get-callback-examples';
 import type { ResponseExamples } from './operation/get-response-examples';
-import type { SchemaWrapper } from './operation/get-parameters-as-json-schema';
 
 import * as RMOAS from './rmoas.types';
 import dedupeCommonParameters from './lib/dedupe-common-parameters';
@@ -65,11 +64,6 @@ export default class Operation {
     request: string[];
     response: string[];
   };
-
-  /**
-   * All parameters and request bodies converted into JSON Schema.
-   */
-  parameterJsonSchema: SchemaWrapper[];
 
   constructor(api: RMOAS.OASDocument, path: string, method: RMOAS.HttpMethods, operation: RMOAS.OperationObject) {
     this.schema = operation;
@@ -439,15 +433,22 @@ export default class Operation {
    * Convert the operation into an array of JSON Schema schemas for each available type of parameter available on the
    * operation.
    *
-   * @param globalDefaults Contains an object of user defined schema defaults.
+   * @param opts
+   * @param opts.globalDefaults Contains an object of user defined schema defaults.
+   * @param opts.mergeIntoBodyAndMetadata If you want the output to be two objects: body (contains
+   *    `body` and `formData` JSON Schema) and metadata (contains `path`, `query`, `cookie`, and
+   *    `header`).
+   * @param opts.retainDeprecatedProperties If you wish to **not** split out deprecated properties
+   *    into a separate `deprecatedProps` object.
    */
-  getParametersAsJsonSchema(globalDefaults?: Record<string, unknown>) {
-    if (this.parameterJsonSchema) {
-      return this.parameterJsonSchema;
-    }
-
-    this.parameterJsonSchema = getParametersAsJsonSchema(this, this.api, globalDefaults);
-    return this.parameterJsonSchema;
+  getParametersAsJsonSchema(
+    opts: {
+      globalDefaults?: Record<string, unknown>;
+      mergeIntoBodyAndMetadata?: boolean;
+      retainDeprecatedProperties?: boolean;
+    } = {}
+  ) {
+    return getParametersAsJsonSchema(this, this.api, opts);
   }
 
   /**

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -179,7 +179,7 @@ export default function getParametersAsJsonSchema(
       return false;
     }
 
-    const components: ComponentsObject = {};
+    const components: Partial<ComponentsObject> = {};
 
     Object.keys(api.components).forEach((componentType: keyof ComponentsObject) => {
       if (typeof api.components[componentType] === 'object' && !Array.isArray(api.components[componentType])) {

--- a/src/rmoas.types.ts
+++ b/src/rmoas.types.ts
@@ -16,7 +16,7 @@ export function isRef(check: unknown): check is OpenAPIV3.ReferenceObject | Open
  * @returns If the definition is a 3.1 definition.
  */
 export function isOAS31(check: OpenAPIV3.Document | OpenAPIV3_1.Document): check is OpenAPIV3_1.Document {
-  return check.openapi === '3.1.0';
+  return check.openapi.startsWith('3.1');
 }
 
 export interface User {
@@ -153,6 +153,7 @@ export type SchemaObject = (
   | JSONSchema
 ) & {
   // TODO: We should split this into one type for v3 and one type for v3.1 to ensure type accuracy.
+  $schema?: string;
   deprecated?: boolean;
   readOnly?: boolean;
   writeOnly?: boolean;

--- a/src/rmoas.types.ts
+++ b/src/rmoas.types.ts
@@ -16,7 +16,7 @@ export function isRef(check: unknown): check is OpenAPIV3.ReferenceObject | Open
  * @returns If the definition is a 3.1 definition.
  */
 export function isOAS31(check: OpenAPIV3.Document | OpenAPIV3_1.Document): check is OpenAPIV3_1.Document {
-  return check.openapi.startsWith('3.1');
+  return check.openapi === '3.1.0';
 }
 
 export interface User {


### PR DESCRIPTION
## 🧰 Changes

This adds a couple new options to `getParametersAsJsonSchema` (and reworks the method signature into accepting an options object).

Because I am changing the method signature of `getParametersAsJsonSchema` this work will incur a breaking change release.
 
### mergeIntoBodyAndMetadata
So for some background, in [api](https://npm.im/api) method signatures consist of two arguments: `body` and `metadata`. `body` is comprised of request body payloads, and `metadata` is comprised of everything else (query params, headers, path, and cookies).

Within the SDK code generation project I'm working on in RM-3414 I need to insert auto-generated Typescript parameter interfaces into methods:

```ts
interface FindPetsByStatusPathParam {
  /**
   * Pet id to delete
   */
  petId?: number;
  [k: string]: unknown;
}

interface FindPetsByStatusQueryParam {
  api_key?: string;
  [k: string]: unknown;
};
```

The problem however is that for the auto-generated method signatures, I don't want to have type unions everywhere:

```ts
findPetsByStatus(body: findPetsByStatusBody, metadata: FindPetsByStatusPathParam & FindPetsByStatusQueryParam) {
  return this.core.fetch('/pet/findByStatus', 'get', body, metadata);
}
```

With this new option I can generate a single JSON Schema entry and using an `allOf` automatically have [json-schema-to-typescript](https://npm.im/json-schema-to-typescript) feed me a pre-unioned type:

```ts
type FindPetsByStatusMetadata = {
  /**
   * Pet id to delete
   */
  petId?: number;
  [k: string]: unknown;
} & {
  api_key?: string;
  [k: string]: unknown;
};
```

Using that, codegen methods get a lot cleaner:

```ts
findPetsByStatus(body: findPetsByStatusBody, metadata: FindPetsByStatusMetadata) {
  return this.core.fetch('/pet/findByStatus', 'get', body, metadata);
}
```

### retainDeprecatedProperties

This new method is to augment our existing handling of splitting `deprecated` properties out of their original schemas and into a `deprecatedProps` object. When this option is enabled this work will not happen and properties and schemas marked as `deprecated` will stay where they are.

I plan on utilizing this option again in [api](https://npm.im/api) codegen so that if a property is deprecated it gets a `@deprecated` JSDoc tag.

## 🧬 QA & Testing

There's a lot going on in the diff because I overhauled how we're instantiating our example `Oas` instances with a `beforeAll()` block to do dereferencing so you might want to view the diff with whitespace changes excluded.

Beyond that, check the couple of new tests I added for these options.