### PR TITLE
fix: bug where primitive schemas would crash dereferencing

### DIFF
--- a/__tests__/__datasets__/3-1-primitive-components.json
+++ b/__tests__/__datasets__/3-1-primitive-components.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Special handling of OpenAPI 3.1 dereferencing cases",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "description": "We should be able to primitive `$ref` pointers.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/primitive"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "primitive": true
+    }
+  }
+}

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1322,6 +1322,13 @@ describe('#dereference()', () => {
     });
   });
 
+  it('should support primitive component schemas', async () => {
+    const oas = await import('./__datasets__/3-1-primitive-components.json').then(r => r.default).then(Oas.init);
+    await oas.dereference();
+
+    expect(oas.api.components.schemas.primitive).toBe(true);
+  });
+
   it('should support `$ref` pointers existing alongside `description` in OpenAPI 3.1 definitions', async () => {
     const oas = await import('./__datasets__/3-1-dereference-handling.json').then(r => r.default).then(Oas.init);
     await oas.dereference();

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,0 +1,3 @@
+export function isPrimitive(val: unknown): boolean {
+  return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
+}

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -6,6 +6,8 @@ import jsonpointer from 'jsonpointer';
 
 import * as RMOAS from '../rmoas.types';
 
+import { isPrimitive } from './helpers';
+
 /**
  * This list has been pulled from `openapi-schema-to-json-schema` but been slightly modified to fit
  * within the constraints in which ReadMe uses the output from this library in schema form
@@ -131,10 +133,6 @@ export function getSchemaVersionString(schema: RMOAS.SchemaObject, api: RMOAS.OA
   }
 
   return 'https://json-schema.org/draft/2020-12/schema#';
-}
-
-export function isPrimitive(val: unknown): boolean {
-  return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
 }
 
 function isPolymorphicSchema(schema: RMOAS.SchemaObject): boolean {

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -3,8 +3,9 @@ import type { ComponentsObject, ExampleObject, OASDocument, ParameterObject, Sch
 import type { OpenAPIV3_1 } from 'openapi-types';
 
 import cloneObject from '../lib/clone-object';
+import { isPrimitive } from '../lib/helpers';
 import matchesMimetype from '../lib/matches-mimetype';
-import toJSONSchema, { isPrimitive, getSchemaVersionString } from '../lib/openapi-to-json-schema';
+import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
 
 const isJSON = matchesMimetype.json;
 

--- a/src/operation/get-response-as-json-schema.ts
+++ b/src/operation/get-response-as-json-schema.ts
@@ -9,8 +9,9 @@ import type {
 } from 'rmoas.types';
 
 import cloneObject from '../lib/clone-object';
+import { isPrimitive } from '../lib/helpers';
 import matches from '../lib/matches-mimetype';
-import toJSONSchema, { isPrimitive, getSchemaVersionString } from '../lib/openapi-to-json-schema';
+import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
 
 const isJSON = matches.json;
 


### PR DESCRIPTION
## 🧰 Changes

This fixes a bug in `Oas.dereference()` where if an OpenAPI 3.1 definition with a primitive component schema is present the dereferencing will crash.