### PR TITLE
fix: issue where a securityScheme may be corrupted with internal library data

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -1,5 +1,6 @@
 import type * as RMOAS from '../src/rmoas.types';
 import Oas, { Operation, Callback } from '../src';
+import openapiParser from '@readme/openapi-parser';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 
@@ -588,9 +589,9 @@ describe('#getSecurityWithTypes()', () => {
     ).toStrictEqual([]);
   });
 
-  it('should not pollute the original OAS with a `_key` property in the security scheme', () => {
+  it('should not pollute the original OAS with a `_key` property in the security scheme', async () => {
     const spec = Oas.init({
-      openapi: '3.0.0',
+      openapi: '3.1.0',
       info: { title: 'testing', version: '1.0' },
       paths: {
         '/things': {
@@ -629,6 +630,14 @@ describe('#getSecurityWithTypes()', () => {
       in: 'query',
       // _key: 'api_key' // This property should not have been added to the original API doc.
     });
+
+    // The original API doc should still be valid.
+    const clonedSpec = JSON.parse(JSON.stringify(spec.api));
+    await expect(openapiParser.validate(clonedSpec)).resolves.toStrictEqual(
+      expect.objectContaining({
+        openapi: '3.1.0',
+      })
+    );
   });
 });
 

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -587,6 +587,49 @@ describe('#getSecurityWithTypes()', () => {
         .getSecurityWithTypes()
     ).toStrictEqual([]);
   });
+
+  it('should not pollute the original OAS with a `_key` property in the security scheme', () => {
+    const spec = Oas.init({
+      openapi: '3.0.0',
+      info: { title: 'testing', version: '1.0' },
+      paths: {
+        '/things': {
+          get: {
+            security: [
+              {
+                api_key: [],
+              },
+            ],
+          },
+        },
+      },
+      components: {
+        securitySchemes: {
+          api_key: {
+            type: 'apiKey',
+            name: 'api_key',
+            in: 'query',
+          },
+        },
+      },
+    });
+
+    expect(spec.operation('/things', 'get').getSecurityWithTypes()).toStrictEqual([
+      [
+        {
+          type: 'Query',
+          security: { type: 'apiKey', name: 'api_key', in: 'query', _key: 'api_key' },
+        },
+      ],
+    ]);
+
+    expect(spec.api.components.securitySchemes.api_key).toStrictEqual({
+      type: 'apiKey',
+      name: 'api_key',
+      in: 'query',
+      // _key: 'api_key' // This property should not have been added to the original API doc.
+    });
+  });
 });
 
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
@@ -633,10 +676,9 @@ describe('#prepareSecurity()', () => {
         scheme: 'basic',
       },
     });
-    const operation = oas.operation(path, method);
 
-    expect(operation.prepareSecurity()).toStrictEqual({
-      Basic: [oas.api.components.securitySchemes.securityScheme],
+    expect(oas.operation(path, method).prepareSecurity()).toStrictEqual({
+      Basic: [{ scheme: 'basic', type: 'http', _key: 'securityScheme' }],
     });
   });
 
@@ -647,10 +689,9 @@ describe('#prepareSecurity()', () => {
         scheme: 'bearer',
       },
     });
-    const operation = oas.operation(path, method);
 
-    expect(operation.prepareSecurity()).toStrictEqual({
-      Bearer: [oas.api.components.securitySchemes.securityScheme],
+    expect(oas.operation(path, method).prepareSecurity()).toStrictEqual({
+      Bearer: [{ scheme: 'bearer', type: 'http', _key: 'securityScheme' }],
     });
   });
 
@@ -662,10 +703,9 @@ describe('#prepareSecurity()', () => {
         name: 'apiKey',
       },
     });
-    const operation = oas.operation(path, method);
 
-    expect(operation.prepareSecurity()).toStrictEqual({
-      Query: [oas.api.components.securitySchemes.securityScheme],
+    expect(oas.operation(path, method).prepareSecurity()).toStrictEqual({
+      Query: [{ type: 'apiKey', in: 'query', name: 'apiKey', _key: 'securityScheme' }],
     });
   });
 
@@ -677,10 +717,9 @@ describe('#prepareSecurity()', () => {
         name: 'x-api-key',
       },
     });
-    const operation = oas.operation(path, method);
 
-    expect(operation.prepareSecurity()).toStrictEqual({
-      Header: [oas.api.components.securitySchemes.securityScheme],
+    expect(oas.operation(path, method).prepareSecurity()).toStrictEqual({
+      Header: [{ type: 'apiKey', in: 'header', name: 'x-api-key', _key: 'securityScheme' }],
     });
   });
 
@@ -692,10 +731,9 @@ describe('#prepareSecurity()', () => {
         name: 'api_key',
       },
     });
-    const operation = oas.operation(path, method);
 
-    expect(operation.prepareSecurity()).toStrictEqual({
-      Cookie: [oas.api.components.securitySchemes.securityScheme],
+    expect(oas.operation(path, method).prepareSecurity()).toStrictEqual({
+      Cookie: [{ type: 'apiKey', in: 'cookie', name: 'api_key', _key: 'securityScheme' }],
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@commitlint/config-conventional": "^16.0.0",
         "@readme/eslint-config": "^8.5.0",
         "@readme/oas-examples": "^4.3.2",
+        "@readme/openapi-parser": "^2.0.4",
         "@types/jest": "^27.0.2",
         "@types/json-schema-merge-allof": "^0.6.1",
         "@types/memoizee": "^0.4.6",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@commitlint/config-conventional": "^16.0.0",
     "@readme/eslint-config": "^8.5.0",
     "@readme/oas-examples": "^4.3.2",
+    "@readme/openapi-parser": "^2.0.4",
     "@types/jest": "^27.0.2",
     "@types/json-schema-merge-allof": "^0.6.1",
     "@types/memoizee": "^0.4.6",

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -204,9 +204,13 @@ export default class Operation {
           return false;
         }
 
-        security._key = key;
-
-        return { type, security };
+        return {
+          type,
+          security: {
+            ...security,
+            _key: key,
+          },
+        };
       });
 
       if (filterInvalid) return keysWithTypes.filter(key => key !== false);


### PR DESCRIPTION
## 🧰 Changes

This resolves an issue I discovered while working on https://github.com/readmeio/api/pull/422 where if you called `operation.prepareSecurity()` and then ran OAS validation against the spec you ingested into `oas` validation would fail because `operation.prepareSecurity()` would append our internal security scheme name tracking information to a `_key` property.

Tests never caught this because they were asserting directly against the corrupted spec data. 🙃 
