### PR TITLE
fix: issue where response schemas in the original spec may get overridden

### DIFF
--- a/__tests__/operation/get-response-as-json-schema.test.ts
+++ b/__tests__/operation/get-response-as-json-schema.test.ts
@@ -1,7 +1,9 @@
 import type { HttpMethods, ResponseObject, SchemaObject } from '../../src/rmoas.types';
 import Oas from '../../src';
+import openapiParser from '@readme/openapi-parser';
 
 import createOas from '../__fixtures__/create-oas';
+import cloneObject from '../../src/lib/clone-object';
 
 let circular: Oas;
 let petstore: Oas;
@@ -205,7 +207,7 @@ describe('$ref quirks', () => {
   });
 
   it('should not override object references', async () => {
-    const readme = await import('@readme/oas-examples/3.0/json/readme.json').then(Oas.init);
+    const readme = await import('@readme/oas-examples/3.0/json/readme.json').then(res => res.default).then(Oas.init);
     await readme.dereference({ preserveRefAsJSONSchemaTitle: true });
 
     const operation = readme.operation('/api-specification', 'post');
@@ -234,5 +236,12 @@ describe('$ref quirks', () => {
       // this to in `getResponseAsJsonSchema`.
       example: 'https://docs.readme.com/logs/6883d0ee-cf79-447a-826f-a48f7d5bdf5f',
     });
+
+    // The original spec should still validate too!
+    await expect(openapiParser.validate(cloneObject(definition))).resolves.toStrictEqual(
+      expect.objectContaining({
+        openapi: '3.0.2',
+      })
+    );
   });
 });

--- a/src/operation/get-response-as-json-schema.ts
+++ b/src/operation/get-response-as-json-schema.ts
@@ -102,14 +102,14 @@ export default function getResponseAsJsonSchema(operation: Operation, api: OASDo
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < contentTypes.length; i++) {
       if (isJSON(contentTypes[i])) {
-        return toJSONSchema(content[contentTypes[i]].schema, { refLogger });
+        return toJSONSchema(cloneObject(content[contentTypes[i]].schema), { refLogger });
       }
     }
 
     // We always want to prefer the JSON-compatible content types over everything else but if we haven't found one we
     // should default to the first available.
     const contentType = contentTypes.shift();
-    return toJSONSchema(content[contentType].schema, { refLogger });
+    return toJSONSchema(cloneObject(content[contentType].schema), { refLogger });
   }
 
   const foundSchema = getPreferredSchema((response as ResponseObject).content);


### PR DESCRIPTION
## 🧰 Changes

This resolves a data corruption bug I discovered in https://github.com/readmeio/api where if you compile the JSON Schema for an operation response with `getResponseAsJsonSchema`, and somewhere within that response is an `example` property, we'd update the original API definition object that was supplied to `Oas` with the `examples` syntax that `getResponseAsJsonSchema` reshapes `example` to -- rendering the original API definition in a non-spec validating state.

## 🧬 QA & Testing

I added a test that runs `getResponseAsJsonSchema` against a response in our own spec and then queries the original spec inside the original `Oas` instance to ensure that the schema property where `example` was present is only set to `examples` in the generated JSON Schema.

:upsidedown-cowboy-quadboy: