### PR TITLE
feat: moving us over to our json-schema-ref-parser fork

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
 {
   "extends": [
     "@readme/eslint-config",
-    "@readme/eslint-config/typescript",
-    "plugin:jsdoc/recommended"
+    "@readme/eslint-config/docs",
+    "@readme/eslint-config/typescript"
   ],
   "root": true,
   "plugins": ["jsdoc"],
@@ -21,7 +21,7 @@
       "allow": ["_key"]
     }],
 
-    "no-use-before-define": ["error", { "classes": false }]
+    "@typescript-eslint/no-use-before-define": ["error", { "classes": false }]
   },
   "overrides": [
     {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import type * as RMOAS from '../src/rmoas.types';
 import Oas, { Operation, Webhook, utils } from '../src';
-import $RefParser from '@apidevtools/json-schema-ref-parser';
+import $RefParser from '@readme/json-schema-ref-parser';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "18.0.8",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@readme/json-schema-ref-parser": "^1.1.0",
         "@types/json-schema": "^7.0.9",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
@@ -20,7 +20,7 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.1.2",
+        "oas-normalize": "^5.2.0",
         "openapi-types": "^10.0.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^5.1.0"
@@ -31,15 +31,14 @@
       "devDependencies": {
         "@commitlint/cli": "^16.0.1",
         "@commitlint/config-conventional": "^16.0.0",
-        "@readme/eslint-config": "^8.5.0",
-        "@readme/oas-examples": "^4.3.2",
+        "@readme/eslint-config": "^8.5.1",
+        "@readme/oas-examples": "^5.0.0",
         "@readme/openapi-parser": "^2.0.4",
         "@types/jest": "^27.0.2",
         "@types/json-schema-merge-allof": "^0.6.1",
         "@types/memoizee": "^0.4.6",
         "alex": "^10.0.0",
-        "eslint": "^8.6.0",
-        "eslint-plugin-jsdoc": "^37.0.3",
+        "eslint": "^8.12.0",
         "husky": "^7.0.2",
         "jest": "^27.0.3",
         "prettier": "^2.5.1",
@@ -48,33 +47,6 @@
       },
       "engines": {
         "node": "^12 || ^14 || ^16"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -597,9 +569,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1031,16 +1003,16 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -1057,9 +1029,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1069,15 +1041,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
@@ -1537,12 +1500,12 @@
       }
     },
     "node_modules/@readme/better-ajv-errors": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.4.tgz",
-      "integrity": "sha512-qQQ8A9NB1gyqmmUbizJFBiOolwXd8iv5SV9HoyM0807YNVHKzbQ7snBR0WMSIw9xkJszqOAaFzpXg/P12sMmxA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.17.7",
+        "@babel/runtime": "^7.17.8",
         "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
@@ -1557,9 +1520,9 @@
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.5.0.tgz",
-      "integrity": "sha512-DNS7WnQs7VSRFLqlTDU44oXi4fs6r38CRFpM24w7KQKFNtJbY4lqj900omM+TxwFB3a4RLKruGdNpUsgd/nojQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.5.1.tgz",
+      "integrity": "sha512-qmIFC2rDQKV1wrhfoWMpwH8LEt2TzaSnhrtXU5S4ckeq4eiI3AExJ0a9xpVppB4LZEb41lqEhYm2s+LeN4o+SQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.14.0",
@@ -1594,9 +1557,9 @@
       }
     },
     "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -1621,22 +1584,22 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
-      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.0.0.tgz",
+      "integrity": "sha512-fGaQXRLqRIaOILefLECyPD5zgnRBL9TnE0W41X4AM9GA61rZHgS2e7zOyIw3Sj3Dvl8MgiyyMI0zfhseje2cGg==",
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.4.tgz",
-      "integrity": "sha512-Wf//6/n41UyUVIDE+NwnBsvv2XdzT8McXqj14jWXr1HwHWvHWDTs9uwSwU9nca4IQKclT1fWDo3l3CFw/N8hlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.4",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.10.0",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
@@ -1648,9 +1611,9 @@
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4734,12 +4697,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.0",
+        "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -10056,11 +10019,11 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.2.tgz",
-      "integrity": "sha512-q6rb9WcxtAp6t0WAPnVj711OPZj/CHhaeGpA5GabR7br5RMChFsKZrUl+3RvhGAxgqrR4YyUjYTpif7kKkItNg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "dependencies": {
-        "@readme/openapi-parser": "^2.0.4",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -13507,32 +13470,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -13938,9 +13875,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
-      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -14265,16 +14202,16 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+      "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -14288,19 +14225,13 @@
           "dev": true
         },
         "globals": {
-          "version": "13.12.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -14660,12 +14591,12 @@
       }
     },
     "@readme/better-ajv-errors": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.4.tgz",
-      "integrity": "sha512-qQQ8A9NB1gyqmmUbizJFBiOolwXd8iv5SV9HoyM0807YNVHKzbQ7snBR0WMSIw9xkJszqOAaFzpXg/P12sMmxA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-1.4.5.tgz",
+      "integrity": "sha512-a3YAAP1bEs9yytoqCy9Kj6VuWJ7WocVxedRcxImdkwTP6NBjtbY/IdBwHakll2DZ1yMOZAAozRebD09Xgfqrsg==",
       "requires": {
         "@babel/code-frame": "^7.16.0",
-        "@babel/runtime": "^7.17.7",
+        "@babel/runtime": "^7.17.8",
         "@humanwhocodes/momoa": "^2.0.3",
         "chalk": "^4.1.2",
         "json-to-ast": "^2.0.3",
@@ -14674,9 +14605,9 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.5.0.tgz",
-      "integrity": "sha512-DNS7WnQs7VSRFLqlTDU44oXi4fs6r38CRFpM24w7KQKFNtJbY4lqj900omM+TxwFB3a4RLKruGdNpUsgd/nojQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-8.5.1.tgz",
+      "integrity": "sha512-qmIFC2rDQKV1wrhfoWMpwH8LEt2TzaSnhrtXU5S4ckeq4eiI3AExJ0a9xpVppB4LZEb41lqEhYm2s+LeN4o+SQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^5.14.0",
@@ -14704,9 +14635,9 @@
       }
     },
     "@readme/json-schema-ref-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
-      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.1.0.tgz",
+      "integrity": "sha512-T0DxTMSEfOQHAlpI68LqYCwSFfP3u0w7E6zXWf16YphmAgWSOhLKuvnMSLXAlh27uxwclRekIvQf8AAUoQSDiw==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -14730,30 +14661,30 @@
       }
     },
     "@readme/oas-examples": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.4.0.tgz",
-      "integrity": "sha512-sZD5ZiRQGsR+h/LUnUGYm4NgfcA0cpv2+wDEiAuAxbk8rXxO2cvRPOeM9g+x93E2L1/t34Z8yCRFf0fnlI92ag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.0.0.tgz",
+      "integrity": "sha512-fGaQXRLqRIaOILefLECyPD5zgnRBL9TnE0W41X4AM9GA61rZHgS2e7zOyIw3Sj3Dvl8MgiyyMI0zfhseje2cGg==",
       "dev": true
     },
     "@readme/openapi-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.0.4.tgz",
-      "integrity": "sha512-Wf//6/n41UyUVIDE+NwnBsvv2XdzT8McXqj14jWXr1HwHWvHWDTs9uwSwU9nca4IQKclT1fWDo3l3CFw/N8hlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.1.0.tgz",
+      "integrity": "sha512-93HDSz0bzBWvG1RyWC0gfupTlqWJB+k5OvD05LB+37cGi7VSiSDH4mGPLiLP410+kXQLN3X1FwWVIhnW2f4DhQ==",
       "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "@readme/better-ajv-errors": "^1.4.4",
-        "@readme/json-schema-ref-parser": "^1.0.0",
-        "ajv": "^8.10.0",
+        "@readme/better-ajv-errors": "^1.4.5",
+        "@readme/json-schema-ref-parser": "^1.1.0",
+        "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -17067,12 +16998,12 @@
       }
     },
     "eslint": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+      "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.0",
+        "@eslint/eslintrc": "^1.2.1",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -20951,11 +20882,11 @@
       }
     },
     "oas-normalize": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.1.2.tgz",
-      "integrity": "sha512-q6rb9WcxtAp6t0WAPnVj711OPZj/CHhaeGpA5GabR7br5RMChFsKZrUl+3RvhGAxgqrR4YyUjYTpif7kKkItNg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.2.0.tgz",
+      "integrity": "sha512-xgbNgaFtsK388B9Wh1yE03TaivPXwSl3oMZBHa1ix8g2ZAal7ogl1mj4hRISPGPUgfDt57IQ9JQwdsGJufYRnw==",
       "requires": {
-        "@readme/openapi-parser": "^2.0.4",
+        "@readme/openapi-parser": "^2.1.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^9.0.6",
+    "@readme/json-schema-ref-parser": "^1.1.0",
     "@types/json-schema": "^7.0.9",
     "cardinal": "^2.1.1",
     "chalk": "^4.1.2",
@@ -60,7 +60,7 @@
     "jsonpointer": "^5.0.0",
     "memoizee": "^0.4.14",
     "minimist": "^1.2.0",
-    "oas-normalize": "^5.1.2",
+    "oas-normalize": "^5.2.0",
     "openapi-types": "^10.0.0",
     "path-to-regexp": "^6.2.0",
     "swagger-inline": "^5.1.0"
@@ -68,15 +68,14 @@
   "devDependencies": {
     "@commitlint/cli": "^16.0.1",
     "@commitlint/config-conventional": "^16.0.0",
-    "@readme/eslint-config": "^8.5.0",
-    "@readme/oas-examples": "^4.3.2",
+    "@readme/eslint-config": "^8.5.1",
+    "@readme/oas-examples": "^5.0.0",
     "@readme/openapi-parser": "^2.0.4",
     "@types/jest": "^27.0.2",
     "@types/json-schema-merge-allof": "^0.6.1",
     "@types/memoizee": "^0.4.6",
     "alex": "^10.0.0",
-    "eslint": "^8.6.0",
-    "eslint-plugin-jsdoc": "^37.0.3",
+    "eslint": "^8.12.0",
     "husky": "^7.0.2",
     "jest": "^27.0.3",
     "prettier": "^2.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type * as RMOAS from './rmoas.types';
 import type { OpenAPIV3_1 } from 'openapi-types';
 import type { MatchResult } from 'path-to-regexp';
 
-import $RefParser from '@apidevtools/json-schema-ref-parser';
+import $RefParser from '@readme/json-schema-ref-parser';
 import { pathToRegexp, match } from 'path-to-regexp';
 import getAuth from './lib/get-auth';
 import getUserVariable from './lib/get-user-variable';


### PR DESCRIPTION
## 🧰 Changes

This formally moves us off `@apidevtools/json-schema-ref-parser` and over to our `@readme/json-schema-ref-parser` fork that we use everywhere.

I've also bumped a handful of out of date dev dependencies.