### PR TITLE
fix: bug where request example selection wouldn't always use the first

### DIFF
--- a/__tests__/__datasets__/requestbody-example-quirks.json
+++ b/__tests__/__datasets__/requestbody-example-quirks.json
@@ -1,0 +1,97 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Request example quirks", "version": "1.0" },
+  "servers": [
+    { "url": "https://httpbin.org" }
+  ],
+  "paths": {
+    "/anything": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["paymentMethodId", "amount", "currency"],
+                "properties": {
+                  "paymentMethodId": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "string"
+                  },
+                  "currency": {
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "Brazil": {
+                  "value": {
+                    "paymentMethodId": "brazil.5e98df1f-1701-499b-a739-4e5e70d51c9b",
+                    "amount": 25000,
+                    "currency": "brazil.BRL"
+                  }
+                },
+                "Colombia": {
+                  "value": {
+                    "paymentmethodid": "colombia.1cd4740f-16c7-419b-a84f-734292c89f01",
+                    "amount": 40000,
+                    "currency": "colombia.COP"
+                  }
+                },
+                "Chile": {
+                  "value": {
+                    "paymentMethodId": "chile.8f0414bf-7cef-47fd-82aa-a77a2fe655f6",
+                    "amount": 2345,
+                    "currency": "chile.CLP"
+                  }
+                },
+                "Mexico": {
+                  "value": {
+                    "paymentmethodid": "mexico.0ef648e0-9f31-4efa-9db8-cf78125d1bdc",
+                    "amount": 500,
+                    "currency": "mexico.MXN"
+                  }
+                },
+                "Ecuador": {
+                  "value": {
+                    "paymentmethodid": "ecuador.1d8b9dd0-80e6-472a-a06f-b518eb24aa58",
+                    "amount": 1067,
+                    "currency": "ecuador.USD"
+                  }
+                },
+                "Argentina": {
+                  "value": {
+                    "paymentmethodid": "argentina.598f2405-21d6-4e6f-a2cb-617a463a45e7",
+                    "amount": 40000,
+                    "currency": "argentina.ARS"
+                  }
+                },
+                "Costa Rica": {
+                  "value": {
+                    "paymentmethodid": "costarica.eb2fc2cb-22f1-4ce2-a25b-7ff54cb646e9",
+                    "amount": 172105,
+                    "currency": "costarica.CRC"
+                  }
+                },
+                "Peru": {
+                  "value": {
+                    "paymentmethodid": "peru.8d74f8f2-dc96-435f-9e10-330578740da9",
+                    "amount": 90021,
+                    "currency": "peru.PES"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "200"
+          }
+        }
+      }
+    }
+  }
+}

--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -1027,4 +1027,21 @@ describe('`example` / `examples` support', () => {
       properties: { limit: { type: 'integer' } },
     });
   });
+
+  it('if multiple examples are present in `examples` it should always use the first in the list', async () => {
+    const oas = await import('../__datasets__/requestbody-example-quirks.json').then(r => r.default).then(Oas.init);
+
+    await oas.dereference();
+
+    const schema = oas.operation('/anything', 'post').getParametersAsJSONSchema() as SchemaObject;
+
+    expect(schema[0].schema.properties).toStrictEqual({
+      paymentMethodId: {
+        type: 'string',
+        examples: ['brazil.5e98df1f-1701-499b-a739-4e5e70d51c9b'],
+      },
+      amount: { type: 'string', examples: [25000] },
+      currency: { type: 'string', examples: ['brazil.BRL'] },
+    });
+  });
 });

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -204,7 +204,7 @@ function searchForExampleByPointer(pointer: string, examples: PrevSchemasType = 
         }
 
         // Prevent us from crashing if `examples` is a completely empty object.
-        schema = schema.examples.shift();
+        schema = [...schema.examples].shift();
       }
 
       try {


### PR DESCRIPTION
| 🚥 Fixes RM-6662 |
| :---------------- |

## 🧰 Changes

This is a weird one! Right now if you have a request body that utilizes `examples` and have multiple examples within that our `example` determination for `Operation.getParametersToJSONSchema()` will now will pick an example from each down the list as it processes property.

For example:

![Screen Shot 2023-03-07 at 2 29 16 PM](https://user-images.githubusercontent.com/33762/223581641-794020c8-dd94-4620-96fb-55c2d9ed09e3.png)

Reason this is happening is because the `schema.examples` array we're working with in `lib/openapi-to-json-schema` is a reference and when we run `.shift()` on it we effectively remove that example from being used for the next property we're processing JSON Schema for.

🫠
