### PR TITLE
feat: `operation.getOperationId()` will now always return a "clean" operationID

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -969,6 +969,32 @@ describe('#getOperationId()', () => {
     expect(operation.getOperationId()).toBe('get_multiple-combo-auths-duped');
   });
 
+  it('should clean up an operationId that has non-alphanumeric characters', () => {
+    const spec = Oas.init({
+      openapi: '3.1.0',
+      info: {
+        title: 'testing',
+        version: '1.0.0',
+      },
+      paths: {
+        '/pet/findByStatus': {
+          get: {
+            // This mess of a string is intentionally nasty so we can be sure that we're not
+            // including anything that wouldn't look right as an operationID for a potential
+            // method accessor in `api`.
+            operationId: 'find/?*!@#$%^&*()-=_.,<>+[]{}\\|pets-by_status',
+          },
+          post: {
+            operationId: 'Databases#remove_resource',
+          },
+        },
+      },
+    });
+
+    expect(spec.operation('/pet/findByStatus', 'get').getOperationId()).toBe('find_pets_by_status');
+    expect(spec.operation('/pet/findByStatus', 'post').getOperationId()).toBe('Databases_remove_resource');
+  });
+
   describe('`shouldCamelCase` option', () => {
     it('should create a camel cased operation ID if one does not exist', () => {
       const operation = multipleSecurities.operation('/multiple-combo-auths-duped', 'get');

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -365,7 +365,13 @@ export default class Operation {
       operationId = operationId.charAt(0).toUpperCase() + operationId.slice(1);
       return `${method}${operationId}`;
     } else if (this.hasOperationId()) {
-      return operationId;
+      // If we aren't creating a programming language-friendly accessor off this operationID we
+      // should still make sure that it doesn't have any weird characters that might throw off
+      // something like AJV when it's set as an `$id` property in a JSON Schema representation.
+      //
+      // And though `_` is non-alphanumeric it's okay in this because it's a neutral enough
+      // character we can use for delineation and it won't harm anything.
+      return operationId.replace(/[^a-zA-Z0-9_]/g, '_').replace(/__+/g, '_');
     }
 
     return `${method}_${operationId}`;


### PR DESCRIPTION
## 🧰 Changes

This resolves a bug in how we're supplying, within our explorer schema validation, `operationId` to AJV as an `$id` property where if an operationID has any problematic non-alphanumeric characters that AJV will throw hard hard error on it:

```
schema is invalid: data/$id must match pattern "^[^#]*#?$"
```

Because the operationID definition within the spec [isn't really specific enough about this](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#user-content-operationid) we're going to start cleaning up these operationIDs and removing any non-alphanumeric characters from them if they're present.

We don't use these operationIDs for anything within ReadMe other than schema validation, some `id`s throughout the explorer, and memoization busting, this can be considered a non-breaking change.