### PR TITLE
feat: `camelCase` opt on `getOperationId()` should clean IDs if present

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -907,6 +907,29 @@ describe('#getOperationId()', () => {
       expect(operation.getOperationId({ camelCase: true })).toBe('getMultipleComboAuthsDuped');
     });
 
+    it('should clean up an operationId that has non-alphanumeric characters', () => {
+      const spec = Oas.init({
+        openapi: '3.1.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        paths: {
+          '/pet/findByStatus': {
+            get: {
+              // This mess of a string is intentionally nasty so we can be sure that we're not
+              // including anything that wouldn't look right as an operationID for a potential
+              // method accessor in `api`.
+              operationId: 'find/?*!@#$%^&*()-=_.,<>+[]{}\\|pets-by_status',
+            },
+          },
+        },
+      });
+
+      const operation = spec.operation('/pet/findByStatus', 'get');
+      expect(operation.getOperationId({ camelCase: true })).toBe('findPetsByStatus');
+    });
+
     it('should not double up on a method prefix if the path starts with the method', () => {
       const spec = Oas.init({
         openapi: '3.0.0',


### PR DESCRIPTION
## 🧰 Changes

This modifies the `camelCase` option I introduced on `Operation.getOperationId()` in #602 to clean up operationIds if they're present. I plan on using this work within `api` to always make an attempt to generate friendlier operation accessors.

Since this work was just recently in [17.8.1](https://github.com/readmeio/oas/releases/tag/17.8.1) and we aren't using this new `camelCase` option anywhere I'm not going to bother with a breaking change release on this one.

## 🧬 QA & Testing

See tests but this'll transform a non-functional JS accessor operationId like `find/petsByStatus` into the friendlier `findPetsByStatus`.