### PR TITLE
fix: various compatibility issues with `api` codegen

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1535,6 +1535,25 @@ describe('#getPaths()', () => {
     });
   });
 
+  it('should be able to handle, and ignore, extensions set at the `paths` level', () => {
+    const oas = Oas.init({
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: '`paths`-level extensions',
+      },
+      servers: [{ url: 'http://httpbin.org' }],
+      paths: {
+        '/post': {},
+        'x-extension-name': 'buster',
+      },
+    });
+
+    expect(oas.getPaths()).toStrictEqual({
+      '/post': {},
+    });
+  });
+
   it('should be able to handle OpenAPI 3.1 `pathItem` reference objects without dereferencing', async () => {
     const oas = await import('./__datasets__/pathitems-component.json').then(r => r.default).then(Oas.init);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -670,6 +670,11 @@ export default class Oas {
     const paths: Record<string, Record<RMOAS.HttpMethods, Operation | Webhook>> = {};
 
     Object.keys(this.api.paths ? this.api.paths : []).forEach(path => {
+      // If this is a specification extension then we should ignore it.
+      if (path.startsWith('x-')) {
+        return;
+      }
+
       paths[path] = {} as Record<RMOAS.HttpMethods, Operation | Webhook>;
 
       // Though this library is generally unaware of `$ref` pointers we're making a singular

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -360,18 +360,26 @@ export default class Operation {
         operationId = sanitize(operationId);
       }
 
+      // Never start with a number.
+      operationId = operationId.replace(/^[0-9]/g, match => `_${match}`);
+
+      // Ensure that the first character of an `operationId` is always lowercase.
+      operationId = operationId.charAt(0).toLowerCase() + operationId.slice(1);
+
       // If the generated `operationId` already starts with the method (eg. `getPets`) we don't want
       // to double it up into `getGetPets`.
       if (operationId.startsWith(method)) {
         return operationId;
       }
 
-      // If this operation already has an operationId and we just cleaned it up then we shouldn't
+      // If this operation already has an `operationId` and we just cleaned it up then we shouldn't
       // prefix it with an HTTP method.
       if (this.hasOperationId()) {
         return operationId;
       }
 
+      // Because we're merging the `operationId` into an HTTP method we need to reset the first
+      // character of it back to lowercase so end up with `getBuster`, not `getbuster`.
       operationId = operationId.charAt(0).toUpperCase() + operationId.slice(1);
       return `${method}${operationId}`;
     } else if (this.hasOperationId()) {

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -310,7 +310,9 @@ export default function getParametersAsJSONSchema(
           // Parameter descriptions don't exist in `current.schema` so `constructSchema` will never
           // have access to it.
           if (current.description) {
-            schema.description = current.description;
+            if (!isPrimitive(schema)) {
+              schema.description = current.description;
+            }
           }
 
           prev[current.name] = schema;


### PR DESCRIPTION
## 🧰 Changes

* [x] Fixing a problem where `Oas.getPaths()` would fail if a primitive specification extension (like `x-extension-name`) were present at the `paths` level.
* [x] Fixing a problem where `Operation.getOperationId` with the `camelCase` option would not clean up an `operationId` that starts with a number -- which cannot be used as a JS method accessor. We now prefix these cases with an underscore.
* [x] Slightly tweaking `operationId` strings that start with a capital letter to now start with one that's lowercase. Only applies with the `camelCase` option.
* [x] Fixed an edgecase where if the `get*AsJSONSchema()` method with a custom `transformer` returned a primitive it may fail.
  * This whole `transformer` thing is becoming a real pain and as I only added it for `api` I may end up removing it and looking for an alternative solution there for the problem I'm trying to solve with it.
