### PR TITLE
fix: don't create an empty metadata allOf is there's no metadata

### DIFF
--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -756,6 +756,16 @@ describe('options', () => {
       expect(jsonSchema).toMatchSnapshot();
     });
 
+    it('should not create an empty `allOf` for metadata if there is no metadata', () => {
+      const operation = petstore.operation('/user', 'post');
+      const jsonSchema = operation.getParametersAsJsonSchema({
+        mergeIntoBodyAndMetadata: true,
+        retainDeprecatedProperties: true,
+      });
+
+      expect(jsonSchema.map(js => js.type)).toStrictEqual(['body']);
+    });
+
     describe('retainDeprecatedProperties (default behavior)', () => {
       it('should support merging `deprecatedProps` together', () => {
         const oas = createOas({

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -320,6 +320,8 @@ export default function getParametersAsJsonSchema(
 
     if (!opts.mergeIntoBodyAndMetadata) {
       return transformed;
+    } else if (!transformed.length) {
+      return [];
     }
 
     // If we want to merge parameters into a single metadata entry then we need to pull all


### PR DESCRIPTION
## 🧰 Changes

Fixes a bug in the new metadata merging work I did in #617 to not generate an empty `allOf` JSON Schema entry for metadata if there's no metadata on the operation.
 
## 🧬 QA & Testing

See tests.