### PR TITLE
feat: improved support for mixed types and `nullable`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@commitlint/cli": "^17.6.1",
         "@commitlint/config-conventional": "^17.6.1",
         "@readme/eslint-config": "^10.5.2",
-        "@readme/oas-examples": "^5.10.0",
+        "@readme/oas-examples": "^5.11.1",
         "@readme/openapi-parser": "^2.5.0",
         "@types/jest": "^29.5.1",
         "@types/json-schema-merge-allof": "^0.6.1",
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.10.0.tgz",
-      "integrity": "sha512-2hU8TfKlbV5WlpAq+/x3tdRM53F9umPdm+Gt2510ipwrK5Crubm5jbCLF3Nq866iowOdRR6acFvY8BKBHt46SQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.11.1.tgz",
+      "integrity": "sha512-Bu9Daac+rso7tZb1UElExkXK/DRaDUEH1mEHT/QEal6l9xjfQfmf9Wj2ChCkYYcW2geeoSMuMI+zzYU3KEXSnA==",
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
@@ -10590,9 +10590,9 @@
       }
     },
     "@readme/oas-examples": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.10.0.tgz",
-      "integrity": "sha512-2hU8TfKlbV5WlpAq+/x3tdRM53F9umPdm+Gt2510ipwrK5Crubm5jbCLF3Nq866iowOdRR6acFvY8BKBHt46SQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.11.1.tgz",
+      "integrity": "sha512-Bu9Daac+rso7tZb1UElExkXK/DRaDUEH1mEHT/QEal6l9xjfQfmf9Wj2ChCkYYcW2geeoSMuMI+zzYU3KEXSnA==",
       "dev": true
     },
     "@readme/openapi-parser": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@commitlint/cli": "^17.6.1",
     "@commitlint/config-conventional": "^17.6.1",
     "@readme/eslint-config": "^10.5.2",
-    "@readme/oas-examples": "^5.10.0",
+    "@readme/oas-examples": "^5.11.1",
     "@readme/openapi-parser": "^2.5.0",
     "@types/jest": "^29.5.1",
     "@types/json-schema-merge-allof": "^0.6.1",


### PR DESCRIPTION
| 🚥 Fixes RM-4713, RM-4328, CX-68, RM-1814 |
| :---------------- |

## 🧰 Changes

* [x] Adds support for OpenAPI 3.1's new `type: [...]` mixed type declaration. When we encounter one of these mixed types during JSON Schema generation, to ease our form system, we're automatically converting them into a `oneOf` schema.
  * If `null` is one of these options then it's removed from the `type` array and `nullable: true` is added to the other available options.
* [x] Adds support for `nullable`.