### PR TITLE
feat: pass through requestBody descriptions

### DIFF
--- a/__tests__/__snapshots__/operation.test.ts.snap
+++ b/__tests__/__snapshots__/operation.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`#getParametersAsJSONSchema() should return json schema 1`] = `
 [
   {
+    "description": "Pet object that needs to be added to the store",
     "label": "Body Params",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -162,6 +162,7 @@ describe('#getContentType()', () => {
     expect(
       new Operation(petstore.getDefinition(), '/body', 'get', {
         requestBody: {
+          description: 'test test test 🫠',
           content: {
             'text/xml': {
               schema: {
@@ -223,6 +224,7 @@ describe('#isFormUrlEncoded()', () => {
   it('should identify `application/x-www-form-urlencoded`', () => {
     const op = new Operation(petstore.getDefinition(), '/form-urlencoded', 'get', {
       requestBody: {
+        description: 'test test test 🫠',
         content: {
           'application/x-www-form-urlencoded': {
             schema: {
@@ -1450,7 +1452,11 @@ describe('#getRequestBody()', () => {
   describe('should support retrieval without a given media type', () => {
     it('should prefer `application/json` media types', () => {
       const operation = petstore.operation('/pet', 'put');
-      expect(operation.getRequestBody()).toStrictEqual(['application/json', { schema: expect.any(Object) }]);
+      expect(operation.getRequestBody()).toStrictEqual([
+        'application/json',
+        { schema: expect.any(Object) },
+        'Pet object that needs to be added to the store',
+      ]);
     });
 
     it('should pick first available if no json-like media types present', () => {

--- a/__tests__/operation.test.ts
+++ b/__tests__/operation.test.ts
@@ -162,7 +162,6 @@ describe('#getContentType()', () => {
     expect(
       new Operation(petstore.getDefinition(), '/body', 'get', {
         requestBody: {
-          description: 'test test test 🫠',
           content: {
             'text/xml': {
               schema: {
@@ -224,7 +223,6 @@ describe('#isFormUrlEncoded()', () => {
   it('should identify `application/x-www-form-urlencoded`', () => {
     const op = new Operation(petstore.getDefinition(), '/form-urlencoded', 'get', {
       requestBody: {
-        description: 'test test test 🫠',
         content: {
           'application/x-www-form-urlencoded': {
             schema: {

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -232,6 +232,7 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-
       },
       "type": "body",
     },
+    "description": "Pet object that needs to be added to the store",
     "label": "Body Params",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
@@ -708,6 +709,7 @@ exports[`polymorphism / discriminators should retain discriminator \`mapping\` r
 exports[`request bodies should convert request bodies to JSON schema application/json 1`] = `
 [
   {
+    "description": "Pet object that needs to be added to the store",
     "label": "Body Params",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
@@ -867,6 +869,7 @@ exports[`type sorting should return with a json schema for each parameter type (
     "type": "query",
   },
   {
+    "description": "Body description",
     "label": "Body Params",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",
@@ -955,6 +958,7 @@ exports[`type sorting should return with a json schema for each parameter type (
     "type": "cookie",
   },
   {
+    "description": "Body description",
     "label": "Form Data",
     "schema": {
       "$schema": "http://json-schema.org/draft-04/schema#",

--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -953,6 +953,7 @@ describe('options', () => {
 
       expect(jsonSchema).toStrictEqual([
         {
+          description: 'Pet object that needs to be added to the store',
           label: 'Body Params',
           schema: 'Pet',
           type: 'body',

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -621,7 +621,7 @@ export default class Operation {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject}
    * @param mediaType Specific request body media type to retrieve if present.
    */
-  getRequestBody(mediaType?: string): false | RMOAS.MediaTypeObject | [string, RMOAS.MediaTypeObject] {
+  getRequestBody(mediaType?: string): false | RMOAS.MediaTypeObject | [string, RMOAS.MediaTypeObject, ...string[]] {
     if (!this.hasRequestBody()) {
       return false;
     }
@@ -660,7 +660,11 @@ export default class Operation {
     }
 
     if (availableMediaType) {
-      return [availableMediaType, requestBody.content[availableMediaType]];
+      return [
+        availableMediaType,
+        requestBody.content[availableMediaType],
+        ...(requestBody.description ? [requestBody.description] : []),
+      ];
     }
 
     return false;

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -13,6 +13,7 @@ export interface SchemaWrapper {
   type: string;
   label?: string;
   schema: SchemaObject;
+  description?: string;
   deprecatedProps?: SchemaWrapper;
 }
 
@@ -124,7 +125,7 @@ export default function getParametersAsJSONSchema(
     const requestBody = operation.getRequestBody();
     if (!requestBody || !Array.isArray(requestBody)) return null;
 
-    const [mediaType, mediaTypeObject] = requestBody;
+    const [mediaType, mediaTypeObject, description] = requestBody;
     const type = mediaType === 'application/x-www-form-urlencoded' ? 'formData' : 'body';
 
     // If this schema is completely empty, don't bother processing it.
@@ -146,6 +147,7 @@ export default function getParametersAsJSONSchema(
     // We're cloning the request schema because we've had issues with request schemas that were
     // dereferenced being processed multiple times because their component is also processed.
     const requestSchema = cloneObject(mediaTypeObject.schema);
+
     const cleanedSchema = toJSONSchema(requestSchema, {
       globalDefaults: opts.globalDefaults,
       prevSchemas,
@@ -168,6 +170,7 @@ export default function getParametersAsJSONSchema(
             $schema: getSchemaVersionString(cleanedSchema, api),
           },
       deprecatedProps: getDeprecated(cleanedSchema, type),
+      ...(description ? { description } : {}),
     };
   }
 


### PR DESCRIPTION
| 🚥 Fixes ISSUE_ID |
| :---------------- |

## 🧰 Changes
buddy PR to [#8316](https://github.com/readmeio/readme/pull/8316)

We say [we support this](https://docs.readme.com/main/docs/openapi-compatibility-chart#request-body-object) (and technically we do, it's in the oas/operation correctly) but weren't actually doing anything with that information 

This surfaces request body descriptions out with the json schema so we can display them on the front end

## 🧬 QA & Testing
Check the tests - a few older tests should now be passing through description as intended 
