### PR TITLE
feat: additional tweaks to json schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## <small>20.8.1 (2023-05-04)</small>
+
+* feat: additional tweaks to json schema mixed type handling (#761) ([57d4442](https://github.com/readmeio/oas/commit/57d4442)), closes [#761](https://github.com/readmeio/oas/issues/761)
+
+
+
 ## 20.8.0 (2023-05-03)
 
 * feat: improved support for mixed types and `nullable` (#760) ([5eff5c4](https://github.com/readmeio/oas/commit/5eff5c4)), closes [#760](https://github.com/readmeio/oas/issues/760)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "memoizee": "^0.4.14",
         "oas-normalize": "^8.4.0",
         "openapi-types": "^12.1.0",
-        "path-to-regexp": "^6.2.0"
+        "path-to-regexp": "^6.2.0",
+        "remove-undefined-objects": "^2.0.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.6.1",
@@ -8055,6 +8056,14 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/remove-undefined-objects": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-2.0.2.tgz",
+      "integrity": "sha512-b6x4MUtR4YBW1aCoGx3tE4mA2PFjiXSmtSdNmLexQzUdZa4ybnJAItXLKpkcVgCUJIzJtk2DFG402sMSEMlonQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -15339,6 +15348,11 @@
           "dev": true
         }
       }
+    },
+    "remove-undefined-objects": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remove-undefined-objects/-/remove-undefined-objects-2.0.2.tgz",
+      "integrity": "sha512-b6x4MUtR4YBW1aCoGx3tE4mA2PFjiXSmtSdNmLexQzUdZa4ybnJAItXLKpkcVgCUJIzJtk2DFG402sMSEMlonQ=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oas",
-  "version": "20.8.0",
+  "version": "20.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oas",
-      "version": "20.8.0",
+      "version": "20.8.1",
       "license": "MIT",
       "dependencies": {
         "@readme/json-schema-ref-parser": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "memoizee": "^0.4.14",
     "oas-normalize": "^8.4.0",
     "openapi-types": "^12.1.0",
-    "path-to-regexp": "^6.2.0"
+    "path-to-regexp": "^6.2.0",
+    "remove-undefined-objects": "^2.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oas",
-  "version": "20.8.0",
+  "version": "20.8.1",
   "description": "Comprehensive tooling for working with OpenAPI definitions",
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,3 +1,12 @@
+import type { SchemaObject } from 'rmoas.types';
+
+export function hasSchemaType(schema: SchemaObject, discriminator: 'array' | 'object') {
+  if (Array.isArray(schema.type)) {
+    return schema.type.includes(discriminator);
+  }
+
+  return schema.type === discriminator;
+}
 export function isPrimitive(val: unknown): boolean {
   return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
 }

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -110,7 +110,7 @@ function sampleFromSchema(
     }
   }
 
-  if (type === 'object') {
+  if (type === 'object' || (Array.isArray(type) && type.includes('object'))) {
     const props = objectify(properties);
     const obj: Record<string, any> = {};
     // eslint-disable-next-line no-restricted-syntax
@@ -145,7 +145,7 @@ function sampleFromSchema(
     return obj;
   }
 
-  if (type === 'array') {
+  if (type === 'array' || (Array.isArray(type) && type.includes('array'))) {
     // `items` should always be present on arrays, but if it isn't we should at least do our best
     // to support its absence.
     if (typeof items === 'undefined') {


### PR DESCRIPTION
## 🧰 Changes

* [x] Descriptions are now retained when we explode mixed types containing primitives and non-primitives.
* [x] Updated handling throughout the JSON Schema generator for handling if `type` is a string or an array.
* [x] Added support for translating `nullable` into a `type: 'null'` or `type: [<existing type>, 'null']` schema.
* [x] Fixed some quirks where we'd unnecessary explode `type: [array, null]` into a `oneOf`.
