### PR TITLE
feat: adding $ref awareness to `Oas.getPaths()`

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1533,6 +1533,18 @@ describe('#getPaths()', () => {
       '/post': {},
     });
   });
+
+  it('should be able to handle OpenAPI 3.1 `pathItem` reference objects without dereferencing', async () => {
+    const oas = await import('./__datasets__/pathitems-component.json').then(r => r.default).then(Oas.init);
+
+    const paths = oas.getPaths();
+
+    expect(Object.keys(paths)).toHaveLength(1);
+    expect(paths['/pet/:id']).toStrictEqual({
+      put: expect.any(Operation),
+      get: expect.any(Operation),
+    });
+  });
 });
 
 describe('#getWebhooks()', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -657,12 +657,19 @@ export default class Oas {
      * anything from within the paths object that isn't a known HTTP method.
      *
      * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-7}
-     * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-7
+     * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-7}
      */
     const paths: Record<string, Record<RMOAS.HttpMethods, Operation | Webhook>> = {};
 
     Object.keys(this.api.paths ? this.api.paths : []).forEach(path => {
       paths[path] = {} as Record<RMOAS.HttpMethods, Operation | Webhook>;
+
+      // Though this library is generally unaware of `$ref` pointers we're making a singular
+      // exception with this accessor out of convenience.
+      if ('$ref' in this.api.paths[path]) {
+        this.api.paths[path] = utils.findSchemaDefinition(this.api.paths[path].$ref, this.api);
+      }
+
       Object.keys(this.api.paths[path]).forEach((method: RMOAS.HttpMethods) => {
         if (!supportedMethods.has(method)) return;
 

--- a/src/lib/find-schema-definition.ts
+++ b/src/lib/find-schema-definition.ts
@@ -1,15 +1,13 @@
-// Nabbed from react-jsonschema-form, but this should probably be extracted into a slim NPM module.
 import jsonpointer from 'jsonpointer';
 
 /**
  * Lookup a reference pointer within an OpenAPI definition and return the schema that it resolves
  * to.
  *
- * @deprecated
  * @param $ref Reference to look up a schema for.
- * @param definitions OpenAPI definition to look for the `$ref` pointer in.
+ * @param definition OpenAPI definition to look for the `$ref` pointer in.
  */
-export default function findSchemaDefinition($ref: string, definitions = {}) {
+export default function findSchemaDefinition($ref: string, definition = {}) {
   const origRef = $ref;
 
   $ref = $ref.trim();
@@ -25,7 +23,7 @@ export default function findSchemaDefinition($ref: string, definitions = {}) {
     throw new Error(`Could not find a definition for ${origRef}.`);
   }
 
-  const current = jsonpointer.get(definitions, $ref);
+  const current = jsonpointer.get(definition, $ref);
   if (current === undefined) {
     throw new Error(`Could not find a definition for ${origRef}.`);
   }


### PR DESCRIPTION
| 🚥 Fix RM-4348 |
| :-- |

## 🧰 Changes

This updates our `getPaths` accessor to be aware of `$ref` pointers.

## 🧬 QA & Testing

See tests.