### PR TITLE
fix: use the last description in a merged allOf schema

### DIFF
--- a/__tests__/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
+++ b/__tests__/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
@@ -1136,3 +1136,306 @@ exports[`\`default\` support should support default 1`] = `
   "type": "object",
 }
 `;
+
+exports[`\`description\` support should support description 1`] = `
+{
+  "properties": {
+    "allOf:array of primitives:description[example description]": {
+      "items": {
+        "description": "example description",
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "allOf:array with an array of primitives:description[example description]": {
+      "items": {
+        "items": {
+          "description": "example description",
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "type": "array",
+    },
+    "allOf:object with primitives and mixed arrays:description[example description]": {
+      "properties": {
+        "param1": {
+          "description": "example description",
+          "type": "string",
+        },
+        "param2": {
+          "items": {
+            "items": {
+              "description": "example description",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      },
+      "type": "object",
+    },
+    "allOf:primitive string:description[example description]": {
+      "description": "example description",
+      "type": "string",
+    },
+    "anyOf:array of primitives:description[example description]": {
+      "anyOf": [
+        {
+          "items": {
+            "description": "example description",
+            "type": "string",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "description": "example description",
+            "type": "string",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "anyOf:array with an array of primitives:description[example description]": {
+      "anyOf": [
+        {
+          "items": {
+            "items": {
+              "description": "example description",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "items": {
+              "description": "example description",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "anyOf:object with primitives and mixed arrays:description[example description]": {
+      "anyOf": [
+        {
+          "properties": {
+            "param1": {
+              "description": "example description",
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "description": "example description",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
+        },
+        {
+          "properties": {
+            "param1": {
+              "description": "example description",
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "description": "example description",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
+        },
+      ],
+    },
+    "anyOf:primitive string:description[example description]": {
+      "anyOf": [
+        {
+          "description": "example description",
+          "type": "string",
+        },
+        {
+          "description": "example description",
+          "type": "string",
+        },
+      ],
+    },
+    "array of primitives:description[example description]": {
+      "items": {
+        "description": "example description",
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "array with an array of primitives:description[example description]": {
+      "items": {
+        "items": {
+          "description": "example description",
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "type": "array",
+    },
+    "object with primitives and mixed arrays:description[example description]": {
+      "properties": {
+        "param1": {
+          "description": "example description",
+          "type": "string",
+        },
+        "param2": {
+          "items": {
+            "items": {
+              "description": "example description",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      },
+      "type": "object",
+    },
+    "oneOf:array of primitives:description[example description]": {
+      "oneOf": [
+        {
+          "items": {
+            "description": "example description",
+            "type": "string",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "description": "example description",
+            "type": "string",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "oneOf:array with an array of primitives:description[example description]": {
+      "oneOf": [
+        {
+          "items": {
+            "items": {
+              "description": "example description",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "items": {
+              "description": "example description",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "oneOf:object with primitives and mixed arrays:description[example description]": {
+      "oneOf": [
+        {
+          "properties": {
+            "param1": {
+              "description": "example description",
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "description": "example description",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
+        },
+        {
+          "properties": {
+            "param1": {
+              "description": "example description",
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "description": "example description",
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "type": "object",
+        },
+      ],
+    },
+    "oneOf:primitive string:description[example description]": {
+      "oneOf": [
+        {
+          "description": "example description",
+          "type": "string",
+        },
+        {
+          "description": "example description",
+          "type": "string",
+        },
+      ],
+    },
+    "primitive string:description[example description]": {
+      "description": "example description",
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`\`description\` support should support description in an \`allOf\` and should prioritize the one from the last schema 1`] = `
+{
+  "properties": {
+    "meta": {
+      "description": "only meta description",
+      "type": "string",
+    },
+    "robots": {
+      "deprecated": true,
+      "description": "second robots description",
+      "readOnly": true,
+      "type": "string",
+    },
+    "uri": {
+      "description": "second uri description",
+      "readOnly": true,
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;

--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -533,7 +533,7 @@ describe('`format` support', () => {
   });
 });
 
-describe('`title` support`', () => {
+describe('`title` support', () => {
   it('should support title', () => {
     const schema: SchemaObject = {
       oneOf: [
@@ -555,6 +555,53 @@ describe('`title` support`', () => {
     };
 
     expect(toJSONSchema(schema)).toStrictEqual(schema);
+  });
+});
+
+describe('`description` support', () => {
+  it('should support description', () => {
+    const schema: SchemaObject = generateJSONSchemaFixture({ description: 'example description' });
+    expect(toJSONSchema(schema)).toMatchSnapshot();
+  });
+
+  it('should support description in an `allOf` and should prioritize the one from the last schema', () => {
+    const schema: SchemaObject = {
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            uri: {
+              type: 'string',
+              description: 'first uri description',
+            },
+            robots: {
+              type: 'string',
+              description: 'first robots description',
+            },
+            meta: {
+              type: 'string',
+              description: 'only meta description',
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            uri: {
+              description: 'second uri description',
+              readOnly: true,
+            },
+            robots: {
+              description: 'second robots description',
+              readOnly: true,
+              deprecated: true,
+            },
+          },
+        },
+      ],
+    };
+
+    expect(toJSONSchema(schema)).toMatchSnapshot();
   });
 });
 

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -310,6 +310,14 @@ export default function toJSONSchema(
         schema = mergeJSONSchemaAllOf(schema as RMOAS.JSONSchema, {
           ignoreAdditionalProperties: true,
           resolvers: {
+            // `merge-json-schema-allof` by default takes the first `description` when you're
+            // merging an `allOf` but because generally when you're merging two schemas together
+            // with an `allOf` you want data in the subsequent schemas to be applied to the first
+            // and `description` should be a part of that.
+            description: (obj: string[]) => {
+              return obj.slice(-1)[0];
+            },
+
             // `merge-json-schema-allof` doesn't support merging enum arrays but since that's a
             // safe and simple operation as enums always contain primitives we can handle it
             // ourselves with a custom resolver.

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -6,7 +6,7 @@
  */
 import type * as RMOAS from '../rmoas.types';
 
-import mergeAllOf from 'json-schema-merge-allof';
+import mergeJSONSchemaAllOf from 'json-schema-merge-allof';
 import memoize from 'memoizee';
 
 import { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } from './utils';
@@ -73,11 +73,11 @@ function sampleFromSchema(
   if (hasPolymorphism === 'allOf') {
     try {
       return sampleFromSchema(
-        mergeAllOf(objectifySchema, {
+        mergeJSONSchemaAllOf(objectifySchema, {
           resolvers: {
             // Ignore any unrecognized OAS-specific keywords that might be present on the schema
             // (like `xml`).
-            defaultResolver: mergeAllOf.options.resolvers.title,
+            defaultResolver: mergeJSONSchemaAllOf.options.resolvers.title,
           },
         }),
         opts


### PR DESCRIPTION
## 🧰 Changes

When [json-schema-merge-allof](https://npm.im/json-schema-merge-allof) merges an `allOf` and two or more schemas within that share the same property, but not the same description, the first description seen is always going to be the one used in the resulting merged schema.

For example this schema:

```js
{
  allOf: [
    {
      type: 'object',
      properties: {
        uri: {
          type: 'string',
          description: 'first uri description',
        },
        robots: {
          type: 'string',
          description: 'first robots description',
        },
        meta: {
          type: 'string',
          description: 'only meta description',
        },
      },
    },
    {
      type: 'object',
      properties: {
        uri: {
          description: 'second uri description',
          readOnly: true,
        },
        robots: {
          description: 'second robots description',
          readOnly: true,
          deprecated: true,
        },
      },
    },
  ],
}
```

When it's merged, the description for `uri` will always be "first uri description". Because when folks use `allOf` it's sometimes to merge a common schema into a more specific one, not using the `description` from the applied schemas doesn't make sense.

With this work, the merged schema's `uri` property will have a `description` of "second uri description".
