### PR TITLE
fix: quirks with discriminators and the `transformer` JSON Schema option

### DIFF
--- a/__tests__/__datasets__/ably.json
+++ b/__tests__/__datasets__/ably.json
@@ -1,0 +1,5970 @@
+{
+  "openapi": "3.0.1",
+  "servers": [
+    {
+      "url": "https://control.ably.net/v1"
+    }
+  ],
+  "info": {
+    "contact": {
+      "x-twitter": "ablyrealtime"
+    },
+    "description": "Use the Control API to manage your applications, namespaces, keys, queues, rules, and more.\n\nDetailed information on using this API can be found in the Ably <a href=\"https://ably.com/documentation/control-api\">developer documentation</a>.\n\nControl API is currently in Beta.\n",
+    "title": "Control API v1",
+    "version": "1.0.14",
+    "x-apisguru-categories": [
+      "cloud"
+    ],
+    "x-logo": {
+      "url": "https://api.apis.guru/v2/cache/logo/https_twitter.com_ablyrealtime_profile_image"
+    },
+    "x-origin": [
+      {
+        "format": "openapi",
+        "url": "https://raw.githubusercontent.com/ably/open-specs/main/definitions/control-v1.yaml",
+        "version": "3.0"
+      }
+    ],
+    "x-providerName": "ably.net",
+    "x-serviceName": "control"
+  },
+  "paths": {
+    "/accounts/{account_id}/apps": {
+      "get": {
+        "description": "List all applications for the specified account ID.",
+        "parameters": [
+          {
+            "description": "The account ID for which to retrieve the associated applications.",
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/app_response"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "List of apps for the specified account are returned"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Account not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Lists apps",
+        "tags": [
+          "apps"
+        ]
+      },
+      "post": {
+        "description": "Creates an application with the specified properties.",
+        "parameters": [
+          {
+            "description": "The account ID of the account in which to create the application.",
+            "in": "path",
+            "name": "account_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/app_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app_response"
+                }
+              }
+            },
+            "description": "App created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Account not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Creates an app",
+        "tags": [
+          "apps"
+        ]
+      }
+    },
+    "/apps/{app_id}/keys": {
+      "get": {
+        "description": "Lists the API keys associated with the application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/key_response"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Key list"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Lists app keys",
+        "tags": [
+          "keys"
+        ]
+      },
+      "post": {
+        "description": "Creates an API key for the application specified.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/key_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/key_response"
+                }
+              }
+            },
+            "description": "Key created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Creates a key",
+        "tags": [
+          "keys"
+        ]
+      }
+    },
+    "/apps/{app_id}/keys/{key_id}": {
+      "patch": {
+        "description": "Update the API key with the specified key ID, for the application with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The API key ID.",
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/key_patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/key_response"
+                }
+              }
+            },
+            "description": "Key updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Updates a key",
+        "tags": [
+          "keys"
+        ]
+      }
+    },
+    "/apps/{app_id}/keys/{key_id}/revoke": {
+      "post": {
+        "description": "Revokes the API key with the specified ID, with the Application ID. This deletes the key.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The key ID.",
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "Key revoked"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Revokes a key",
+        "tags": [
+          "keys"
+        ]
+      }
+    },
+    "/apps/{app_id}/namespaces": {
+      "get": {
+        "description": "List the namespaces for the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/namespace_response"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Namespace list"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Lists namespaces",
+        "tags": [
+          "namespaces"
+        ]
+      },
+      "post": {
+        "description": "Creates a namespace for the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/namespace_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/namespace_response"
+                }
+              }
+            },
+            "description": "Namespace created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Creates a namespace",
+        "tags": [
+          "namespaces"
+        ]
+      }
+    },
+    "/apps/{app_id}/namespaces/{namespace_id}": {
+      "delete": {
+        "description": "Deletes the namespace with the specified ID, for the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The namespace ID.",
+            "in": "path",
+            "name": "namespace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {},
+            "description": "Namespace deleted"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Deletes a namespace",
+        "tags": [
+          "namespaces"
+        ]
+      },
+      "patch": {
+        "description": "Updates the namespace with the specified ID, for the application with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The namespace ID.",
+            "in": "path",
+            "name": "namespace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/namespace_patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/namespace_response"
+                }
+              }
+            },
+            "description": "Namespace updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Updates a namespace",
+        "tags": [
+          "namespaces"
+        ]
+      }
+    },
+    "/apps/{app_id}/queues": {
+      "get": {
+        "description": "Lists the queues associated with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/queue_response"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Queue list"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "503 Service unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Lists queues",
+        "tags": [
+          "queues"
+        ]
+      },
+      "post": {
+        "description": "Creates a queue for the application specified by application ID. The properties for the queue to be created are specified in the request body.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/queue"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/queue_response"
+                }
+              }
+            },
+            "description": "Queue created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Creates a queue",
+        "tags": [
+          "queues"
+        ]
+      }
+    },
+    "/apps/{app_id}/queues/{queue_id}": {
+      "delete": {
+        "description": "Delete the queue with the specified queue name, from the application with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The queue ID.",
+            "in": "path",
+            "name": "queue_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {},
+            "description": "Queue deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "503 Service unavailable"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Deletes a queue",
+        "tags": [
+          "queues"
+        ]
+      }
+    },
+    "/apps/{app_id}/rules": {
+      "get": {
+        "description": "Lists the rules for the application specified by the application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/rule_response"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Reactor rule list"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Lists Reactor rules",
+        "tags": [
+          "rules"
+        ]
+      },
+      "post": {
+        "description": "Creates a rule for the application with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/rule_post"
+              }
+            }
+          },
+          "description": "The rule properties."
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rule_response"
+                }
+              }
+            },
+            "description": "Reactor rule created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Creates a Reactor rule",
+        "tags": [
+          "rules"
+        ]
+      }
+    },
+    "/apps/{app_id}/rules/{rule_id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The rule ID.",
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {},
+            "description": "Reactor rule deleted"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Deletes a Reactor rule",
+        "tags": [
+          "rules"
+        ]
+      },
+      "get": {
+        "description": "Returns the rule specified by the rule ID, for the application specified by application ID.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The rule ID.",
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rule_response"
+                }
+              }
+            },
+            "description": "Reactor rule"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Gets a reactor rule by rule ID",
+        "tags": [
+          "rules"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "app_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The rule ID.",
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/rule_patch"
+              }
+            }
+          },
+          "description": "Properties for the rule."
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rule_response"
+                }
+              }
+            },
+            "description": "Reactor rule updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Gateway timeout"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Updates a Reactor rule",
+        "tags": [
+          "rules"
+        ]
+      }
+    },
+    "/apps/{id}": {
+      "delete": {
+        "description": "Deletes the application with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The ID of the application to be deleted.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {},
+            "description": "App deleted"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Deletes an app",
+        "tags": [
+          "apps"
+        ]
+      },
+      "patch": {
+        "description": "Updates the application with the specified application ID.",
+        "parameters": [
+          {
+            "description": "The ID of application to be updated.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/app_patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app_response"
+                }
+              }
+            },
+            "description": "App updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Updates an app",
+        "tags": [
+          "apps"
+        ]
+      }
+    },
+    "/apps/{id}/pkcs12": {
+      "post": {
+        "description": "Updates the application's Apple Push Notification service (APNs) information.",
+        "parameters": [
+          {
+            "description": "The application ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/app_pkcs12"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app_response"
+                }
+              }
+            },
+            "description": "App updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "App not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Updates app's APNs info from a `.p12` file",
+        "tags": [
+          "apps"
+        ]
+      }
+    },
+    "/me": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/me"
+                }
+              }
+            },
+            "description": "Token details"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "summary": "Get token details",
+        "tags": [
+          "tokens"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "amqp_external_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AMQP external (using Firehose). See the <a href=\"https://ably.com/documentation/general/firehose\">Ably documentation</a> for further information.",
+            "enum": [
+              "amqp/external"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "mandatoryRoute": {
+                "description": "Reject delivery of the message if the route does not exist, otherwise fail silently.",
+                "type": "boolean"
+              },
+              "messageTtl": {
+                "description": "You can optionally override the default TTL on a queue and specify a TTL in minutes for messages to be persisted. It is unusual to change the default TTL, so if this field is left empty, the default TTL for the queue will be used.",
+                "type": "integer"
+              },
+              "persistentMessages": {
+                "description": "Marks the message as persistent, instructing the broker to write it to disk if it is in a durable queue.",
+                "type": "boolean"
+              },
+              "routingKey": {
+                "description": "The AMQP routing key. See this <a href=\"https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule\">Ably knowledge base article</a> for details.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "amqp_external_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AMQP external (using Firehose). See the <a href=\"https://ably.com/documentation/general/firehose\">documentation</a> for further information.",
+            "enum": [
+              "amqp/external"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "mandatoryRoute": {
+                "description": "Reject delivery of the message if the route does not exist, otherwise fail silently.",
+                "type": "boolean"
+              },
+              "messageTtl": {
+                "description": "You can optionally override the default TTL on a queue and specify a TTL in minutes for messages to be persisted. It is unusual to change the default TTL, so if this field is left empty, the default TTL for the queue will be used.",
+                "type": "integer"
+              },
+              "persistentMessages": {
+                "description": "Marks the message as persistent, instructing the broker to write it to disk if it is in a durable queue.",
+                "type": "boolean"
+              },
+              "routingKey": {
+                "description": "The AMQP routing key. See this <a href=\"https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule\">Ably knowledge base article</a> for details.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url",
+              "routingKey",
+              "mandatoryRoute",
+              "persistentMessages"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "amqp_external_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AMQP external (using Firehose). See the <a href=\"https://ably.com/documentation/general/firehose\">Ably documentation</a> for further information.",
+            "enum": [
+              "amqp/external"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "mandatoryRoute": {
+                "description": "Reject delivery of the message if the route does not exist, otherwise fail silently.",
+                "type": "boolean"
+              },
+              "messageTtl": {
+                "description": "You can optionally override the default TTL on a queue and specify a TTL in minutes for messages to be persisted. It is unusual to change the default TTL, so if this field is left empty, the default TTL for the queue will be used.",
+                "type": "integer"
+              },
+              "persistentMessages": {
+                "description": "Marks the message as persistent, instructing the broker to write it to disk if it is in a durable queue.",
+                "type": "boolean"
+              },
+              "routingKey": {
+                "description": "The AMQP routing key. See this <a href=\"https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule\">Ably knowledge base article</a> for details.",
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url",
+              "routingKey",
+              "mandatoryRoute",
+              "persistentMessages"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "amqp_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AMQP. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "amqp"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "queueId": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "amqp_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AMQP. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "amqp"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "queueId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "queueId"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "amqp_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AMQP. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "amqp"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "queueId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "queueId"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "app_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "apnsCertificate": {
+            "description": "The Apple Push Notification service certificate.",
+            "nullable": true,
+            "type": "string"
+          },
+          "apnsPrivateKey": {
+            "description": "The Apple Push Notification service private key.",
+            "nullable": true,
+            "type": "string"
+          },
+          "apnsUseSandboxEndpoint": {
+            "description": "The Apple Push Notification service sandbox endpoint.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "fcmKey": {
+            "description": "The Firebase Cloud Messaging key.",
+            "example": false,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the application for your reference only.",
+            "example": "My App",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the application. Can be `enabled` or `disabled`. Enabled means available to accept inbound connections and all services are available.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "tlsOnly": {
+            "description": "Enforce TLS for all connections.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "app_pkcs12": {
+        "additionalProperties": false,
+        "properties": {
+          "p12File": {
+            "description": "The `.p12` file containing the app's APNs information.",
+            "format": "binary",
+            "type": "string"
+          },
+          "p12Pass": {
+            "description": "The password for the corresponding `.p12` file.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "p12File",
+          "p12Pass"
+        ],
+        "type": "object"
+      },
+      "app_post": {
+        "additionalProperties": false,
+        "properties": {
+          "apnsCertificate": {
+            "description": "The Apple Push Notification service certificate.",
+            "nullable": true,
+            "type": "string"
+          },
+          "apnsPrivateKey": {
+            "description": "The Apple Push Notification service private key.",
+            "nullable": true,
+            "type": "string"
+          },
+          "apnsUseSandboxEndpoint": {
+            "description": "The Apple Push Notification service sandbox endpoint.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "fcmKey": {
+            "description": "The Firebase Cloud Messaging key.",
+            "example": false,
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the application for your reference only.",
+            "example": "My App",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the application. Can be `enabled` or `disabled`. Enabled means available to accept inbound connections and all services are available.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "tlsOnly": {
+            "description": "Enforce TLS for all connections.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "app_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "description": "A link self-referencing the app that has been created.",
+            "nullable": true,
+            "type": "object"
+          },
+          "accountId": {
+            "description": "The ID of your Ably account.",
+            "example": "WgRpOB",
+            "type": "string"
+          },
+          "apnsUseSandboxEndpoint": {
+            "description": "Apple Push Notification service endpoint.",
+            "example": false,
+            "nullable": true,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The application ID.",
+            "example": "28AB6x",
+            "type": "string"
+          },
+          "name": {
+            "description": "The application name.",
+            "example": "Default",
+            "type": "string"
+          },
+          "status": {
+            "description": "The application status. Disabled applications will not accept new connections and will return an error to all clients.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "tlsOnly": {
+            "description": "Enforce TLS for all connections. This setting overrides any channel setting.",
+            "example": true,
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "aws_access_keys": {
+        "additionalProperties": false,
+        "properties": {
+          "accessKeyId": {
+            "description": "The AWS key ID for the AWS IAM user. See this <a href=\"https://knowledge.ably.com/authentication-for-reactor-rules-for-aws-reactor-events-for-lambda-functions-reactor-firehose-for-aws-sqs-and-kinesis\">Ably knowledge base article</a> for details.",
+            "type": "string"
+          },
+          "authenticationMode": {
+            "description": "Authentication method is using AWS credentials (AWS key ID and secret key).",
+            "enum": [
+              "credentials"
+            ],
+            "type": "string"
+          },
+          "secretAccessKey": {
+            "description": "The AWS secret key for the AWS IAM user. See this <a href=\"https://knowledge.ably.com/authentication-for-reactor-rules-for-aws-reactor-events-for-lambda-functions-reactor-firehose-for-aws-sqs-and-kinesis\">Ably knowledge base article</a> for details.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "accessKeyId",
+          "secretAccessKey"
+        ],
+        "type": "object"
+      },
+      "aws_access_keys_response": {
+        "additionalProperties": false,
+        "properties": {
+          "accessKeyId": {
+            "description": "The AWS key ID for the AWS IAM user. See this <a href=\"https://knowledge.ably.com/authentication-for-reactor-rules-for-aws-reactor-events-for-lambda-functions-reactor-firehose-for-aws-sqs-and-kinesis\">Ably knowledge base article</a> for details.",
+            "type": "string"
+          },
+          "authenticationMode": {
+            "description": "Authentication method is using AWS credentials (AWS key ID and secret key).",
+            "enum": [
+              "credentials"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "aws_assume_role": {
+        "additionalProperties": false,
+        "properties": {
+          "assumeRoleArn": {
+            "description": "If you are using the \"ARN of an assumable role\" authentication method, this is your Assume Role ARN. See this <a href=\"https://knowledge.ably.com/authentication-for-reactor-rules-for-aws-reactor-events-for-lambda-functions-reactor-firehose-for-aws-sqs-and-kinesis\">Ably knowledge base article</a> for details.",
+            "type": "string"
+          },
+          "authenticationMode": {
+            "description": "Authentication method is using the ARN of an assumable role. See this <a href=\"https://knowledge.ably.com/authentication-for-reactor-rules-for-aws-reactor-events-for-lambda-functions-reactor-firehose-for-aws-sqs-and-kinesis\">Ably knowledge base article</a> for details.",
+            "enum": [
+              "assumeRole"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "assumeRoleArn"
+        ],
+        "type": "object"
+      },
+      "aws_kinesis_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS Kinesis. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/kinesis"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "partitionKey": {
+                "description": "The AWS Kinesis partition key. See this <a href=\"https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule\">Ably knowledge base article</a> for details.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which AWS Kinesis is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              },
+              "streamName": {
+                "description": "The name of your AWS Kinesis Stream.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "aws_kinesis_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS Kinesis. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/kinesis"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "partitionKey": {
+                "description": "The AWS Kinesis partition key. See this <a href=\"https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule\">Ably knowledge base article</a> for details.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which AWS Kinesis is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              },
+              "streamName": {
+                "description": "The name of your AWS Kinesis Stream.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "streamName",
+              "partitionKey",
+              "authentication",
+              "format"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "aws_kinesis_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS Kinesis. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/kinesis"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys_response"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys_response"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "partitionKey": {
+                "description": "The AWS Kinesis partition key. See this <a href=\"https://knowledge.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule\">Ably knowledge base article</a> for details.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which AWS Kinesis is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              },
+              "streamName": {
+                "description": "The name of your AWS Kinesis Stream.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "streamName",
+              "partitionKey",
+              "authentication",
+              "format"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "aws_lambda_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS Lambda. See the <a href=\"https://ably.com/integrations\">Ably documentation</a> for further information.",
+            "enum": [
+              "aws/lambda"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "functionName": {
+                "description": "The name of your AWS Lambda Function.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which your AWS Lambda Function is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "functionName",
+              "authentication"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "aws_lambda_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS Lambda. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/lambda"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "functionName": {
+                "description": "The name of your AWS Lambda Function.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which your AWS Lambda Function is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "functionName",
+              "authentication"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "aws_lambda_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS Lambda. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/lambda"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys_response"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys_response"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "functionName": {
+                "description": "The name of your AWS Lambda Function.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which your AWS Lambda Function is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "functionName",
+              "authentication"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "aws_sqs_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS SQS. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/sqs"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "awsAccountId": {
+                "description": "Your AWS account ID.",
+                "type": "string"
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "queueName": {
+                "description": "The AWS SQS queue name.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which AWS SQS is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "aws_sqs_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS SQS. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/sqs"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "awsAccountId": {
+                "description": "Your AWS account ID.",
+                "type": "string"
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "queueName": {
+                "description": "The AWS SQS queue name.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which AWS SQS is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "awsAccountId",
+              "queueName",
+              "authentication"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "aws_sqs_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case AWS SQS. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "aws/sqs"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "authentication": {
+                "discriminator": {
+                  "mapping": {
+                    "assumeRole": "#/components/schemas/aws_assume_role",
+                    "credentials": "#/components/schemas/aws_access_keys_response"
+                  },
+                  "propertyName": "authenticationMode"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/aws_access_keys_response"
+                  },
+                  {
+                    "$ref": "#/components/schemas/aws_assume_role"
+                  }
+                ]
+              },
+              "awsAccountId": {
+                "description": "Your AWS account ID.",
+                "type": "string"
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "type": "string"
+              },
+              "queueName": {
+                "description": "The AWS SQS queue name.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region is which AWS SQS is hosted. See the <a href=\"https://docs.aws.amazon.com/general/latest/gr/rande.html#lambda_region\">AWS documentation</a> for more detail.",
+                "example": "us-west-1",
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "awsAccountId",
+              "queueName",
+              "authentication"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "azure_function_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Microsoft Azure Function. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/azure-function"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "azureAppId": {
+                "description": "The Microsoft Azure Application ID. You can find your Microsoft Azure Application ID as shown in this <a href=\"https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID\">article</a>.",
+                "example": "d1e9f419-c438-6032b32df979",
+                "type": "string"
+              },
+              "azureFunctionName": {
+                "description": "The name of your Microsoft Azure Function.",
+                "type": "string"
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "azure_function_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Microsoft Azure Function. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/azure-function"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "azureAppId": {
+                "description": "The Microsoft Azure Application ID. You can find your Microsoft Azure Application ID as shown in this <a href=\"https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID\">article</a>.",
+                "example": "d1e9f419-c438-6032b32df979",
+                "type": "string"
+              },
+              "azureFunctionName": {
+                "description": "The name of your Microsoft Azure Function.",
+                "type": "string"
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "azureAppId",
+              "azureFunctionName"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "azure_function_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Microsoft Azure Function. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/azure-function"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "azureAppId": {
+                "description": "The Microsoft Azure Application ID. You can find your Microsoft Azure Application ID as shown in this <a href=\"https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID\">article</a>.",
+                "example": "d1e9f419-c438-6032b32df979",
+                "type": "string"
+              },
+              "azureFunctionName": {
+                "description": "The name of your Microsoft Azure Function.",
+                "type": "string"
+              },
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "azureAppId",
+              "azureFunctionName"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "cloudflare_worker_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Cloudflare Worker. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/cloudflare-worker"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "cloudflare_worker_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Cloudflare Worker. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/cloudflare-worker"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "cloudflare_worker_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Cloudflare Worker. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/cloudflare-worker"
+            ],
+            "example": "http/cloudflare-worker",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "error": {
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "description": "The HTTP status code returned.",
+            "type": "integer"
+          },
+          "details": {
+            "description": "Any additional details about the error message.",
+            "nullable": true,
+            "type": "object"
+          },
+          "href": {
+            "description": "The URL to documentation about the error code.",
+            "type": "string"
+          },
+          "message": {
+            "description": "The error message.",
+            "type": "string"
+          },
+          "statusCode": {
+            "description": "The Ably error code.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "message",
+          "code",
+          "statusCode",
+          "href"
+        ],
+        "type": "object"
+      },
+      "google_cloud_function_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Google Cloud Function. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/google-cloud-function"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "functionName": {
+                "description": "The name of your Google Cloud Function.",
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "projectId": {
+                "description": "The project ID for your Google Cloud Project that was generated when you created your project.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region in which your Google Cloud Function is hosted. See the <a href=\"https://cloud.google.com/compute/docs/regions-zones/\">Google documentation</a> for more details.",
+                "example": "us-west1",
+                "type": "string"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "google_cloud_function_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Google Cloud Function. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/google-cloud-function"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "functionName": {
+                "description": "The name of your Google Cloud Function.",
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "projectId": {
+                "description": "The project ID for your Google Cloud Project that was generated when you created your project.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region in which your Google Cloud Function is hosted. See the <a href=\"https://cloud.google.com/compute/docs/regions-zones/\">Google documentation</a> for more details.",
+                "example": "us-west1",
+                "type": "string"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "projectId",
+              "functionName"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "google_cloud_function_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Google Cloud Function. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/google-cloud-function"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a text-based encoding.",
+                "enum": [
+                  "json"
+                ],
+                "type": "string"
+              },
+              "functionName": {
+                "description": "The name of your Google Cloud Function.",
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "projectId": {
+                "description": "The project ID for your Google Cloud Project that was generated when you created your project.",
+                "type": "string"
+              },
+              "region": {
+                "description": "The region in which your Google Cloud Function is hosted. See the <a href=\"https://cloud.google.com/compute/docs/regions-zones/\">Google documentation</a> for more details.",
+                "example": "us-west1",
+                "type": "string"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "region",
+              "projectId",
+              "functionName"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "http_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a simpler text-based encoding, whereas MsgPack provides a more efficient binary encoding.",
+                "enum": [
+                  "json",
+                  "msgpack"
+                ],
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "http_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a simpler text-based encoding, whereas MsgPack provides a more efficient binary encoding.",
+                "enum": [
+                  "json",
+                  "msgpack"
+                ],
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "description": "The URL of the endpoint that is invoked when events occur on Ably.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url",
+              "format"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "http_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "enveloped": {
+                "description": "Messages delivered through Reactor are wrapped in an Ably envelope by default that contains metadata about the message and its payload. The form of the envelope depends on whether it is part of a Webhook/Function or a Queue/Firehose rule. For everything besides Webhooks, you can ensure you only get the raw payload by unchecking \"Enveloped\" when setting up the rule.",
+                "nullable": true,
+                "type": "boolean"
+              },
+              "format": {
+                "description": "JSON provides a simpler text-based encoding, whereas MsgPack provides a more efficient binary encoding.",
+                "enum": [
+                  "json",
+                  "msgpack"
+                ],
+                "type": "string"
+              },
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url",
+              "format"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "ifttt_rule_patch": {
+        "x-requestMode": {
+          "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+          "enum": [
+            "single"
+          ],
+          "example": "single",
+          "type": "string"
+        },
+        "x-ruleType": {
+          "description": "The type of rule. In this case IFTTT. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+          "enum": [
+            "http/ifttt"
+          ],
+          "type": "string"
+        },
+        "x-source": {
+          "$ref": "#/components/schemas/rule_source"
+        },
+        "x-target": {
+          "additionalProperties": false,
+          "properties": {
+            "eventName": {
+              "type": "string"
+            },
+            "webhookKey": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "ifttt_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case IFTTT. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/ifttt"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "type": "string"
+              },
+              "webhookKey": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "webhookKey",
+              "eventName"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "ifttt_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "Single request mode sends each event separately to the endpoint specified by the rule. You can read more about single request mode events in the <a href=\"https://ably.com/documentation/general/events#batching\">Ably documentation</a>.",
+            "enum": [
+              "single"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case IFTTT. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/ifttt"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "eventName": {
+                "type": "string"
+              },
+              "webhookKey": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "webhookKey",
+              "eventName"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "key_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "capabilities": {
+            "description": "The capabilities that this key has. More information on capabilities can be found in the <a href=\"https://ably.com/documentation/core-features/authentication#capabilities-explained\">Ably documentation</a>.",
+            "items": {
+              "enum": [
+                "publish",
+                "subscribe",
+                "history",
+                "presence",
+                "channel-metadata",
+                "push-admin",
+                "push-subscribe",
+                "statistics"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "channels": {
+            "description": "Specify the channels and queues that this key can be used with.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name for your API key. This is a friendly name for your reference.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "key_post": {
+        "additionalProperties": false,
+        "properties": {
+          "capabilities": {
+            "description": "The capabilities that this key has. More information on capabilities can be found in the <a href=\"https://ably.com/documentation/core-features/authentication#capabilities-explained\">Ably documentation</a>.",
+            "items": {
+              "enum": [
+                "publish",
+                "subscribe",
+                "history",
+                "presence",
+                "channel-metadata",
+                "push-admin",
+                "push-subscribe",
+                "statistics"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "channels": {
+            "description": "Specify the channels and queues that this key can be used with.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name for your API key. This is a friendly name for your reference.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "channels",
+          "capabilities"
+        ],
+        "type": "object"
+      },
+      "key_response": {
+        "additionalProperties": false,
+        "properties": {
+          "appId": {
+            "description": "The Ably application ID which this key is associated with.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "capability": {
+            "additionalProperties": {
+              "items": {
+                "enum": [
+                  "publish",
+                  "subscribe",
+                  "history",
+                  "presence",
+                  "channel-metadata",
+                  "push-admin",
+                  "push-subscribe",
+                  "statistics"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": "The capabilities that this key has. More information on capabilities can be found in the <a href=\"https://ably.com/documentation/core-features/authentication#capabilities-explained\">Ably documentation</a>.",
+            "type": "object"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the key.",
+            "example": 1602844091815,
+            "type": "integer"
+          },
+          "id": {
+            "description": "The key ID.",
+            "type": "string"
+          },
+          "key": {
+            "description": "The complete API key including API secret.",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of the last modification of the key.",
+            "example": 1614679682091,
+            "type": "integer"
+          },
+          "name": {
+            "description": "The name of the application this key is associated with.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "me": {
+        "additionalProperties": false,
+        "properties": {
+          "account": {
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "description": "The account ID.",
+                "example": "VpWaOA",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the account.",
+                "example": "Free account",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "type": "object"
+          },
+          "token": {
+            "additionalProperties": false,
+            "properties": {
+              "capabilities": {
+                "description": "An array containing the access capabilities associated with the access token.",
+                "example": [
+                  "write:namespace",
+                  "read:namespace",
+                  "write:queue",
+                  "read:queue",
+                  "write:rule",
+                  "read:rule",
+                  "write:key",
+                  "read:key",
+                  "write:app",
+                  "read:app"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "The token ID. This is a UUID.",
+                "example": "C95837C9-184B-4CC2-8779-B769F960FADB",
+                "type": "integer"
+              },
+              "name": {
+                "description": "The friendly name for the token.",
+                "example": "My Token",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "capabilities"
+            ],
+            "type": "object"
+          },
+          "user": {
+            "additionalProperties": false,
+            "properties": {
+              "email": {
+                "description": "Email address of the user associated with the account.",
+                "type": "string"
+              },
+              "id": {
+                "description": "The user ID associated with the account. This is a UUID.",
+                "example": "C95837C9-184B-4CC2-8779-B769F960FADB",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "id",
+              "email"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "namespace_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "authenticated": {
+            "default": false,
+            "description": "If `true`, clients will not be permitted to use (including to attach, publish, or subscribe) any channels within this namespace unless they are identified, that is, authenticated using a client ID. See the <a href=\"https://knowledge.ably.com/authenticated-and-identified-clients\">Ably knowledge base/a> for more details.",
+            "example": false,
+            "type": "boolean"
+          },
+          "persistLast": {
+            "default": false,
+            "description": "If `true`, the last message published on a channel will be stored for 365 days. You can access the stored message only by using the channel rewind mechanism and attaching with rewind=1. Please note that for each message stored, an additional message is deducted from your monthly allocation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "persisted": {
+            "default": false,
+            "description": "If `true`, all messages on a channel will be stored for 24 hours. You can access stored messages via the History API. Please note that for each message stored, an additional message is deducted from your monthly allocation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "pushEnabled": {
+            "default": false,
+            "description": "If `true`, publishing messages with a push payload in the extras field is permitted and can trigger the delivery of a native push notification to registered devices for the channel.",
+            "example": false,
+            "type": "boolean"
+          },
+          "tlsOnly": {
+            "default": false,
+            "description": "If `true`, only clients that are connected using TLS will be permitted to subscribe to any channels within this namespace.",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "namespace_post": {
+        "additionalProperties": false,
+        "properties": {
+          "authenticated": {
+            "default": false,
+            "description": "If `true`, clients will not be permitted to use (including to attach, publish, or subscribe) any channels within this namespace unless they are identified, that is, authenticated using a client ID. See the <a href=\"https://knowledge.ably.com/authenticated-and-identified-clients\">Ably Knowledge base</a> for more details.",
+            "example": false,
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The namespace or channel name that the channel rule will apply to. For example, if you specify `namespace` the namespace will be set to `namespace` and will match with channels `namespace:*` and `namespace`.",
+            "example": "namespace",
+            "type": "string"
+          },
+          "persistLast": {
+            "default": false,
+            "description": "If `true`, the last message published on a channel will be stored for 365 days. You can access the stored message only by using the channel rewind mechanism and attaching with rewind=1. Please note that for each message stored, an additional message is deducted from your monthly allocation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "persisted": {
+            "default": false,
+            "description": "If `true`, all messages on a channel will be stored for 24 hours. You can access stored messages via the History API. Please note that for each message stored, an additional message is deducted from your monthly allocation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "pushEnabled": {
+            "default": false,
+            "description": "If `true`, publishing messages with a push payload in the extras field is permitted and can trigger the delivery of a native push notification to registered devices for the channel.",
+            "example": false,
+            "type": "boolean"
+          },
+          "tlsOnly": {
+            "default": false,
+            "description": "If `true`, only clients that are connected using TLS will be permitted to subscribe to any channels within this namespace.",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "namespace_response": {
+        "additionalProperties": false,
+        "properties": {
+          "authenticated": {
+            "default": false,
+            "description": "If `true`, clients will not be permitted to use (including to attach, publish, or subscribe) any channels within this namespace unless they are identified, that is, authenticated using a client ID. See the <a href=\"https://knowledge.ably.com/authenticated-and-identified-clients\">Ably knowledge base</a> for more details.",
+            "example": false,
+            "type": "boolean"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the namespace.",
+            "example": 1602844091815,
+            "type": "integer"
+          },
+          "id": {
+            "description": "The namespace or channel name that the channel rule will apply to. For example, if you specify `namespace` the namespace will be set to `namespace` and will match with channels `namespace:*` and `namespace`.",
+            "example": "namespace",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the namespace.",
+            "example": 1614679682091,
+            "type": "integer"
+          },
+          "persistLast": {
+            "default": false,
+            "description": "If `true`, the last message published on a channel will be stored for 365 days. You can access the stored message only by using the channel rewind mechanism and attaching with rewind=1. Please note that for each message stored, an additional message is deducted from your monthly allocation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "persisted": {
+            "default": false,
+            "description": "If `true`, all messages on a channel will be stored for 24 hours. You can access stored messages via the History API. Please note that for each message stored, an additional message is deducted from your monthly allocation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "pushEnabled": {
+            "default": false,
+            "description": "If `true`, publishing messages with a push payload in the extras field is permitted and can trigger the delivery of a native push notification to registered devices for the channel.",
+            "example": false,
+            "type": "boolean"
+          },
+          "tlsOnly": {
+            "default": false,
+            "description": "If `true`, only clients that are connected using TLS will be permitted to subscribe to any channels within this namespace.",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "queue": {
+        "additionalProperties": false,
+        "properties": {
+          "maxLength": {
+            "description": "Message limit in number of messages.",
+            "example": 10000,
+            "type": "integer"
+          },
+          "name": {
+            "description": "A friendly name for your queue.",
+            "example": "My queue",
+            "type": "string"
+          },
+          "region": {
+            "description": "The data center region. US East (Virginia) or EU West (Ireland). Values are `us-east-1-a` or `eu-west-1-a`.",
+            "example": "us-east-1-a",
+            "type": "string"
+          },
+          "ttl": {
+            "description": "TTL in minutes.",
+            "example": 60,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "ttl",
+          "maxLength",
+          "region"
+        ],
+        "type": "object"
+      },
+      "queue_response": {
+        "additionalProperties": false,
+        "properties": {
+          "amqp": {
+            "additionalProperties": false,
+            "properties": {
+              "queueName": {
+                "description": "Name of the Ably queue.",
+                "example": "28AB6w:My queue",
+                "type": "string"
+              },
+              "uri": {
+                "description": "URI for the AMQP queue interface.",
+                "example": "amqps://us-east-1-a-queue.ably.io:5671/shared",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28AB6w",
+            "type": "string"
+          },
+          "deadletter": {
+            "description": "A boolean that indicates whether this is a dead letter queue or not.",
+            "example": false,
+            "type": "boolean"
+          },
+          "deadletterId": {
+            "example": "28AB6w:us-east-1-a:deadletter",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the Ably queue",
+            "example": "28AB6w:us-east-1-a:My queue",
+            "type": "string"
+          },
+          "maxLength": {
+            "description": "Message limit in number of messages.",
+            "example": 10000,
+            "type": "integer"
+          },
+          "messages": {
+            "additionalProperties": false,
+            "description": "Details of messages in the queue.",
+            "properties": {
+              "ready": {
+                "description": "The number of ready messages in the queue.",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "total": {
+                "description": "The total number of messages in the queue.",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              },
+              "unacknowledged": {
+                "description": "The number of unacknowledged messages in the queue.",
+                "example": 0,
+                "nullable": true,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "name": {
+            "description": "The friendly name of the queue.",
+            "example": "My queue",
+            "type": "string"
+          },
+          "region": {
+            "description": "The data center region for the queue.",
+            "example": "eu-west-1-a",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state of the queue.",
+            "example": "Running",
+            "type": "string"
+          },
+          "stats": {
+            "additionalProperties": false,
+            "properties": {
+              "acknowledgementRate": {
+                "description": "The rate at which messages are acknowledged. Rate is messages per minute.",
+                "nullable": true,
+                "type": "number"
+              },
+              "deliveryRate": {
+                "description": "The rate at which messages are delivered from the queue. Rate is messages per minute.",
+                "nullable": true,
+                "type": "number"
+              },
+              "publishRate": {
+                "description": "The rate at which messages are published to the queue. Rate is messages per minute.",
+                "nullable": true,
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "stomp": {
+            "additionalProperties": false,
+            "properties": {
+              "destination": {
+                "description": "Destination queue.",
+                "example": "/amqp/queue/28AB6w:My queue",
+                "type": "string"
+              },
+              "host": {
+                "description": "The host type for the queue.",
+                "example": "shared",
+                "type": "string"
+              },
+              "uri": {
+                "description": "URI for the STOMP queue interface.",
+                "example": "stomp://us-east-1-a-queue.ably.io:61614",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "ttl": {
+            "description": "TTL in minutes.",
+            "example": 60,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "rule_attributes": {
+        "additionalProperties": false,
+        "properties": {
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "rule_patch": {
+        "discriminator": {
+          "mapping": {
+            "amqp": "#/components/schemas/amqp_rule_patch",
+            "amqp/external": "#/components/schemas/amqp_external_rule_patch",
+            "aws/kinesis": "#/components/schemas/aws_kinesis_rule_patch",
+            "aws/lambda": "#/components/schemas/aws_lambda_rule_patch",
+            "aws/sqs": "#/components/schemas/aws_sqs_rule_patch",
+            "http": "#/components/schemas/http_rule_patch",
+            "http/azure-function": "#/components/schemas/azure_function_rule_patch",
+            "http/cloudflare-worker": "#/components/schemas/cloudflare_worker_rule_patch",
+            "http/google-cloud-function": "#/components/schemas/google_cloud_function_rule_patch",
+            "http/ifttt": "#/components/schemas/ifttt_rule_patch",
+            "http/zapier": "#/components/schemas/zapier_rule_patch"
+          },
+          "propertyName": "ruleType"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/http_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/ifttt_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/zapier_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/cloudflare_worker_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/azure_function_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/google_cloud_function_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/aws_lambda_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/aws_kinesis_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/aws_sqs_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/amqp_rule_patch"
+          },
+          {
+            "$ref": "#/components/schemas/amqp_external_rule_patch"
+          }
+        ]
+      },
+      "rule_post": {
+        "discriminator": {
+          "mapping": {
+            "amqp": "#/components/schemas/amqp_rule_post",
+            "amqp/external": "#/components/schemas/amqp_external_rule_post",
+            "aws/kinesis": "#/components/schemas/aws_kinesis_rule_post",
+            "aws/lambda": "#/components/schemas/aws_lambda_rule_post",
+            "aws/sqs": "#/components/schemas/aws_sqs_rule_post",
+            "http": "#/components/schemas/http_rule_post",
+            "http/azure-function": "#/components/schemas/azure_function_rule_post",
+            "http/cloudflare-worker": "#/components/schemas/cloudflare_worker_rule_post",
+            "http/google-cloud-function": "#/components/schemas/google_cloud_function_rule_post",
+            "http/ifttt": "#/components/schemas/ifttt_rule_post",
+            "http/zapier": "#/components/schemas/zapier_rule_post",
+            "unsupported": "#/components/schemas/unsupported_rule_response"
+          },
+          "propertyName": "ruleType"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/http_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/ifttt_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/zapier_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/cloudflare_worker_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/azure_function_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/google_cloud_function_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/aws_lambda_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/aws_kinesis_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/aws_sqs_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/amqp_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/amqp_external_rule_post"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported_rule_response"
+          }
+        ]
+      },
+      "rule_response": {
+        "discriminator": {
+          "mapping": {
+            "amqp": "#/components/schemas/amqp_rule_response",
+            "amqp/external": "#/components/schemas/amqp_external_rule_response",
+            "aws/kinesis": "#/components/schemas/aws_kinesis_rule_response",
+            "aws/lambda": "#/components/schemas/aws_lambda_rule_response",
+            "aws/sqs": "#/components/schemas/aws_sqs_rule_response",
+            "http": "#/components/schemas/http_rule_response",
+            "http/azure-function": "#/components/schemas/azure_function_rule_response",
+            "http/cloudflare-worker": "#/components/schemas/cloudflare_worker_rule_response",
+            "http/google-cloud-function": "#/components/schemas/google_cloud_function_rule_response",
+            "http/ifttt": "#/components/schemas/ifttt_rule_response",
+            "http/zapier": "#/components/schemas/zapier_rule_response"
+          },
+          "propertyName": "ruleType"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/http_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/ifttt_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/zapier_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/cloudflare_worker_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/azure_function_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/google_cloud_function_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/aws_lambda_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/aws_kinesis_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/aws_sqs_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/amqp_rule_response"
+          },
+          {
+            "$ref": "#/components/schemas/amqp_external_rule_response"
+          }
+        ]
+      },
+      "rule_source": {
+        "additionalProperties": false,
+        "properties": {
+          "channelFilter": {
+            "description": "This field allows you to filter your rule based on a regular expression that is matched against the complete channel name. Leave this empty if you want the rule to apply to all channels.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type `channel.message` delivers all messages published on a channel. The type `channel.presence` delivers all enter, update and leave events for members present on a channel. The type `channel.lifecycle` events for this rule type are currently not supported. Get in touch (https://ably.com/contact) if you need this feature. The type `channel.occupancy` delivers all occupancy events for the channel.",
+            "enum": [
+              "channel.message",
+              "channel.presence",
+              "channel.lifecycle",
+              "channel.occupancy"
+            ],
+            "example": "channel.message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channelFilter",
+          "type"
+        ],
+        "type": "object"
+      },
+      "rule_source_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "channelFilter": {
+            "description": "This field allows you to filter your rule based on a regular expression that is matched against the complete channel name. Leave this empty if you want the rule to apply to all channels.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type `channel.message` delivers all messages published on a channel. The type `channel.presence` delivers all enter, update and leave events for members present on a channel. The type `channel.lifecycle` events for this rule type are currently not supported. Get in touch (https://ably.com/contact) if you need this feature. The type `channel.occupancy` delivers all occupancy events for the channel.",
+            "enum": [
+              "channel.message",
+              "channel.presence",
+              "channel.lifecycle",
+              "channel.occupancy"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "unsupported_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "This rule type is currently unsupported.",
+            "enum": [
+              "unsupported"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "zapier_rule_patch": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Zapier. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/zapier"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "zapier_rule_post": {
+        "additionalProperties": false,
+        "properties": {
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Zapier. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/zapier"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      },
+      "zapier_rule_response": {
+        "additionalProperties": false,
+        "properties": {
+          "_links": {
+            "nullable": true,
+            "type": "object"
+          },
+          "appId": {
+            "description": "The Ably application ID.",
+            "example": "28GY6a",
+            "type": "string"
+          },
+          "created": {
+            "description": "Unix timestamp representing the date and time of creation of the rule.",
+            "example": 1602844091815,
+            "type": "number"
+          },
+          "id": {
+            "description": "The rule ID.",
+            "example": "83IzAB",
+            "type": "string"
+          },
+          "modified": {
+            "description": "Unix timestamp representing the date and time of last modification of the rule.",
+            "example": 1614679682091,
+            "type": "number"
+          },
+          "requestMode": {
+            "description": "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule. Batch Request mode rolls up multiple events into the same request. You can read more about the difference between single and batched events in the Ably <a href=\"https://ably.com/documentation/general/events#batching\">documentation</a>.",
+            "enum": [
+              "single",
+              "batch"
+            ],
+            "example": "single",
+            "type": "string"
+          },
+          "ruleType": {
+            "description": "The type of rule. In this case Zapier. See the <a href=\"https://ably.com/integrations\">documentation</a> for further information.",
+            "enum": [
+              "http/zapier"
+            ],
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/rule_source"
+          },
+          "status": {
+            "description": "The status of the rule. Rules can be enabled or disabled.",
+            "enum": [
+              "enabled",
+              "disabled"
+            ],
+            "example": "enabled",
+            "type": "string"
+          },
+          "target": {
+            "additionalProperties": false,
+            "properties": {
+              "headers": {
+                "description": "If you have additional information to send, you'll need to include the relevant headers.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "The name of the header.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "The value of the header.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "signingKeyId": {
+                "description": "The signing key ID for use in `batch` mode. Ably will optionally sign the payload using an API key ensuring your servers can validate the payload using the private API key. See the <a href=\"https://ably.com/documentation/general/events#security\">webhook security docs</a> for more information.",
+                "nullable": true,
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "version": {
+            "description": "API version. Events and the format of their payloads are versioned. Please see the <a href=\"https://ably.com/documentation/general/events\">Events documentation</a>.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ruleType",
+          "requestMode",
+          "source",
+          "target"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearer_auth": {
+        "description": "Control API uses bearer authentication. You need to generate an access token for use with this API. More details can be found in the <a href=\"https://ably.com/documentation/control-api/#authentication\">Ably documentation</a>.",
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  }
+}

--- a/__tests__/operation/get-response-as-json-schema.test.ts
+++ b/__tests__/operation/get-response-as-json-schema.test.ts
@@ -375,5 +375,33 @@ describe('options', () => {
         },
       ]);
     });
+
+    describe('with the `includeDiscriminatorMappingRefs` option', () => {
+      it('should be able to support an operation that has discriminator mappings', async () => {
+        const ably = await import('../__datasets__/ably.json').then(r => r.default).then(Oas.init);
+        await ably.dereference();
+
+        const operation = ably.operation('/apps/{app_id}/rules', 'post');
+        const jsonSchema = operation.getResponseAsJSONSchema('201', {
+          includeDiscriminatorMappingRefs: false,
+          transformer: schema => {
+            if ('x-readme-ref-name' in schema) {
+              return schema['x-readme-ref-name'] as SchemaObject;
+            }
+
+            return schema;
+          },
+        });
+
+        expect(jsonSchema).toStrictEqual([
+          {
+            type: 'string',
+            schema: 'rule_response',
+            label: 'Response body',
+            description: 'Reactor rule created',
+          },
+        ]);
+      });
+    });
   });
 });

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -56,7 +56,7 @@ export type toJSONSchemaOptions = {
   /**
    * A function that's called anytime a (circular) `$ref` is found.
    */
-  refLogger?: (ref: string) => void;
+  refLogger?: (ref: string, type: 'ref' | 'discriminator') => void;
 
   /**
    * A function that's called to potentially transform any discovered schema.
@@ -295,7 +295,7 @@ export default function toJSONSchema(
   // If this schema contains a `$ref`, it's circular and we shouldn't try to resolve it. Just
   // return and move along.
   if (RMOAS.isRef(schema)) {
-    refLogger(schema.$ref);
+    refLogger(schema.$ref, 'ref');
 
     return transformer({
       $ref: schema.$ref,
@@ -381,7 +381,7 @@ export default function toJSONSchema(
         // them to the supplied `refLogger`.
         const mapping = schema.discriminator.mapping;
         Object.keys(mapping).forEach(k => {
-          refLogger(mapping[k]);
+          refLogger(mapping[k], 'discriminator');
         });
       }
     }
@@ -427,7 +427,7 @@ export default function toJSONSchema(
           if ('$ref' in example) {
             // no-op because any `$ref` example here after dereferencing is circular so we should
             // ignore it
-            refLogger(example.$ref);
+            refLogger(example.$ref, 'ref');
           } else if ('value' in example) {
             if (isPrimitive(example.value)) {
               examples.push(example.value);
@@ -480,7 +480,7 @@ export default function toJSONSchema(
         if (!Array.isArray(schema.items) && Object.keys(schema.items).length === 1 && RMOAS.isRef(schema.items)) {
           // `items` contains a `$ref`, so since it's circular we should do a no-op here and log
           // and ignore it.
-          refLogger(schema.items.$ref);
+          refLogger(schema.items.$ref, 'ref');
         } else if (schema.items !== true) {
           // Run through the arrays contents and clean them up.
           schema.items = toJSONSchema(schema.items as RMOAS.SchemaObject, {

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -466,6 +466,12 @@ export default class Operation {
       globalDefaults?: Record<string, unknown>;
 
       /**
+       * If you wish to include discriminator mapping `$ref` components alongside your
+       * `discriminator` in schemas. Defaults to `true`.
+       */
+      includeDiscriminatorMappingRefs?: boolean;
+
+      /**
        * If you want the output to be two objects: body (contains `body` and `formData` JSON
        * Schema) and metadata (contains `path`, `query`, `cookie`, and `header`).
        */
@@ -485,11 +491,11 @@ export default class Operation {
       transformer?: (schema: RMOAS.SchemaObject) => RMOAS.SchemaObject;
     } = {}
   ) {
-    if (!opts.transformer) {
-      opts.transformer = (s: RMOAS.SchemaObject) => s;
-    }
-
-    return getParametersAsJSONSchema(this, this.api, opts);
+    return getParametersAsJSONSchema(this, this.api, {
+      includeDiscriminatorMappingRefs: true,
+      transformer: (s: RMOAS.SchemaObject) => s,
+      ...opts,
+    });
   }
 
   /**
@@ -501,16 +507,24 @@ export default class Operation {
     statusCode: string | number,
     opts: {
       /**
+       * If you wish to include discriminator mapping `$ref` components alongside your
+       * `discriminator` in schemas. Defaults to `true`.
+       */
+      includeDiscriminatorMappingRefs?: boolean;
+
+      /**
        * With a transformer you can transform any data within a given schema, like say if you want
        * to rewrite a potentially unsafe `title` that might be eventually used as a JS variable
        * name, just make sure to return your transformed schema.
        */
       transformer?: (schema: RMOAS.SchemaObject) => RMOAS.SchemaObject;
-    } = {
-      transformer: (s: RMOAS.SchemaObject) => s,
-    }
+    } = {}
   ) {
-    return getResponseAsJSONSchema(this, this.api, statusCode, opts);
+    return getResponseAsJSONSchema(this, this.api, statusCode, {
+      includeDiscriminatorMappingRefs: true,
+      transformer: (s: RMOAS.SchemaObject) => s,
+      ...opts,
+    });
   }
 
   /**


### PR DESCRIPTION
## 🧰 Changes

This fixes some quirks with the `transformer` option I introduced for compiling JSON Schema where because we're counting `$ref` pointers from `discriminator.mapping` objects, we'd attempt to set an object to a potentially transformed string.

🤡 

I've refactored the `refLogger` system to differentiate between what's a circular `$ref` and what's a discriminator mapping and then introduced a new option to disable emitting discriminator components alongside discriminators -- because I don't need this in [api](https://npm.api).