### PR TITLE
fix: adding in protections for if `user.keys` is an empty array

### DIFF
--- a/__tests__/lib/get-auth.test.ts
+++ b/__tests__/lib/get-auth.test.ts
@@ -139,6 +139,9 @@ describe('#getByScheme', () => {
     expect(getByScheme({}, { type: 'http', scheme: 'bearer', _key: 'schemeName' })).toBeNull();
     expect(getByScheme({}, { type: 'http', scheme: 'unknown', _key: 'schemeName' })).toBeNull();
 
+    expect(getByScheme({ keys: [] }, { type: 'http', scheme: 'bearer', _key: 'schemeName' })).toBeNull();
+    expect(getByScheme({ keys: [] }, { type: 'http', scheme: 'unknown', _key: 'schemeName' })).toBeNull();
+
     // @todo bring these tests back
     // expect(getByScheme(topLevelUser, { type: 'unknown' })).toBeNull();
     // expect(getByScheme(keysUser, { type: 'unknown' })).toBeNull();

--- a/src/lib/get-auth.ts
+++ b/src/lib/get-auth.ts
@@ -45,7 +45,7 @@ export function getByScheme(
   scheme = <RMOAS.KeyedSecuritySchemeObject>{},
   selectedApp?: string | number
 ): authKey {
-  if (user?.keys) {
+  if (user?.keys && user.keys.length) {
     if (selectedApp) {
       return getKey(
         user.keys.find(key => key.name === selectedApp),
@@ -77,7 +77,7 @@ export default function getAuth(
         [scheme]: getByScheme(
           user,
           {
-            // This sucks but since we dereference we'll never a `$ref` pointer here with a `ReferenceObject` type.
+            // This sucks but since we dereference we'll never have a `$ref` pointer here with a `ReferenceObject` type.
             ...(api.components.securitySchemes[scheme] as RMOAS.SecuritySchemeObject),
             _key: scheme,
           },


### PR DESCRIPTION
## 🧰 Changes

This resolves a regression that we introduced in `get-auth` when we rewrote the library in Typescript we removed length checks on `user.keys` so if that property is an empty array, we'd throw a hard error due to passing `undefined` into `getKey` from inside of `getByScheme`.

![Screen Shot 2022-04-07 at 9 32 45 AM](https://user-images.githubusercontent.com/33762/162252932-9c2ed13b-ce3d-465c-8324-65882f7cd548.png)

s/o to @kevinports for the discovery