### PR TITLE
fix: don't remove underscores in operationIds

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -977,6 +977,28 @@ describe('#getOperationId()', () => {
       expect(operation.getOperationId({ camelCase: true })).toBe('getMultipleComboAuthsDuped');
     });
 
+    it("should not touch an operationId that doesn't need to be camelCased", () => {
+      const spec = Oas.init({
+        openapi: '3.1.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        paths: {
+          '/anything': {
+            get: {
+              // This operationID is already fine to use as a JS method accessor so we shouldn't do
+              // anything to it.
+              operationId: 'ExchangeRESTAPI_GetAccounts',
+            },
+          },
+        },
+      });
+
+      const operation = spec.operation('/anything', 'get');
+      expect(operation.getOperationId({ camelCase: true })).toBe('ExchangeRESTAPI_GetAccounts');
+    });
+
     it('should clean up an operationId that has non-alphanumeric characters', () => {
       const spec = Oas.init({
         openapi: '3.1.0',
@@ -990,7 +1012,7 @@ describe('#getOperationId()', () => {
               // This mess of a string is intentionally nasty so we can be sure that we're not
               // including anything that wouldn't look right as an operationID for a potential
               // method accessor in `api`.
-              operationId: 'find/?*!@#$%^&*()-=_.,<>+[]{}\\|pets-by_status',
+              operationId: 'find/?*!@#$%^&*()-=.,<>+[]{}\\|pets-by-status',
             },
           },
         },

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -349,7 +349,7 @@ export default class Operation {
 
     const method = this.method.toLowerCase();
     if (opts?.camelCase) {
-      operationId = operationId.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase());
+      operationId = operationId.replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => chr.toUpperCase());
 
       // If the generated `operationId` already starts with the method (eg. `getPets`) we don't want
       // to double it up into `getGetPets`.


### PR DESCRIPTION
## 🧰 Changes

This fixes a problem in `api` (https://github.com/readmeio/api/issues/488) where if you have an OAS with an `operationId` that has an underscore, like `ExchangeRESTAPI_GetAccounts`, when we call `getOperationId({ camelCase: true })` we were transforming it into `ExchangeRESTAPIGetAccounts` because we didn't recognize an underscore as being a valid character in a potential JS method accessor.