### PR TITLE
fix: issue where hostname server variables wouldn't match subdomains or ports

### DIFF
--- a/__tests__/__datasets__/server-variables.json
+++ b/__tests__/__datasets__/server-variables.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
     "title": "Server variables",
     "version": "1.0.0"
@@ -18,15 +18,42 @@
           "default": "v2"
         }
       }
+    },
+    {
+      "url": "{protocol}://{hostname}/api/public/v1",
+      "variables": {
+        "protocol": {
+          "default": "http"
+        },
+        "hostname": {
+          "default": "localhost:10000"
+        }
+      }
     }
   ],
   "paths": {
     "/post": {
       "post": {
-        "summary": "Should fetch variables from defaults and user values",
-        "description": "",
-        "parameters": [],
-        "responses": {}
+        "summary": "Should fetch variables from defaults and user values"
+      }
+    },
+    "/tables/{tableId}/rows/{rowId}": {
+      "put": {
+        "summary": "Should be able to match a complex URL that uses a server that has a full hostname as a server variable.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tableId",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "in": "path",
+            "name": "rowId",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ]
       }
     }
   }

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -761,12 +761,9 @@ describe('#findOperation()', () => {
         slugs: {},
         method: 'POST',
       },
-      operation: {
+      operation: expect.objectContaining({
         summary: 'Should fetch variables from defaults and user values',
-        description: '',
-        parameters: [],
-        responses: {},
-      },
+      }),
     });
   });
 
@@ -808,6 +805,23 @@ describe('#findOperation()', () => {
     });
 
     expect(serverVariables.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
+  });
+
+  it('should be able to match against servers with a variable hostname that includes subdomains and a port', () => {
+    const uri = 'http://online.example.global:3001/api/public/v1/tables/c445a575-ee58-4aa7/rows/5ba96283-29c2-47f7';
+    const method = 'put';
+
+    const res = serverVariables.findOperation(uri, method);
+    expect(res.url).toStrictEqual({
+      origin: '{protocol}://{hostname}/api/public/v1',
+      path: '/tables/:tableId/rows/:rowId',
+      nonNormalizedPath: '/tables/{tableId}/rows/{rowId}',
+      slugs: {
+        ':rowId': '5ba96283-29c2-47f7',
+        ':tableId': 'c445a575-ee58-4aa7',
+      },
+      method: 'PUT',
+    });
   });
 
   describe('quirks', () => {
@@ -1465,7 +1479,7 @@ describe('#getTags()', () => {
     });
 
     it('should ensure that operations without a tag still have a tag set as the path name if `setIfMissing` is true', () => {
-      expect(serverVariables.getTags(true)).toStrictEqual(['/post']);
+      expect(serverVariables.getTags(true)).toStrictEqual(['/post', '/tables/{tableId}/rows/{rowId}']);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ type PathMatches = PathMatch[];
 
 type Variables = Record<string, string | number | { default?: string | number }[] | { default?: string | number }>;
 
+const SERVER_VARIABLE_REGEX = /{([-_a-zA-Z0-9:.[\]]+)}/g;
+
 function ensureProtocol(url: string) {
   // Add protocol to urls starting with // e.g. //example.com
   // This is because httpsnippet throws a HARError when it doesnt have a protocol
@@ -84,12 +86,12 @@ function normalizedUrl(api: RMOAS.OASDocument, selected: number) {
  *
  * For example, when given `https://{region}.node.example.com/v14` this will return back:
  *
- *    https://([-_a-zA-Z0-9[\\]]+).node.example.com/v14
+ *    https://([-_a-zA-Z0-9:.[\\]]+).node.example.com/v14
  *
  * @param url URL to transform
  */
 function transformUrlIntoRegex(url: string) {
-  return stripTrailingSlash(url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, '([-_a-zA-Z0-9[\\]]+)'));
+  return stripTrailingSlash(url.replace(SERVER_VARIABLE_REGEX, '([-_a-zA-Z0-9:.[\\]]+)'));
 }
 
 /**
@@ -384,7 +386,7 @@ export default class Oas {
         // way we'll be able to extract the parameter names and match them up with the matched server that we obtained
         // above.
         const variables: Record<string, string | number> = {};
-        Array.from(server.url.matchAll(/{([-_a-zA-Z0-9[\]]+)}/g)).forEach((variable, y) => {
+        Array.from(server.url.matchAll(SERVER_VARIABLE_REGEX)).forEach((variable, y) => {
           variables[variable[1]] = found[y + 1];
         });
 
@@ -420,7 +422,7 @@ export default class Oas {
     // When we're constructing URLs, server URLs with trailing slashes cause problems with doing lookups, so if we have
     // one here on, slice it off.
     return stripTrailingSlash(
-      url.replace(/{([-_a-zA-Z0-9[\]]+)}/g, (original: string, key: string) => {
+      url.replace(SERVER_VARIABLE_REGEX, (original: string, key: string) => {
         const userVariable = getUserVariable(this.user, key);
         if (userVariable) {
           return userVariable as string;


### PR DESCRIPTION
| 🚥 Fix RM-3921 |
| :-- |

## 🧰 Changes

This fixes a bug in our server variable matching work in `Oas.findOperation()` where if an OAS had a fully variable hostname like `{protocol}://{hostname}/api/public/v1` we wouldn't be able to match against it if that `hostname` was being populated with either a subdomain or a port.

For example, this `servers` config:

```js
"servers": [
  {
    "url": "{protocol}://{hostname}/api/public/v1",
    "variables": {
      "protocol": { "default": "http" },
      "hostname": { "default": "localhost:10000" }
    }
  }
]
```

Attempting to find an operation for http://online.example.global:3001/api/public/v1/tables/c445a575-ee58-4aa7/rows/5ba96283-29c2-47f7 within this spec would fail because `online.example.global:3001` wasn't being seen as a valid `hostname`.

## 🧬 QA & Testing

Check out the test I wrote or kick off `npm run build` and run then this code against the spec that prompted this ticket:

```js
const Oas = require('./dist').default;
const spec = require('spec.json');

const url = 'http://online.spaedu.global:3001/api/public/v1/tables/ta_0e5ad9914a91461d8179a958293aca6e/rows/ro_ta_0e5ad9914a91461d8179a958293aca6e_5b54a8495591484ba669ef41821c5597';
const method = 'put';

(async () => {
  const oas = new Oas(spec);
  await oas.dereference();

  const res = oas.findOperation(url, method);
  console.log(res)
})();
```

That code will/should log the following:

```js
{
  url: {
    origin: '{protocol}://{hostname}/api/public/v1',
    path: '/tables/:tableId/rows/:rowId',
    nonNormalizedPath: '/tables/{tableId}/rows/{rowId}',
    slugs: {
      ':tableId': 'ta_0e5ad9914a91461d8179a958293aca6e',
      ':rowId': 'ro_ta_0e5ad9914a91461d8179a958293aca6e_5b54a8495591484ba669ef41821c5597'
    },
    method: 'PUT'
  },
  operation: {
    summary: 'Update a row',
    // other operation details
  }
}
```