### PR TITLE
feat: additional tweaks to json schema mixed type handling

### DIFF
--- a/__tests__/__fixtures__/json-schema.ts
+++ b/__tests__/__fixtures__/json-schema.ts
@@ -57,6 +57,14 @@ const SCHEMA_SCENARIOS = {
       ...(allowEmptyValue !== undefined ? { allowEmptyValue } : {}),
     };
   },
+
+  'mixed primitive': (props, allowEmptyValue) => {
+    return {
+      type: ['string', 'number'],
+      ...props,
+      ...(allowEmptyValue !== undefined ? { allowEmptyValue } : {}),
+    };
+  },
 };
 
 function buildSchemaCore(opts: Parameters<typeof generateJSONSchemaFixture>[0] = {}) {
@@ -89,7 +97,10 @@ function buildSchemaCore(opts: Parameters<typeof generateJSONSchemaFixture>[0] =
   return props;
 }
 
-function generateScenarioName(testCase: string, opts: Parameters<typeof generateJSONSchemaFixture>[0] = {}) {
+function generateScenarioName(
+  scenario: keyof typeof SCHEMA_SCENARIOS,
+  opts: Parameters<typeof generateJSONSchemaFixture>[0] = {}
+) {
   const caseOptions: string[] = [];
 
   if (opts.allowEmptyValue !== undefined) caseOptions.push(`allowEmptyValue[${opts.allowEmptyValue}]`);
@@ -98,7 +109,7 @@ function generateScenarioName(testCase: string, opts: Parameters<typeof generate
   if (opts.example !== undefined) caseOptions.push(`example[${opts.example}]`);
   if (opts.examples !== undefined) caseOptions.push(`examples[${opts.examples}]`);
 
-  return `${testCase}:${caseOptions.join('')}`;
+  return `${scenario}:${caseOptions.join('')}`;
 }
 
 export default function generateJSONSchemaFixture(
@@ -113,14 +124,18 @@ export default function generateJSONSchemaFixture(
   const props = buildSchemaCore(opts);
   const schemas: { scenario: string; schema: any }[] = [];
 
-  const getScenario = (scenario: string, allowEmptyValue?: boolean) => {
+  const getScenario = (scenario: keyof typeof SCHEMA_SCENARIOS, allowEmptyValue?: boolean) => {
     return {
       scenario: generateScenarioName(scenario, { ...opts, allowEmptyValue }),
       schema: SCHEMA_SCENARIOS[scenario](props, allowEmptyValue),
     };
   };
 
-  const getPolymorphismScenario = (polyType: string, scenario: string, allowEmptyValue?: boolean) => {
+  const getPolymorphismScenario = (
+    polyType: string,
+    scenario: keyof typeof SCHEMA_SCENARIOS,
+    allowEmptyValue?: boolean
+  ) => {
     return {
       scenario: `${polyType}:${generateScenarioName(scenario, { ...opts, allowEmptyValue })}`,
       schema: {
@@ -154,7 +169,12 @@ export default function generateJSONSchemaFixture(
     getScenario('primitive string'),
     getPolymorphismScenario('oneOf', 'primitive string'),
     getPolymorphismScenario('allOf', 'primitive string'),
-    getPolymorphismScenario('anyOf', 'primitive string')
+    getPolymorphismScenario('anyOf', 'primitive string'),
+
+    getScenario('mixed primitive'),
+    getPolymorphismScenario('oneOf', 'mixed primitive'),
+    getPolymorphismScenario('allOf', 'mixed primitive'),
+    getPolymorphismScenario('anyOf', 'mixed primitive')
   );
 
   if (opts.allowEmptyValue !== undefined) {
@@ -181,7 +201,13 @@ export default function generateJSONSchemaFixture(
       getScenario('primitive string', false),
       getPolymorphismScenario('oneOf', 'primitive string', true),
       getPolymorphismScenario('allOf', 'primitive string', false),
-      getPolymorphismScenario('anyOf', 'primitive string', false)
+      getPolymorphismScenario('anyOf', 'primitive string', false),
+
+      getScenario('mixed primitive', true),
+      getScenario('mixed primitive', false),
+      getPolymorphismScenario('oneOf', 'mixed primitive', true),
+      getPolymorphismScenario('allOf', 'mixed primitive', false),
+      getPolymorphismScenario('anyOf', 'mixed primitive', false)
     );
   }
 

--- a/__tests__/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
+++ b/__tests__/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
@@ -35,6 +35,19 @@ exports[`\`allowEmptyValue\` support should support allowEmptyValue 1`] = `
       },
       "type": "array",
     },
+    "allOf:mixed primitive:allowEmptyValue[false]default[]": {
+      "allowEmptyValue": false,
+      "type": [
+        "string",
+        "number",
+      ],
+    },
+    "allOf:mixed primitive:default[]": {
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "allOf:object with primitives and mixed arrays:allowEmptyValue[false]default[]": {
       "properties": {
         "param1": {
@@ -155,6 +168,40 @@ exports[`\`allowEmptyValue\` support should support allowEmptyValue 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "anyOf:mixed primitive:allowEmptyValue[false]default[]": {
+      "anyOf": [
+        {
+          "allowEmptyValue": false,
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "allowEmptyValue": false,
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+      ],
+    },
+    "anyOf:mixed primitive:default[]": {
+      "anyOf": [
+        {
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -311,6 +358,27 @@ exports[`\`allowEmptyValue\` support should support allowEmptyValue 1`] = `
       },
       "type": "array",
     },
+    "mixed primitive:allowEmptyValue[false]default[]": {
+      "allowEmptyValue": false,
+      "type": [
+        "string",
+        "number",
+      ],
+    },
+    "mixed primitive:allowEmptyValue[true]default[]": {
+      "allowEmptyValue": true,
+      "default": "",
+      "type": [
+        "string",
+        "number",
+      ],
+    },
+    "mixed primitive:default[]": {
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "object with primitives and mixed arrays:allowEmptyValue[false]default[]": {
       "properties": {
         "param1": {
@@ -449,6 +517,42 @@ exports[`\`allowEmptyValue\` support should support allowEmptyValue 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "oneOf:mixed primitive:allowEmptyValue[true]default[]": {
+      "oneOf": [
+        {
+          "allowEmptyValue": true,
+          "default": "",
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "allowEmptyValue": true,
+          "default": "",
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+      ],
+    },
+    "oneOf:mixed primitive:default[]": {
+      "oneOf": [
+        {
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -597,6 +701,13 @@ exports[`\`default\` support should support a default of \`false\` 1`] = `
       },
       "type": "array",
     },
+    "allOf:mixed primitive:default[false]": {
+      "default": false,
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "allOf:object with primitives and mixed arrays:default[false]": {
       "properties": {
         "param1": {
@@ -659,6 +770,24 @@ exports[`\`default\` support should support a default of \`false\` 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "anyOf:mixed primitive:default[false]": {
+      "anyOf": [
+        {
+          "default": false,
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "default": false,
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -733,6 +862,13 @@ exports[`\`default\` support should support a default of \`false\` 1`] = `
       },
       "type": "array",
     },
+    "mixed primitive:default[false]": {
+      "default": false,
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "object with primitives and mixed arrays:default[false]": {
       "properties": {
         "param1": {
@@ -791,6 +927,24 @@ exports[`\`default\` support should support a default of \`false\` 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "oneOf:mixed primitive:default[false]": {
+      "oneOf": [
+        {
+          "default": false,
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "default": false,
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -877,6 +1031,13 @@ exports[`\`default\` support should support default 1`] = `
       },
       "type": "array",
     },
+    "allOf:mixed primitive:default[example default]": {
+      "default": "example default",
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "allOf:object with primitives and mixed arrays:default[example default]": {
       "properties": {
         "param1": {
@@ -939,6 +1100,24 @@ exports[`\`default\` support should support default 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "anyOf:mixed primitive:default[example default]": {
+      "anyOf": [
+        {
+          "default": "example default",
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "default": "example default",
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -1013,6 +1192,13 @@ exports[`\`default\` support should support default 1`] = `
       },
       "type": "array",
     },
+    "mixed primitive:default[example default]": {
+      "default": "example default",
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "object with primitives and mixed arrays:default[example default]": {
       "properties": {
         "param1": {
@@ -1071,6 +1257,24 @@ exports[`\`default\` support should support default 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "oneOf:mixed primitive:default[example default]": {
+      "oneOf": [
+        {
+          "default": "example default",
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "default": "example default",
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -1157,6 +1361,13 @@ exports[`\`description\` support should support description 1`] = `
       },
       "type": "array",
     },
+    "allOf:mixed primitive:description[example description]": {
+      "description": "example description",
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "allOf:object with primitives and mixed arrays:description[example description]": {
       "properties": {
         "param1": {
@@ -1219,6 +1430,24 @@ exports[`\`description\` support should support description 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "anyOf:mixed primitive:description[example description]": {
+      "anyOf": [
+        {
+          "description": "example description",
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "description": "example description",
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },
@@ -1293,6 +1522,13 @@ exports[`\`description\` support should support description 1`] = `
       },
       "type": "array",
     },
+    "mixed primitive:description[example description]": {
+      "description": "example description",
+      "type": [
+        "string",
+        "number",
+      ],
+    },
     "object with primitives and mixed arrays:description[example description]": {
       "properties": {
         "param1": {
@@ -1351,6 +1587,24 @@ exports[`\`description\` support should support description 1`] = `
             "type": "array",
           },
           "type": "array",
+        },
+      ],
+    },
+    "oneOf:mixed primitive:description[example description]": {
+      "oneOf": [
+        {
+          "description": "example description",
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "description": "example description",
+          "type": [
+            "string",
+            "number",
+          ],
         },
       ],
     },


### PR DESCRIPTION
## 🧰 Changes

This reworks some of the work I did in https://github.com/readmeio/oas/pull/760.

* [ ] `{ type: ['string', 'null'] }` is no longer transformed into `{ type: 'string', nullable: true }`.
* [ ] `type: null` is now being converted to `type: 'null'`.
* [ ] If a mixed type contains an `array` or `object` that non-primitive is now moved into an `oneOf`.
* [ ] Added unit tests for `const` support.