### PR TITLE
fix: `operation.getSecurity()` should return an empty array for an empty `securitySchemes` object

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -383,7 +383,7 @@ describe('#getSecurity()', () => {
     ).toStrictEqual([]);
   });
 
-  it('should default to empty array if no securitySchemes are defined', () => {
+  it('should default to empty array if no `securitySchemes` are defined', () => {
     expect(
       Oas.init({
         openapi: '3.0.0',
@@ -401,6 +401,27 @@ describe('#getSecurity()', () => {
           },
         },
         components: {},
+      })
+        .operation('/things', 'post')
+        .getSecurity()
+    ).toStrictEqual([]);
+  });
+
+  it('should default to empty array if an empty `securitySchemes` object is defined', () => {
+    expect(
+      Oas.init({
+        openapi: '3.1.0',
+        info: { title: 'testing', version: '1.0' },
+        paths: {
+          '/things': {
+            post: {
+              security,
+            },
+          },
+        },
+        components: {
+          securitySchemes: {},
+        },
       })
         .operation('/things', 'post')
         .getSecurity()
@@ -543,7 +564,7 @@ describe('#getSecurityWithTypes()', () => {
     ).toStrictEqual([]);
   });
 
-  it('should default to empty array if no securitySchemes are defined', () => {
+  it('should default to empty array if no `securitySchemes` are defined', () => {
     expect(
       Oas.init({
         openapi: '3.0.0',

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -146,7 +146,7 @@ export default class Operation {
    *
    */
   getSecurity(): RMOAS.SecurityRequirementObject[] {
-    if (!this.api?.components?.securitySchemes) {
+    if (!this.api?.components?.securitySchemes || !Object.keys(this.api.components.securitySchemes).length) {
       return [];
     }
 


### PR DESCRIPTION
## 🧰 Changes

This updates our `Operation.getSecurity()` handling to now return an empty array if `#/components/securitySchemes` is present but is an empty object.

See PR 6389 in ReadMe for background.

## 🧬 QA & Testing

See tests.