### PR TITLE
fix: reversing the logic order for common summary+descriptions

### DIFF
--- a/__tests__/__datasets__/callbacks.json
+++ b/__tests__/__datasets__/callbacks.json
@@ -96,6 +96,8 @@
                 }
               ],
               "post": {
+                "summary": "[post] callback summary",
+                "description": "[post] callback description",
                 "requestBody": {
                   "description": "Callback payload",
                   "content": {
@@ -113,6 +115,8 @@
                 }
               },
               "get": {
+                "summary": "[get] callback summary",
+                "description": "[get] callback description",
                 "parameters": [
                   {
                     "in": "query",

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -76,11 +76,11 @@ describe('#getSummary() + #getDescription()', () => {
     expect(operation.getDescription()).toBeUndefined();
   });
 
-  it('should allow a common summary to override the operation-level summary', () => {
+  it('should allow an operation-level summary + description to override the common one', () => {
     const operation = parametersCommon.operation('/anything/{id}', 'get');
 
-    expect(operation.getSummary()).toBe('[common] Summary');
-    expect(operation.getDescription()).toBe('[common] Description');
+    expect(operation.getSummary()).toBe('[get] Summary');
+    expect(operation.getDescription()).toBe('[get] Description');
   });
 
   describe('callbacks', () => {
@@ -104,7 +104,7 @@ describe('#getSummary() + #getDescription()', () => {
       expect(callback.getDescription()).toBeUndefined();
     });
 
-    it('should allow a common summary to override the callback-level summary', () => {
+    it('should allow an operation-level callback summary + description to override the common one', () => {
       const operation = callbackSchema.operation('/callbacks', 'get');
       const callback = operation.getCallback(
         'multipleCallback',
@@ -112,8 +112,8 @@ describe('#getSummary() + #getDescription()', () => {
         'post'
       ) as Callback;
 
-      expect(callback.getSummary()).toBe('[common] callback summary');
-      expect(callback.getDescription()).toBe('[common] callback description');
+      expect(callback.getSummary()).toBe('[post] callback summary');
+      expect(callback.getDescription()).toBe('[post] callback description');
     });
   });
 });
@@ -1534,10 +1534,14 @@ describe('#getCallback()', () => {
       description: '[common] callback description',
       parameters: expect.any(Array),
       post: {
+        description: '[post] callback description',
+        summary: '[post] callback summary',
         requestBody: expect.any(Object),
         responses: expect.any(Object),
       },
       get: {
+        description: '[get] callback description',
+        summary: '[get] callback summary',
         parameters: expect.any(Array),
         responses: expect.any(Object),
       },

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -78,19 +78,23 @@ export default class Operation {
   }
 
   getSummary(): string {
-    if (this.api.paths[this.path].summary) {
+    if (this.schema?.summary) {
+      return this.schema.summary.trim();
+    } else if (this.api.paths[this.path].summary) {
       return this.api.paths[this.path].summary;
     }
 
-    return this.schema?.summary ? this.schema.summary.trim() : undefined;
+    return undefined;
   }
 
   getDescription(): string {
-    if (this.api.paths[this.path].description) {
+    if (this.schema?.description) {
+      return this.schema.description.trim();
+    } else if (this.api.paths[this.path].description) {
       return this.api.paths[this.path].description;
     }
 
-    return this.schema?.description ? this.schema.description.trim() : undefined;
+    return undefined;
   }
 
   getContentType(): string {
@@ -846,19 +850,23 @@ export class Callback extends Operation {
   }
 
   getSummary(): string {
-    if (this.parentSchema.summary) {
+    if (this.schema?.summary) {
+      return this.schema.summary.trim();
+    } else if (this.parentSchema.summary) {
       return this.parentSchema.summary;
     }
 
-    return this.schema?.summary ? this.schema.summary.trim() : undefined;
+    return undefined;
   }
 
   getDescription(): string {
-    if (this.parentSchema.description) {
+    if (this.schema?.description) {
+      return this.schema.description.trim();
+    } else if (this.parentSchema.description) {
       return this.parentSchema.description;
     }
 
-    return this.schema?.description ? this.schema.description.trim() : undefined;
+    return undefined;
   }
 
   getParameters(): RMOAS.ParameterObject[] {


### PR DESCRIPTION
## 🧰 Changes

This reverses the logic order for how we extract a `summary` and `description` out of an operation or callback operation when common `summary` and `description` properties are present. Previous we would always prefer the common one over the more specific, but we're reversing this as it makes more sense to do so.

Unfortunately the spec doesn't specify this behavior so we're kind of winging this on how it *feels*.