### PR TITLE
fix: `operation.hasOperationId` should return false for an empty string

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -867,6 +867,27 @@ describe('#hasOperationId()', () => {
     const operation = multipleSecurities.operation('/multiple-combo-auths-duped', 'get');
     expect(operation.hasOperationId()).toBe(false);
   });
+
+  it("should return false if one is present but it's empty", () => {
+    const spec = Oas.init({
+      openapi: '3.1.0',
+      info: {
+        title: 'testing',
+        version: '1.0.0',
+      },
+      paths: {
+        '/anything': {
+          get: {
+            operationId: '',
+          },
+        },
+      },
+    });
+
+    const operation = spec.operation('/anything', 'get');
+
+    expect(operation.hasOperationId()).toBe(false);
+  });
 });
 
 describe('#getOperationId()', () => {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -315,11 +315,12 @@ export default class Operation {
   }
 
   /**
-   * Determine if the operation has an operation present in its schema.
+   * Determine if the operation has an operation present in its schema. Note that if one is present
+   * in the schema but is an empty string then this will return false.
    *
    */
   hasOperationId(): boolean {
-    return 'operationId' in this.schema;
+    return Boolean('operationId' in this.schema && this.schema.operationId.length);
   }
 
   /**
@@ -330,7 +331,7 @@ export default class Operation {
    * @param opts.camelCase Generate a JS method-friendly operation ID when one isn't present.
    */
   getOperationId(opts?: { camelCase: boolean }): string {
-    if ('operationId' in this.schema) {
+    if (this.hasOperationId()) {
       return this.schema.operationId;
     }
 
@@ -344,7 +345,7 @@ export default class Operation {
     if (opts?.camelCase) {
       operationId = operationId.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
 
-      // If the generated operationId already starts with the method (eg. `getPets`) we don't want
+      // If the generated `operationId` already starts with the method (eg. `getPets`) we don't want
       // to double it up into `getGetPets`.
       if (operationId.startsWith(method)) {
         return operationId;


### PR DESCRIPTION
## 🧰 Changes

Updates `Operation.hasOperationId()` to return `false` if an `operationId` is present but an empty string.