### PR TITLE
fix: don't attempt to clone undefined objects, resulting in a crash

### DIFF
--- a/__tests__/__datasets__/responses.json
+++ b/__tests__/__datasets__/responses.json
@@ -86,6 +86,27 @@
           }
         }
       }
+    },
+    "/response-with-example-and-no-schema": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": [
+                  {
+                    "id": 29748772,
+                    "calendar_ids": [
+                      6625762,
+                      6447372
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/__tests__/operation/__snapshots__/get-response-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-response-as-json-schema.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`$ref quirks should retain $ref pointers in the schema even if they're circular 1`] = `
+exports[`quirks $ref quirks should retain $ref pointers in the schema even if they're circular 1`] = `
 Array [
   Object {
     "description": "OK",

--- a/src/lib/clone-object.ts
+++ b/src/lib/clone-object.ts
@@ -1,5 +1,5 @@
 export default function cloneObject<T>(obj: T): T {
-  if (obj === undefined) {
+  if (typeof obj === 'undefined') {
     return undefined;
   }
 

--- a/src/lib/clone-object.ts
+++ b/src/lib/clone-object.ts
@@ -1,3 +1,7 @@
 export default function cloneObject<T>(obj: T): T {
+  if (obj === undefined) {
+    return undefined;
+  }
+
   return JSON.parse(JSON.stringify(obj));
 }


### PR DESCRIPTION
| 🚥 Fix RM-4226 |
| :-- |

## 🧰 Changes

This fixes a crash I introduced in work I did in #634 where if a response does not have a schema we were still attempting to clone it with `JSON.parse(JSON.stringify())`, which fails:

```
> JSON.parse(JSON.stringify(undefined))
VM226:1 Uncaught SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at <anonymous>:1:6
```