### PR TITLE
feat: adding $schema version identifiers into generated response JSON Schema

### DIFF
--- a/__tests__/operation/__snapshots__/get-response-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-response-as-json-schema.test.ts.snap
@@ -6,6 +6,7 @@ Array [
     "description": "OK",
     "label": "Response body",
     "schema": Object {
+      "$schema": "http://json-schema.org/draft-04/schema#",
       "components": Object {
         "schemas": Object {
           "ProductStock": Object {

--- a/__tests__/operation/get-response-as-json-schema.test.ts
+++ b/__tests__/operation/get-response-as-json-schema.test.ts
@@ -49,6 +49,7 @@ test('it should return a response as JSON Schema', () => {
           message: { type: 'string' },
         },
         'x-readme-ref-name': 'ApiResponse',
+        $schema: 'http://json-schema.org/draft-04/schema#',
       },
     },
   ]);
@@ -86,6 +87,7 @@ describe('content type handling', () => {
             bar: { type: 'number' },
           },
           'x-readme-ref-name': 'simple-object',
+          $schema: 'http://json-schema.org/draft-04/schema#',
         },
       },
     ]);
@@ -112,7 +114,10 @@ describe('content type handling', () => {
         label: 'Response body',
         description: 'response level description',
         type: 'string',
-        schema: { type: 'string' },
+        schema: {
+          type: 'string',
+          $schema: 'http://json-schema.org/draft-04/schema#',
+        },
       },
     ]);
   });
@@ -160,6 +165,23 @@ describe('`headers` support', () => {
   });
 });
 
+describe('$schema version', () => {
+  it('should add the v4 schema version to OpenAPI 3.0.x schemas', () => {
+    const operation = petstore.operation('/pet/findByStatus', 'get');
+    expect(operation.getResponseAsJsonSchema('200')[0].schema.$schema).toBe('http://json-schema.org/draft-04/schema#');
+  });
+
+  it('should add v2020-12 schema version on OpenAPI 3.1 schemas', async () => {
+    const petstore_31 = await import('@readme/oas-examples/3.1/json/petstore.json').then(Oas.init);
+    await petstore_31.dereference();
+
+    const operation = petstore_31.operation('/pet/findByStatus', 'get');
+    expect(operation.getResponseAsJsonSchema('200')[0].schema.$schema).toBe(
+      'https://json-schema.org/draft/2020-12/schema#'
+    );
+  });
+});
+
 describe('$ref quirks', () => {
   it("should retain $ref pointers in the schema even if they're circular", () => {
     const operation = circular.operation('/', 'put');
@@ -175,6 +197,7 @@ describe('$ref quirks', () => {
         type: 'string',
         schema: {
           $ref: '#/components/schemas/SalesLine',
+          $schema: 'http://json-schema.org/draft-04/schema#',
           components: circular.api.components,
         },
       },

--- a/src/lib/clone-object.ts
+++ b/src/lib/clone-object.ts
@@ -1,0 +1,3 @@
+export default function cloneObject<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/src/operation/get-response-as-json-schema.ts
+++ b/src/operation/get-response-as-json-schema.ts
@@ -7,8 +7,9 @@ import type {
   HeaderObject,
 } from 'rmoas.types';
 import type Operation from 'operation';
-import toJSONSchema from '../lib/openapi-to-json-schema';
+import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
 import matches from '../lib/matches-mimetype';
+import cloneObject from '../lib/clone-object';
 
 const isJSON = matches.json;
 
@@ -113,6 +114,7 @@ export default function getResponseAsJsonSchema(operation: Operation, api: OASDo
 
   const foundSchema = getPreferredSchema((response as ResponseObject).content);
   if (foundSchema) {
+    const schema = cloneObject(foundSchema);
     const schemaWrapper: {
       type: string | string[];
       schema: SchemaObject;
@@ -123,7 +125,10 @@ export default function getResponseAsJsonSchema(operation: Operation, api: OASDo
       // instead of generating a JSON Schema with an `undefined` type we should default to `string` so there's at least
       // *something* the end-user can interact with.
       type: foundSchema.type || 'string',
-      schema: JSON.parse(JSON.stringify(foundSchema)),
+      schema: {
+        ...schema,
+        $schema: getSchemaVersionString(schema, api),
+      },
       label: 'Response body',
     };
 


### PR DESCRIPTION
## 🧰 Changes

This updates our response JSON Schema generation to start emitting `$schema` versioning identifiers, something we already do for parameters and request bodies.

Adding this should help to resolve a performance issue I've found in some code generation work I'm doing over in https://github.com/readmeio/api.