### PR TITLE
feat: updating response JSON Schema generation to auto-add enums to descriptions

### DIFF
--- a/__tests__/__datasets__/response-enums.json
+++ b/__tests__/__datasets__/response-enums.json
@@ -1,0 +1,82 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Responses w/ enums",
+    "description": "This is a demo API definition for our support to supplement response schema descriptions with enums are present.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org"
+    }
+  ],
+  "paths": {
+    "/anything": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/enum-request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/enum-request"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "enum-request": {
+        "type": "object",
+        "properties": {
+          "stock": {
+            "type": "string"
+          },
+          "description (markdown)": {
+            "type": "string",
+            "description": "This is a string with a **markdown** description: [link](ref:action-object)"
+          },
+          "enum (no description)": {
+            "type": "string",
+            "enum": ["available", "pending", "sold"]
+          },
+          "enum (with default)": {
+            "type": "string",
+            "description": "This enum has a `default` of `available`.",
+            "enum": ["available", "pending", "sold"],
+            "default": "available"
+          },
+          "enum (with default + no description)": {
+            "type": "string",
+            "enum": ["available", "pending", "sold"],
+            "default": "available"
+          },
+          "enum (with empty option)": {
+            "type": "string",
+            "description": "This enum has a an empty string (`\"\"`) as one of its available options.",
+            "enum": ["", "available", "pending", "sold"]
+          },
+          "enum (with empty option and empty default)": {
+            "type": "string",
+            "description": "This enum has a an empty string (`\"\"`) as its only available option, and that same value is set as its `default`.",
+            "enum": [""],
+            "default": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3584,14 +3584,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001332",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -16127,9 +16133,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001332",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
       "dev": true
     },
     "cardinal": {

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -557,6 +557,10 @@ export default function toJSONSchema(
     // https://stackoverflow.com/questions/33464504/using-spread-syntax-and-new-set-with-typescript/56870548
     schema.enum = Array.from(new Set(schema.enum));
 
+    // If we want to add enums to descriptions (like in the case of response JSON Schema)
+    // generation we need to convert them into a list of Markdown tilda'd strings. We're also
+    // filtering away empty and falsy strings here because adding empty `` blocks to the description
+    // will serve nobody any good.
     if (addEnumsToDescriptions) {
       const enums = schema.enum
         .filter(Boolean)

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -25,7 +25,8 @@ const UNSUPPORTED_SCHEMA_PROPS: ('nullable' | 'xml' | 'externalDocs' | 'example'
 
 type PrevSchemasType = RMOAS.SchemaObject[];
 
-export type toJsonSchemaOptions = {
+export type toJSONSchemaOptions = {
+  addEnumsToDescriptions?: boolean;
   currentLocation?: string;
   globalDefaults?: Record<string, unknown>;
   isPolymorphicAllOfChild?: boolean;
@@ -230,6 +231,7 @@ function searchForExampleByPointer(pointer: string, examples: PrevSchemasType = 
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject}
  * @param data OpenAPI Schema Object to convert to pure JSON Schema.
  * @param opts Options
+ * @param opts.addEnumsToDescriptions Whether or not to extend descriptions with a list of any present enums.
  * @param opts.currentLocation Current location within the schema -- this is a JSON pointer.
  * @param opts.globalDefaults Object containing a global set of defaults that we should apply to schemas that match it.
  * @param opts.isPolymorphicAllOfChild Is this schema the child of a polymorphic `allOf` schema?
@@ -238,12 +240,13 @@ function searchForExampleByPointer(pointer: string, examples: PrevSchemasType = 
  */
 export default function toJSONSchema(
   data: RMOAS.SchemaObject | boolean,
-  opts: toJsonSchemaOptions = {}
+  opts: toJSONSchemaOptions = {}
 ): RMOAS.SchemaObject {
   let schema = data === true ? {} : { ...data };
   const schemaAdditionalProperties = RMOAS.isSchema(schema) ? schema.additionalProperties : null;
 
-  const { currentLocation, globalDefaults, isPolymorphicAllOfChild, prevSchemas, refLogger } = {
+  const { addEnumsToDescriptions, currentLocation, globalDefaults, isPolymorphicAllOfChild, prevSchemas, refLogger } = {
+    addEnumsToDescriptions: false,
     currentLocation: '',
     globalDefaults: {},
     isPolymorphicAllOfChild: false,
@@ -299,7 +302,8 @@ export default function toJSONSchema(
     ['anyOf', 'oneOf'].forEach((polyType: 'anyOf' | 'oneOf') => {
       if (polyType in schema && Array.isArray(schema[polyType])) {
         schema[polyType].forEach((item, idx) => {
-          const polyOptions: toJsonSchemaOptions = {
+          const polyOptions: toJSONSchemaOptions = {
+            addEnumsToDescriptions,
             currentLocation: `${currentLocation}/${idx}`,
             globalDefaults,
             isPolymorphicAllOfChild: false,
@@ -431,6 +435,7 @@ export default function toJSONSchema(
         } else if (schema.items !== true) {
           // Run through the arrays contents and clean them up.
           schema.items = toJSONSchema(schema.items as RMOAS.SchemaObject, {
+            addEnumsToDescriptions,
             currentLocation: `${currentLocation}/0`,
             globalDefaults,
             prevSchemas,
@@ -456,6 +461,7 @@ export default function toJSONSchema(
             (typeof schema.properties[prop] === 'object' && schema.properties[prop] !== null)
           ) {
             schema.properties[prop] = toJSONSchema(schema.properties[prop] as RMOAS.SchemaObject, {
+              addEnumsToDescriptions,
               currentLocation: `${currentLocation}/${encodePointer(prop)}`,
               globalDefaults,
               prevSchemas,
@@ -480,6 +486,7 @@ export default function toJSONSchema(
         } else {
           // We know it will be a schema object because it's dereferenced
           schema.additionalProperties = toJSONSchema(schemaAdditionalProperties as RMOAS.SchemaObject, {
+            addEnumsToDescriptions,
             currentLocation,
             globalDefaults,
             prevSchemas,
@@ -544,11 +551,26 @@ export default function toJSONSchema(
     }
   }
 
-  // Enums should not have duplicated items as those will break AJV validation.
   if (RMOAS.isSchema(schema, isPolymorphicAllOfChild) && 'enum' in schema && Array.isArray(schema.enum)) {
+    // Enums should not have duplicated items as those will break AJV validation.
     // If we ever target ES6 for typescript we can drop this array.from.
     // https://stackoverflow.com/questions/33464504/using-spread-syntax-and-new-set-with-typescript/56870548
     schema.enum = Array.from(new Set(schema.enum));
+
+    if (addEnumsToDescriptions) {
+      const enums = schema.enum
+        .filter(Boolean)
+        .map(str => `\`${str}\``)
+        .join(' ');
+
+      if (enums.length) {
+        if ('description' in schema) {
+          schema.description += `\n\n${enums}`;
+        } else {
+          schema.description = enums;
+        }
+      }
+    }
   }
 
   // Clean up any remaining `items` or `properties` schema fragments lying around if there's also polymorphism present.

--- a/src/operation/get-response-as-json-schema.ts
+++ b/src/operation/get-response-as-json-schema.ts
@@ -37,7 +37,7 @@ function buildHeadersSchema(response: ResponseObject) {
       // TODO: Response headers are essentially parameters in OAS
       //    This means they can have content instead of schema.
       //    We should probably support that in the future
-      headersSchema.properties[key] = toJSONSchema(header.schema);
+      headersSchema.properties[key] = toJSONSchema(header.schema, { addEnumsToDescriptions: true });
 
       if (header.description) {
         (headersSchema.properties[key] as HeaderObject).description = header.description;
@@ -102,14 +102,14 @@ export default function getResponseAsJsonSchema(operation: Operation, api: OASDo
     // eslint-disable-next-line no-plusplus
     for (let i = 0; i < contentTypes.length; i++) {
       if (isJSON(contentTypes[i])) {
-        return toJSONSchema(cloneObject(content[contentTypes[i]].schema), { refLogger });
+        return toJSONSchema(cloneObject(content[contentTypes[i]].schema), { addEnumsToDescriptions: true, refLogger });
       }
     }
 
     // We always want to prefer the JSON-compatible content types over everything else but if we haven't found one we
     // should default to the first available.
     const contentType = contentTypes.shift();
-    return toJSONSchema(cloneObject(content[contentType].schema), { refLogger });
+    return toJSONSchema(cloneObject(content[contentType].schema), { addEnumsToDescriptions: true, refLogger });
   }
 
   const foundSchema = getPreferredSchema((response as ResponseObject).content);


### PR DESCRIPTION
| 🚥 Fix RM-988 |
| :-- |

## 🧰 Changes

This updates our `Operation.getResponseAsJsonSchema()` accessor to auto-add a list of enums into generated descriptions if enums are present.

This is how it'll look in the real world:

![Screen Shot 2022-04-24 at 12 00 30 PM](https://user-images.githubusercontent.com/33762/164992592-0912025e-5a93-48f5-b102-1af1eb47cc66.png)

## 🧬 QA & Testing

See the test and example dataset I added.