### PR TITLE
fix: only adding components to generated JSON Schema if we need to

### DIFF
--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -309,7 +309,6 @@ describe('polymorphism / discriminators', () => {
           type: 'object',
           properties: expect.any(Object),
           required: ['account_id'],
-          components: expect.any(Object),
         },
       },
       {
@@ -322,7 +321,6 @@ describe('polymorphism / discriminators', () => {
           type: 'object',
           'x-readme-ref-name': 'app_post',
           $schema: 'http://json-schema.org/draft-04/schema#',
-          components: expect.any(Object),
         },
       },
     ]);

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -188,7 +188,7 @@ export default function getParametersAsJSONSchema(
        * we'll later remove if they didn't get used.
        *
        * Obviously not ideal but I'd rather have a couple lines of boilerplate nonsense than having
-       * to wait a noticeably frustrating amoutn of time for TS Intellisense to reload itself after
+       * to wait a noticeably frustrating amount of time for TS Intellisense to reload itself after
        * you save a line in any file.
        */
       examples: {},

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -411,7 +411,7 @@ export default function getParametersAsJSONSchema(
   const jsonSchema = [transformRequestBody()].concat(...transformParameters()).filter(Boolean);
 
   // We should only include `components`, or even bother transforming components into JSON Schema,
-  // if we either have circular refs or if we have discriminator mapping refs somehwere and want to
+  // if we either have circular refs or if we have discriminator mapping refs somewhere and want to
   // include them.
   const shouldIncludeComponents =
     hasCircularRefs || (hasDiscriminatorMappingRefs && opts.includeDiscriminatorMappingRefs);


### PR DESCRIPTION
## 🧰 Changes

This fixes a pretty large performance issue in `Operation.getParametersAsJSONSchema()` where if an API Definition has a very large schema in a component we will bog down pretty hard converting it to JSON Schema even if we don't need to.

For example this excerpted component schema:

![screen_shot_2023-02-27_at_10 37 34_pm](https://user-images.githubusercontent.com/33762/221790965-86516d4e-43f2-456f-9f3b-c570c753c64e.png)

Because these `$ref` pointers, and the parental schema itself, are normally able to be safely dereferenced, we're still adding the into the generated JSON Schema for that parameter or request body that we're generating JSON Schema for on the off chance that they might be used within our API Explorer for schemas that may be circular and we're able to safely render them there.

The problem though is that we're doing this work for everything and everybody. Even if your entire API definition has no circular `$ref` pointers and can 100% be safely dereferenced we still process the entire `#/components` block, converting every component into JSON Schema, and then add that to the JSON Schema we *actually* want.

The operation that above screenshot? That comes from [this page](https://apis-cedro.readme.io/reference/get_services-negotiation-brokerserviceaccountinformation-nomeusuario-conta-codmercado) where because we're re-processing all components, components that have already been processed because they were dereferenced, a single call to `Operation.getParametersAsJSONSchema()` takes ~2000ms.

Remember that this is happening for every user, every API definition, everything.

![columbo.](https://user-images.githubusercontent.com/33762/221792549-fde8ca29-150b-4a4d-9ed6-8ffa9166ec29.gif)

## 🧬 QA & Testing

To fix this I went ahead and fixed the glitch. Because we have some internal logging work within this generator to keep track of when we encounter a `$ref` pointer that wasn't able to be dereferenced we know if we'll need to ever reference the `#/components` object at all. The results are pretty goddamn mindblowing.

That operation that took 2000ms to generate JSON Schema? Now? 3ms. T H R E E.

Try it[^1] if you don't believe me, I honestly didn't either.

```ts
import spec from './cedro.json';
import Oas from './src';

declare global {
  interface Console {
    logx: any;
  }
}

console.logx = (obj: any) => {
  console.log(require('util').inspect(obj, false, null, true));
};

const oas = new Oas(spec as any);

(async () => {
  await oas.dereference();

  const START = process.hrtime();

  const op = oas.operation(
    '/services/negotiation/brokerServiceAccountInformation/{nomeUsuario}/{conta}/{codMercado}',
    'get'
  );

  console.logx(op.getParametersAsJSONSchema());

  const END = process.hrtime(START);
  console.log(`${(END[0] * 1000000000 + END[1]) / 1000000}ms`);
})();
```

There's still a lot of improvement here for when we *do* need to inject these components into the schema (mostly only cases where circular `$ref` pointers are present) but to do that we'll need to process these stored up `$ref` pointers that we found, find them in `#/components` if they exist and then add them. Just to curb the bleeding on this particular user, and this particularly disastrous performance issue I'm opting to not do that now. Large schemas with circular refs will still have poorly unoptimized JSON Schema generation.

[^1]: Use this spec: https://apis-cedro.readme.io/openapi/63eace87ab83b2001e63306c