### PR TITLE
feat: addition of a new JSON Schema transformer option + operationId fixes

### DIFF
--- a/__tests__/__snapshots__/operation.test.ts.snap
+++ b/__tests__/__snapshots__/operation.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#getParametersAsJsonSchema() should return json schema 1`] = `
+exports[`#getParametersAsJSONSchema() should return json schema 1`] = `
 Array [
   Object {
     "label": "Body Params",

--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -861,7 +861,7 @@ describe('`example` / `examples` support', () => {
 
     it('should function through the normal workflow of retrieving a json schema and feeding it an initial example', () => {
       const operation = petstore.operation('/pet', 'post');
-      const schema: SchemaObject = operation.getParametersAsJsonSchema()[0].schema;
+      const schema: SchemaObject = operation.getParametersAsJSONSchema()[0].schema;
 
       expect(schema.components).toBeUndefined();
       expect((schema.properties.id as SchemaObject).examples).toStrictEqual([25]);
@@ -960,7 +960,7 @@ describe('`example` / `examples` support', () => {
 
     await oas.dereference();
 
-    const schema: SchemaObject = oas.operation('/', 'post').getParametersAsJsonSchema();
+    const schema: SchemaObject = oas.operation('/', 'post').getParametersAsJSONSchema();
     expect(schema[0].schema).toStrictEqual({
       $schema: 'http://json-schema.org/draft-04/schema#',
       type: 'object',
@@ -1020,7 +1020,7 @@ describe('`example` / `examples` support', () => {
       components: {},
     });
 
-    const schema: SchemaObject = oas.operation('/', 'post').getParametersAsJsonSchema();
+    const schema: SchemaObject = oas.operation('/', 'post').getParametersAsJSONSchema();
     expect(schema[0].schema).toStrictEqual({
       $schema: 'http://json-schema.org/draft-04/schema#',
       type: 'object',

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -1237,10 +1237,10 @@ describe('#hasRequiredParameters()', () => {
   });
 });
 
-describe('#getParametersAsJsonSchema()', () => {
+describe('#getParametersAsJSONSchema()', () => {
   it('should return json schema', () => {
     const operation = petstore.operation('/pet', 'put');
-    expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+    expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
   });
 });
 

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -1040,6 +1040,27 @@ describe('#getOperationId()', () => {
       expect(operation.getOperationId({ camelCase: true })).toBe('findPetsByStatus');
     });
 
+    it('should clean up an operationId that ends in non-alpha characters', () => {
+      const spec = Oas.init({
+        openapi: '3.1.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        paths: {
+          '/pet/findByStatus': {
+            get: {
+              deprecated: true,
+              operationId: 'find pets by status (deprecated?*!@#$%^&*()-=.,<>+[]{})',
+            },
+          },
+        },
+      });
+
+      const operation = spec.operation('/pet/findByStatus', 'get');
+      expect(operation.getOperationId({ camelCase: true })).toBe('findPetsByStatusDeprecated');
+    });
+
     it('should not double up on a method prefix if the path starts with the method', () => {
       const spec = Oas.init({
         openapi: '3.0.0',

--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -39,8 +39,8 @@ beforeAll(async () => {
 });
 
 test('it should return with null if there are no parameters', () => {
-  expect(createOas({ parameters: [] }).operation('/', 'get').getParametersAsJsonSchema()).toBeNull();
-  expect(createOas({}).operation('/', 'get').getParametersAsJsonSchema()).toBeNull();
+  expect(createOas({ parameters: [] }).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
+  expect(createOas({}).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
 });
 
 describe('type sorting', () => {
@@ -68,7 +68,7 @@ describe('type sorting', () => {
     };
 
     const oas = createOas(operation);
-    const jsonschema = oas.operation('/', 'get').getParametersAsJsonSchema();
+    const jsonschema = oas.operation('/', 'get').getParametersAsJSONSchema();
 
     expect(jsonschema).toMatchSnapshot();
     expect(
@@ -89,7 +89,7 @@ describe('type sorting', () => {
     };
 
     const oas = createOas(operation);
-    const jsonschema = oas.operation('/', 'get').getParametersAsJsonSchema();
+    const jsonschema = oas.operation('/', 'get').getParametersAsJSONSchema();
 
     expect(jsonschema).toMatchSnapshot();
     expect(
@@ -102,13 +102,13 @@ describe('type sorting', () => {
 
 describe('$schema version', () => {
   it('should add the v4 schema version to OpenAPI 3.0.x schemas', () => {
-    expect(petstore.operation('/pet', 'post').getParametersAsJsonSchema()[0].schema.$schema).toBe(
+    expect(petstore.operation('/pet', 'post').getParametersAsJSONSchema()[0].schema.$schema).toBe(
       'http://json-schema.org/draft-04/schema#'
     );
   });
 
   it('should add v2020-12 schema version on OpenAPI 3.1 schemas', () => {
-    expect(petstore_31.operation('/pet', 'post').getParametersAsJsonSchema()[0].schema.$schema).toBe(
+    expect(petstore_31.operation('/pet', 'post').getParametersAsJSONSchema()[0].schema.$schema).toBe(
       'https://json-schema.org/draft/2020-12/schema#'
     );
   });
@@ -117,13 +117,13 @@ describe('$schema version', () => {
 describe('parameters', () => {
   it('should convert parameters to JSON schema', () => {
     const operation = petstore.operation('/pet/{petId}', 'delete');
-    expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+    expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
   });
 
   describe('polymorphism', () => {
     it('should merge allOf schemas together', () => {
       const operation = polymorphismQuirks.operation('/allof-with-empty-object-property', 'post');
-      expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+      expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
     });
   });
 
@@ -140,7 +140,7 @@ describe('parameters', () => {
         ],
       });
 
-      const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+      const schema = oas.operation('/', 'get').getParametersAsJSONSchema();
       expect(schema[0].schema.properties.userId).toStrictEqual({
         $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'string',
@@ -162,7 +162,7 @@ describe('parameters', () => {
         ],
       });
 
-      const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+      const schema = oas.operation('/', 'get').getParametersAsJSONSchema();
       expect(schema[0].schema.properties.userId).toStrictEqual({
         $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'integer',
@@ -187,7 +187,7 @@ describe('parameters', () => {
         ],
       });
 
-      const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+      const schema = oas.operation('/', 'get').getParametersAsJSONSchema();
       expect(schema[0].schema.properties.userId).toStrictEqual({
         $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'integer',
@@ -208,7 +208,7 @@ describe('parameters', () => {
         ],
       });
 
-      const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+      const schema = oas.operation('/', 'get').getParametersAsJSONSchema();
       expect(schema[0].schema.properties.userId).toStrictEqual({
         $schema: 'http://json-schema.org/draft-04/schema#',
         type: 'integer',
@@ -220,7 +220,7 @@ describe('parameters', () => {
     it('should override path-level parameters on the operation level', () => {
       expect(
         (
-          parametersCommon.operation('/anything/{id}/override', 'get').getParametersAsJsonSchema()[0].schema.properties
+          parametersCommon.operation('/anything/{id}/override', 'get').getParametersAsJSONSchema()[0].schema.properties
             .id as SchemaObject
         ).description
       ).toBe('A comma-separated list of pet IDs');
@@ -228,7 +228,7 @@ describe('parameters', () => {
 
     it('should add common parameter to path params', () => {
       const operation = parametersCommon.operation('/anything/{id}', 'get');
-      expect((operation.getParametersAsJsonSchema()[0].schema.properties.id as SchemaObject).description).toBe(
+      expect((operation.getParametersAsJSONSchema()[0].schema.properties.id as SchemaObject).description).toBe(
         'ID parameter'
       );
     });
@@ -239,12 +239,12 @@ describe('request bodies', () => {
   describe('should convert request bodies to JSON schema', () => {
     it('application/json', () => {
       const operation = petstore.operation('/pet', 'post');
-      expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+      expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
     });
 
     it('application/x-www-form-urlencoded', () => {
       const operation = petstoreServerVars.operation('/pet/{petId}', 'post');
-      expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+      expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
     });
   });
 
@@ -260,7 +260,7 @@ describe('request bodies', () => {
       },
     });
 
-    expect(oas.operation('/', 'get').getParametersAsJsonSchema()).toStrictEqual([]);
+    expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toStrictEqual([]);
   });
 
   it('should not return anything for a requestBody that has no schema', () => {
@@ -275,20 +275,20 @@ describe('request bodies', () => {
       },
     });
 
-    expect(oas.operation('/', 'get').getParametersAsJsonSchema()).toStrictEqual([]);
+    expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toStrictEqual([]);
   });
 });
 
 describe('$ref quirks', () => {
   it("should retain $ref pointers in the schema even if they're circular", () => {
-    expect(circular.operation('/', 'put').getParametersAsJsonSchema()).toMatchSnapshot();
+    expect(circular.operation('/', 'put').getParametersAsJSONSchema()).toMatchSnapshot();
   });
 });
 
 describe('polymorphism / discriminators', () => {
   it('should retain discriminator `mapping` refs when present', () => {
     const operation = discriminators.operation('/anything/discriminator-with-mapping', 'patch');
-    expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+    expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
   });
 });
 
@@ -345,7 +345,7 @@ describe('type', () => {
 
         // So we can test that components are transformed, this test intentionally does **not**
         // dereference the API definition.
-        const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+        const schema = oas.operation('/', 'get').getParametersAsJSONSchema();
 
         expect(schema[0].schema.components.schemas.messages.type).toBe('object');
         expect(schema[0].schema.components.schemas.user.type).toBe('object');
@@ -371,7 +371,7 @@ describe('descriptions', () => {
       ],
     });
 
-    expect(oas.operation('/', 'get').getParametersAsJsonSchema()).toStrictEqual([
+    expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toStrictEqual([
       {
         label: 'Headers',
         type: 'header',
@@ -426,7 +426,7 @@ describe('descriptions', () => {
 
     await oas.dereference();
 
-    expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].schema).toStrictEqual({
+    expect(oas.operation('/', 'get').getParametersAsJSONSchema()[0].schema).toStrictEqual({
       type: 'object',
       properties: {
         pathId: {
@@ -489,7 +489,7 @@ describe('`example` / `examples` support', () => {
         ],
       });
 
-      const schema = oas.operation('/', 'get').getParametersAsJsonSchema();
+      const schema = oas.operation('/', 'get').getParametersAsJSONSchema();
       expect(schema).toStrictEqual([
         {
           type: 'query',
@@ -532,7 +532,7 @@ describe('deprecated', () => {
         ],
       });
 
-      expect(oas.operation('/', 'get').getParametersAsJsonSchema()).toStrictEqual([
+      expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toStrictEqual([
         {
           label: 'Headers',
           type: 'header',
@@ -594,7 +594,7 @@ describe('deprecated', () => {
       );
 
       await oas.dereference();
-      expect(oas.operation('/', 'get').getParametersAsJsonSchema()[0].deprecatedProps.schema).toStrictEqual({
+      expect(oas.operation('/', 'get').getParametersAsJSONSchema()[0].deprecatedProps.schema).toStrictEqual({
         type: 'object',
         $schema: 'http://json-schema.org/draft-04/schema#',
         properties: {
@@ -613,22 +613,22 @@ describe('deprecated', () => {
 
     it('should create deprecatedProps from body and metadata parameters', () => {
       const operation = deprecated.operation('/anything', 'post');
-      expect(operation.getParametersAsJsonSchema()).toMatchSnapshot();
+      expect(operation.getParametersAsJSONSchema()).toMatchSnapshot();
     });
 
     it('should not put required deprecated parameters in deprecatedProps', () => {
       const operation = deprecated.operation('/anything', 'post');
-      const deprecatedSchema = operation.getParametersAsJsonSchema()[1].deprecatedProps.schema;
+      const deprecatedSchema = operation.getParametersAsJSONSchema()[1].deprecatedProps.schema;
 
       (deprecatedSchema.required as string[]).forEach(requiredParam => {
-        expect(requiredParam in deprecatedSchema.properties).toBe(false);
+        expect(deprecatedSchema.properties[requiredParam]).toBeUndefined();
       });
       expect(Object.keys(deprecatedSchema.properties)).toHaveLength(4);
     });
 
     it('should not put readOnly deprecated parameters in deprecatedProps', () => {
       const operation = deprecated.operation('/anything', 'post');
-      const deprecatedSchema = operation.getParametersAsJsonSchema()[1].deprecatedProps.schema;
+      const deprecatedSchema = operation.getParametersAsJSONSchema()[1].deprecatedProps.schema;
 
       expect(Object.keys(deprecatedSchema.properties)).toHaveLength(4);
       expect('idReadOnly' in Object.keys(deprecatedSchema.properties)).toBe(false);
@@ -661,7 +661,7 @@ describe('deprecated', () => {
         },
       });
 
-      expect(oas.operation('/', 'get').getParametersAsJsonSchema()).toStrictEqual([
+      expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toStrictEqual([
         {
           type: 'body',
           label: 'Body Params',
@@ -729,7 +729,7 @@ describe('deprecated', () => {
         },
       });
 
-      expect(oas.operation('/', 'get').getParametersAsJsonSchema()).toMatchSnapshot();
+      expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toMatchSnapshot();
     });
   });
 });
@@ -745,7 +745,7 @@ describe('options', () => {
         },
       };
 
-      const jsonSchema = operation.getParametersAsJsonSchema({ globalDefaults: jwtDefaults });
+      const jsonSchema = operation.getParametersAsJSONSchema({ globalDefaults: jwtDefaults });
       expect((jsonSchema[0].schema.properties.category as SchemaObject).default).toStrictEqual(jwtDefaults.category);
     });
 
@@ -755,7 +755,7 @@ describe('options', () => {
         petId: 1,
       };
 
-      const jsonSchema = operation.getParametersAsJsonSchema({ globalDefaults: jwtDefaults });
+      const jsonSchema = operation.getParametersAsJSONSchema({ globalDefaults: jwtDefaults });
       expect((jsonSchema[0].schema.properties.petId as SchemaObject).default).toStrictEqual(jwtDefaults.petId);
     });
   });
@@ -763,7 +763,7 @@ describe('options', () => {
   describe('mergeIntoBodyAndMetadata', () => {
     it('should merge params categorized as metadata into a single block', () => {
       const operation = petstore.operation('/pet/{petId}', 'delete');
-      const jsonSchema = operation.getParametersAsJsonSchema({
+      const jsonSchema = operation.getParametersAsJSONSchema({
         mergeIntoBodyAndMetadata: true,
         retainDeprecatedProperties: true,
       });
@@ -773,7 +773,7 @@ describe('options', () => {
 
     it('should not create an empty `allOf` for metadata if there is no metadata', () => {
       const operation = petstore.operation('/user', 'post');
-      const jsonSchema = operation.getParametersAsJsonSchema({
+      const jsonSchema = operation.getParametersAsJSONSchema({
         mergeIntoBodyAndMetadata: true,
         retainDeprecatedProperties: true,
       });
@@ -796,7 +796,7 @@ describe('options', () => {
           ],
         });
 
-        const jsonSchema = oas.operation('/', 'get').getParametersAsJsonSchema({ mergeIntoBodyAndMetadata: true });
+        const jsonSchema = oas.operation('/', 'get').getParametersAsJSONSchema({ mergeIntoBodyAndMetadata: true });
         expect(jsonSchema).toMatchSnapshot();
       });
     });
@@ -817,7 +817,7 @@ describe('options', () => {
         ],
       });
 
-      const jsonSchema = oas.operation('/', 'get').getParametersAsJsonSchema({ retainDeprecatedProperties: true });
+      const jsonSchema = oas.operation('/', 'get').getParametersAsJSONSchema({ retainDeprecatedProperties: true });
       expect(jsonSchema[0].schema).toStrictEqual({
         type: 'object',
         properties: {
@@ -827,6 +827,78 @@ describe('options', () => {
       });
 
       expect(jsonSchema[0].deprecatedProps).toBeUndefined();
+    });
+  });
+
+  describe('transformer', () => {
+    it('should be able transform part of a schema', () => {
+      const oas = createOas({
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                oneOf: [
+                  {
+                    title: '260 Created (token)',
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        example: '61e36b8fc12c4d8fd0842f76',
+                      },
+                    },
+                  },
+                  {
+                    title: '260 Created',
+                    type: 'object',
+                    properties: {
+                      id: {
+                        type: 'string',
+                        example: '61e36b8fc12c4d8fd0842f76',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      const jsonSchema = oas.operation('/', 'get').getParametersAsJSONSchema({
+        transformer: schema => {
+          if (schema.title) {
+            if (/^\d/.test(schema.title)) {
+              schema.title = schema.title.toUpperCase();
+            }
+          }
+
+          return schema;
+        },
+      });
+
+      expect(jsonSchema[0].schema.oneOf).toStrictEqual([
+        {
+          title: '260 CREATED (TOKEN)',
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+              examples: ['61e36b8fc12c4d8fd0842f76'],
+            },
+          },
+        },
+        {
+          title: '260 CREATED',
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+              examples: ['61e36b8fc12c4d8fd0842f76'],
+            },
+          },
+        },
+      ]);
     });
   });
 });

--- a/__tests__/ts-quirks.test.js
+++ b/__tests__/ts-quirks.test.js
@@ -48,7 +48,7 @@ test('should be able to generate enums', () => {
   };
 
   const oas = new Oas(spec);
-  expect(oas.operation('/anything', 'post').getParametersAsJsonSchema()[0].schema.properties.enumType).toStrictEqual({
+  expect(oas.operation('/anything', 'post').getParametersAsJSONSchema()[0].schema.properties.enumType).toStrictEqual({
     type: 'string',
     enum: ['pug', 'cat'],
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/json-schema-merge-allof": "^0.6.1",
         "@types/jsonpath": "^0.2.0",
         "@types/memoizee": "^0.4.6",
+        "@types/node": "^18.8.2",
         "eslint": "^8.20.0",
         "husky": "^8.0.1",
         "jest": "^28.1.3",
@@ -2016,9 +2017,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "18.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -11157,9 +11158,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "18.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/json-schema-merge-allof": "^0.6.1",
     "@types/jsonpath": "^0.2.0",
     "@types/memoizee": "^0.4.6",
+    "@types/node": "^18.8.2",
     "eslint": "^8.20.0",
     "husky": "^8.0.1",
     "jest": "^28.1.3",

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -336,20 +336,26 @@ export default class Operation {
    * @param opts.camelCase Generate a JS method-friendly operation ID when one isn't present.
    */
   getOperationId(opts?: { camelCase: boolean }): string {
+    function sanitize(id: string) {
+      return id
+        .replace(/[^a-zA-Z0-9_]/g, '-') // Remove weird characters
+        .replace(/^-|-$/g, '') // Don't start or end with -
+        .replace(/--+/g, '-'); // Remove double --'s
+    }
+
     let operationId;
     if (this.hasOperationId()) {
       operationId = this.schema.operationId;
     } else {
-      operationId = this.path
-        .replace(/[^a-zA-Z0-9]/g, '-') // Remove weird characters
-        .replace(/^-|-$/g, '') // Don't start or end with -
-        .replace(/--+/g, '-') // Remove double --'s
-        .toLowerCase();
+      operationId = sanitize(this.path).toLowerCase();
     }
 
     const method = this.method.toLowerCase();
     if (opts?.camelCase) {
       operationId = operationId.replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => chr.toUpperCase());
+      if (this.hasOperationId()) {
+        operationId = sanitize(operationId);
+      }
 
       // If the generated `operationId` already starts with the method (eg. `getPets`) we don't want
       // to double it up into `getGetPets`.

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -7,9 +7,9 @@ import dedupeCommonParameters from './lib/dedupe-common-parameters';
 import findSchemaDefinition from './lib/find-schema-definition';
 import matchesMimeType from './lib/matches-mimetype';
 import getCallbackExamples from './operation/get-callback-examples';
-import getParametersAsJsonSchema from './operation/get-parameters-as-json-schema';
+import getParametersAsJSONSchema from './operation/get-parameters-as-json-schema';
 import getRequestBodyExamples from './operation/get-requestbody-examples';
-import getResponseAsJsonSchema from './operation/get-response-as-json-schema';
+import getResponseAsJSONSchema from './operation/get-response-as-json-schema';
 import getResponseExamples from './operation/get-response-examples';
 import * as RMOAS from './rmoas.types';
 import { supportedMethods } from './utils';
@@ -455,24 +455,43 @@ export default class Operation {
    *    `header`).
    * @param opts.retainDeprecatedProperties If you wish to **not** split out deprecated properties
    *    into a separate `deprecatedProps` object.
+   * @param opts.transformer With a transformer you can transform any data within a given schema,
+   *    like say if you want to rewrite a potentially unsafe `title` that might be eventually used
+   *    as a JS variable name, just make sure to return your transformed schema.
    */
-  getParametersAsJsonSchema(
+  getParametersAsJSONSchema(
     opts: {
       globalDefaults?: Record<string, unknown>;
       mergeIntoBodyAndMetadata?: boolean;
       retainDeprecatedProperties?: boolean;
+      transformer?: (schema: RMOAS.SchemaObject) => RMOAS.SchemaObject;
     } = {}
   ) {
-    return getParametersAsJsonSchema(this, this.api, opts);
+    if (!opts.transformer) {
+      opts.transformer = (s: RMOAS.SchemaObject) => s;
+    }
+
+    return getParametersAsJSONSchema(this, this.api, opts);
   }
 
   /**
    * Get a single response for this status code, formatted as JSON schema.
    *
    * @param statusCode Status code to pull a JSON Schema response for.
+   * @param opts Options
+   * @param opts.transformer With a transformer you can transform any data within a given schema,
+   *    like say if you want to rewrite a potentially unsafe `title` that might be eventually used
+   *    as a JS variable name, just make sure to return your transformed schema.
    */
-  getResponseAsJsonSchema(statusCode: string | number) {
-    return getResponseAsJsonSchema(this, this.api, statusCode);
+  getResponseAsJSONSchema(
+    statusCode: string | number,
+    opts: {
+      transformer?: (schema: RMOAS.SchemaObject) => RMOAS.SchemaObject;
+    } = {
+      transformer: (s: RMOAS.SchemaObject) => s,
+    }
+  ) {
+    return getResponseAsJSONSchema(this, this.api, statusCode, opts);
   }
 
   /**
@@ -538,7 +557,7 @@ export default class Operation {
     // final point where we don't have a required request body, but the underlying Media Type Object
     // schema says that it has required properties then we should ultimately recognize that this
     // request body is required -- even as the request body description says otherwise.
-    return !!this.getParametersAsJsonSchema()
+    return !!this.getParametersAsJSONSchema()
       .filter(js => ['body', 'formData'].includes(js.type))
       .find(js => js.schema && Array.isArray(js.schema.required) && js.schema.required.length);
   }


### PR DESCRIPTION
| 🚥 Fix https://github.com/readmeio/api/issues/523 |
| :-- |

## 🧰 Changes

I've discovered [api](https://github.com/readmeio/api) that if a JSON Schema `title` starts with a number, [json-schema-to-typescript](https://npm.im/json-schema-to-typescript) will leave it in, resulting in a generated Typescript interface that's invalid -- causing `api` SDK generation to crash. Instead of adding in more bespoke logic into this library to fix this very `api`-specific issue I've decided instead to add a new `transform` option to `operation.getParametersAsJsonSchema()` and `operation.getResponseAsJsonSchema()` so I can fix it in `api`.

This new `transform` option takes a single `SchemaObject` object and expects you to return the same. With this I'll be able to do something in `api` to make these problematic schema interfaces compile without issues. Maybe by adding an underscore or a `$` to the top of them if they start with a number? I'm not sure yet.

Beyond this I've also fixed a few other things:

* [x] Renamed `getParametersAsJsonSchema` and `getResponseAsJsonSchema` to `getParametersAsJSONSchema` and `getResponseAsJSONSchema` as not capitalizing the JSON in JSON Schema has always bothered me and I'm not sure why I wrote it like that to begin with.
  * ⚠️ This is a breaking change so I'll publish these changes as a v19.
* [x] I've also fixed a bug in our `Operation.getOperationId` method where the `camelCase` option is present where if an `operationId` ended in a non-alphanumeric character, like `get (deprecated)`, we'd retain that last character in the created operation ID: `getDeprecated)`. This would bubble up into `api` and cause some further crashes as we use these operation IDs as method names and `getDeprecated)` isn't valid in this case.

## 🧬 QA & Testing

Most of this PR is the `*JsonSchema` → `*JSONSchema` rename, but check out the handful of new tests I added.