### PR TITLE
fix: edgecase where we wouldn't always create valid operationIds

### DIFF
--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -1014,6 +1014,24 @@ describe('#getOperationId()', () => {
       expect(operation.getOperationId({ camelCase: true })).toBe('getPets');
     });
 
+    it('should not create an operationId that ends in a hyphen', () => {
+      const spec = Oas.init({
+        openapi: '3.1.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        paths: {
+          '//candidate/{candidate_id}/': {
+            get: {},
+          },
+        },
+      });
+
+      const operation = spec.operation('/candidate/{candidate_id}/', 'get');
+      expect(operation.getOperationId({ camelCase: true })).toBe('getCandidateCandidate_id');
+    });
+
     it.each([
       [
         "should slightly tweak an operationId that's already good to use",

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -342,7 +342,7 @@ export default class Operation {
     function sanitize(id: string) {
       return id
         .replace(/[^a-zA-Z0-9_]/g, '-') // Remove weird characters
-        .replace(/^-*|-*$/g, '') // Don't start or end with -
+        .replace(/^-+|-+$/g, '') // Don't start or end with -
         .replace(/--+/g, '-'); // Remove double --'s
     }
 

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -342,8 +342,8 @@ export default class Operation {
     function sanitize(id: string) {
       return id
         .replace(/[^a-zA-Z0-9_]/g, '-') // Remove weird characters
-        .replace(/^-+|-+$/g, '') // Don't start or end with -
-        .replace(/--+/g, '-'); // Remove double --'s
+        .replace(/--+/g, '-') // Remove double --'s
+        .replace(/^-|-$/g, ''); // Don't start or end with -
     }
 
     let operationId;

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -342,7 +342,7 @@ export default class Operation {
     function sanitize(id: string) {
       return id
         .replace(/[^a-zA-Z0-9_]/g, '-') // Remove weird characters
-        .replace(/^-|-$/g, '') // Don't start or end with -
+        .replace(/^-*|-*$/g, '') // Don't start or end with -
         .replace(/--+/g, '-'); // Remove double --'s
     }
 


### PR DESCRIPTION
## 🧰 Changes

This fixes an edgase where if a path is `/candidate/{candidate_id}/` and there's no `operationId` we were generating  `getCandidateCandidate_id-`. Normally we lop off starting and trailing `-` but because the path ends in `}/` that's getting converted into `--` and we're only lopping off one of those.