### PR TITLE
fix: quirks with path matching on malformed path params and params with hypens

### DIFF
--- a/__tests__/__datasets__/path-matching-quirks.json
+++ b/__tests__/__datasets__/path-matching-quirks.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
     "title": "Path Matching Quirks",
     "description": "Example API definition to cover some quirks with path matching where a query param in a path might break `Oas.findOperation()`",
@@ -45,6 +45,50 @@
             "description": "OK"
           }
         }
+      }
+    },
+    "/games/{game}/dlc/{dlcrelease}}": {
+      "get": {
+        "description": "This operation is us asserting that we're able to match against a path with a malformed path parameter.",
+        "parameters": [
+          {
+            "schema": { "type": "string" },
+            "name": "game",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": { "type": "string" },
+            "name": "dlcrelease",
+            "in": "path",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/games/{game}/platforms/{platform}/dlc/{dlc-release}": {
+      "get": {
+        "description": "This operation is asserting that we're able to match against a path that has a path parameter that contains a hyphen.",
+        "parameters": [
+          {
+            "schema": { "type": "string" },
+            "name": "game",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": { "type": "string" },
+            "name": "platform",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": { "type": "string" },
+            "name": "dlc-release",
+            "in": "path",
+            "required": true
+          }
+        ]
       }
     }
   }

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -814,6 +814,42 @@ describe('#findOperation()', () => {
   });
 
   describe('quirks', () => {
+    it('should return result if the operation path has malformed path parameters', () => {
+      const oas = Oas.init(pathMatchingQuirks);
+
+      const uri = 'https://api.example.com/v2/games/destiny-2/dlc/witch-queen';
+      const method = 'get';
+      const res = oas.findOperation(uri, method);
+
+      expect(res.url).toStrictEqual({
+        origin: 'https://api.example.com/v2',
+        path: '/games/:game/dlc/:dlcrelease',
+        nonNormalizedPath: '/games/{game}/dlc/{dlcrelease}}',
+        slugs: { ':game': 'destiny-2', ':dlcrelease': 'witch-queen' },
+        method: 'GET',
+      });
+    });
+
+    it('should support a path parameter that has a hypen in it', () => {
+      const oas = Oas.init(pathMatchingQuirks);
+
+      const uri = 'https://api.example.com/v2/games/destiny-2/platforms/ps5/dlc/witch-queen';
+      const method = 'get';
+      const res = oas.findOperation(uri, method);
+
+      expect(res.url).toStrictEqual({
+        origin: 'https://api.example.com/v2',
+        path: '/games/:game/platforms/:platform/dlc/:dlcrelease',
+        nonNormalizedPath: '/games/{game}/platforms/{platform}/dlc/{dlc-release}',
+        slugs: {
+          ':game': 'destiny-2',
+          ':platform': 'ps5',
+          ':dlcrelease': 'witch-queen',
+        },
+        method: 'GET',
+      });
+    });
+
     it('should return a match if a defined server has camelcasing, but the uri is all lower', () => {
       const oas = new Oas({
         openapi: '3.0.0',
@@ -902,7 +938,7 @@ describe('#findOperation()', () => {
     });
 
     it('should not error if an unrelated OAS path has a query param in it', () => {
-      const oas = new Oas(pathMatchingQuirks);
+      const oas = Oas.init(pathMatchingQuirks);
       const uri = 'https://api.example.com/v2/listings';
       const method = 'post';
 
@@ -917,7 +953,7 @@ describe('#findOperation()', () => {
     });
 
     it('should match a path that has a query param in its OAS path definition', () => {
-      const oas = new Oas(pathMatchingQuirks);
+      const oas = Oas.init(pathMatchingQuirks);
       const uri = 'https://api.example.com/v2/rating_stats';
       const method = 'get';
 
@@ -932,7 +968,7 @@ describe('#findOperation()', () => {
     });
 
     it('should match a path that has a hash in its OAS path definition', () => {
-      const oas = new Oas(pathMatchingQuirks);
+      const oas = Oas.init(pathMatchingQuirks);
       const uri = 'https://api.example.com/v2/listings#hash';
       const method = 'get';
 


### PR DESCRIPTION
## 🧰 Changes

This fixes a couple problems that were found today with how our `findOperation` path matching works:

* [ ] If a path parameter was malformed and either had a trailing or preceeding curly bracket, our regex work would throw a fatal exception because it was generating invalid regex (like `:pathParam})`. We're now able to handle these.
* [ ] In my efforts to fix that issue I also discovered that if a path had a path parameter with a hyphen in it, `{path-param}`, we wouldn't be able to match on it **at all** because [path-to-regexp](https://npm.im/path-to-regexp) would only look at the first part of the `:path-param` regex we'd give it. I've added some string replacement work in our path matching code to adhoc transform `:path-param` into `:pathparam` before it's sent over.

## 🧬 QA & Testing

Check out the couple tests I added.