### PR TITLE
fix: inability to merge enums within an `allOf`

### DIFF
--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -414,6 +414,37 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-
 ]
 `;
 
+exports[`deprecated polymorphism should be able to merge enums within an allOf schema 1`] = `
+[
+  {
+    "label": "Body Params",
+    "schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "events": {
+          "items": {
+            "enum": [
+              "one",
+              "two",
+              "three",
+              "four",
+              "five",
+              "six",
+            ],
+            "type": "string",
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true,
+        },
+      },
+      "type": "object",
+    },
+    "type": "body",
+  },
+]
+`;
+
 exports[`deprecated polymorphism should pass through deprecated on a (merged) allOf schema 1`] = `
 [
   {

--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -779,6 +779,41 @@ describe('deprecated', () => {
 
       expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toMatchSnapshot();
     });
+
+    it('should be able to merge enums within an allOf schema', () => {
+      const oas = createOas({
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  events: {
+                    type: 'array',
+                    minItems: 1,
+                    uniqueItems: true,
+                    items: {
+                      allOf: [
+                        {
+                          type: 'string',
+                          enum: ['one', 'two', 'three'],
+                        },
+                        {
+                          type: 'string',
+                          enum: ['four', 'five', 'six'],
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(oas.operation('/', 'get').getParametersAsJSONSchema()).toMatchSnapshot();
+    });
   });
 });
 

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -310,6 +310,18 @@ export default function toJSONSchema(
         schema = mergeJSONSchemaAllOf(schema as RMOAS.JSONSchema, {
           ignoreAdditionalProperties: true,
           resolvers: {
+            // `merge-json-schema-allof` doesn't support merging enum arrays but since that's a
+            // safe and simple operation as enums always contain primitives we can handle it
+            // ourselves with a custom resolver.
+            enum: (obj: unknown[]) => {
+              let arr: unknown[] = [];
+              obj.forEach(e => {
+                arr = arr.concat(e);
+              });
+
+              return arr;
+            },
+
             // JSON Schema ony supports examples with the `examples` property, since we're
             // ingesting OpenAPI definitions we need to add a custom resolver for its `example`
             // property.


### PR DESCRIPTION
| 🚥 Fixes CX-141 |
| :---------------- |

## 🧰 Changes

This adds handling for a quirk within [json-schema-merge-allof](https://npm.im/json-schema-merge-allof) where it cannot merge `enum` arrays like the following:

```js
allOf: [
  {
    type: 'string',
    enum: ['one', 'two', 'three'],
  },
  {
    type: 'string',
    enum: ['four', 'five', 'six'],
  },
],
```
The error that that library throws, that we catch and then delete the `allOf` from the schema, is this:

![Screen Shot 2023-04-24 at 1 50 42 PM](https://user-images.githubusercontent.com/33762/234115320-51ce3a44-6abd-42ff-836b-9d39001ed2bc.png)

Because enums are a known datatype and `json-schema-merge-allof` has support for custom resolvers we can easily handle this merging ourselves resulting in a merged schema of the following:

```js
{
  "type": "string",
  "enum": ["one", "two", "three", "four", "five", "six"]
}
```

## 🧬 QA & Testing

With a spec with one of these `allOf`s this is what this fix looks like before and after:

```js
import aqid from './aqid.json';
import Oas from './src';

const spec = Oas.init(aqid);
(async () => {
  await spec.dereference();

  console.log(spec.operation('/webhooks', 'post').getParametersAsJSONSchema());
})();
```

![Screen Shot 2023-04-24 at 1 54 18 PM](https://user-images.githubusercontent.com/33762/234115252-303873d7-386d-4d73-b601-d3f60bfd3943.png)
