### PR TITLE
feat: supporting transforming a schema object to a primitive

### DIFF
--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -900,5 +900,27 @@ describe('options', () => {
         },
       ]);
     });
+
+    it('should be able to transform a schema into a non-object', () => {
+      const operation = petstore.operation('/pet', 'post');
+
+      const jsonSchema = operation.getParametersAsJSONSchema({
+        transformer: schema => {
+          if ('x-readme-ref-name' in schema) {
+            return schema['x-readme-ref-name'] as SchemaObject;
+          }
+
+          return schema;
+        },
+      });
+
+      expect(jsonSchema).toStrictEqual([
+        {
+          label: 'Body Params',
+          schema: 'Pet',
+          type: 'body',
+        },
+      ]);
+    });
   });
 });

--- a/__tests__/operation/get-response-as-json-schema.test.ts
+++ b/__tests__/operation/get-response-as-json-schema.test.ts
@@ -352,5 +352,28 @@ describe('options', () => {
         },
       ]);
     });
+
+    it('should be able to transform a schema into a non-object', () => {
+      const operation = petstore.operation('/pet/{petId}/uploadImage', 'post');
+
+      const jsonSchema = operation.getResponseAsJSONSchema('200', {
+        transformer: schema => {
+          if ('x-readme-ref-name' in schema) {
+            return schema['x-readme-ref-name'] as SchemaObject;
+          }
+
+          return schema;
+        },
+      });
+
+      expect(jsonSchema).toStrictEqual([
+        {
+          description: 'successful operation',
+          label: 'Response body',
+          schema: 'ApiResponse',
+          type: 'string',
+        },
+      ]);
+    });
   });
 });

--- a/src/operation/get-response-as-json-schema.ts
+++ b/src/operation/get-response-as-json-schema.ts
@@ -10,7 +10,7 @@ import type {
 
 import cloneObject from '../lib/clone-object';
 import matches from '../lib/matches-mimetype';
-import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
+import toJSONSchema, { isPrimitive, getSchemaVersionString } from '../lib/openapi-to-json-schema';
 
 const isJSON = matches.json;
 
@@ -160,10 +160,12 @@ export default function getResponseAsJSONSchema(
       // able to render so instead of generating a JSON Schema with an `undefined` type we should
       // default to `string` so there's at least *something* the end-user can interact with.
       type: foundSchema.type || 'string',
-      schema: {
-        ...schema,
-        $schema: getSchemaVersionString(schema, api),
-      },
+      schema: isPrimitive(schema)
+        ? schema
+        : {
+            ...schema,
+            $schema: getSchemaVersionString(schema, api),
+          },
       label: 'Response body',
     };
 


### PR DESCRIPTION
## 🧰 Changes

This extends the `transformer` option I introduced in #695 to allow the ability to transform a schema object into a pure primitive.

I'm using this over in [api](https://npm.im/api) for transforming schemas that contain a `x-readme-ref-name` property into being the value of that ref.