### PR TITLE
feat: split mixed json schema types with booleans out into a oneOf

### DIFF
--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -67,6 +67,35 @@ describe('`type` support', () => {
       });
     });
 
+    describe('booleans', () => {
+      it('should turn a mixed primitive type with a boolean into a oneOf', () => {
+        expect(toJSONSchema({ type: ['string', 'boolean'], description: 'tktk' })).toStrictEqual({
+          oneOf: [
+            { type: 'string', description: 'tktk' },
+            { type: 'boolean', description: 'tktk' },
+          ],
+        });
+      });
+
+      it('should turn a mixed primitive type with a boolean and an array into a oneOf', () => {
+        expect(
+          toJSONSchema({
+            type: ['string', 'boolean', 'array'],
+            description: 'tktk',
+            items: {
+              type: 'string',
+            },
+          })
+        ).toStrictEqual({
+          oneOf: [
+            { type: 'string', description: 'tktk' },
+            { type: 'array', description: 'tktk', items: { type: 'string' } },
+            { type: 'boolean', description: 'tktk' },
+          ],
+        });
+      });
+    });
+
     describe('non-primitive', () => {
       it('should explode a mixed non-primitive into a oneOf', () => {
         expect(

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -456,7 +456,7 @@ export default function toJSONSchema(
       // We don't need `type: [<type>]` when we can just as easily make it `type: <type>`.
       if (schema.type.length === 1) {
         schema.type = schema.type.shift();
-      } else if (schema.type.includes('array') || schema.type.includes('object')) {
+      } else if (schema.type.includes('array') || schema.type.includes('boolean') || schema.type.includes('object')) {
         // If we have a `null` type but there's only two types present then we can remove `null`
         // as an option and flag the whole schema as `nullable`.
         const isNullable = schema.type.includes('null');
@@ -468,10 +468,11 @@ export default function toJSONSchema(
           // we're moving them into a `oneOf`.
           const nonPrimitives: any[] = [];
 
-          // Because we're moving an `array` and/or an `object` into a `oneOf` we also want to take
-          // with it its specific properties that maybe present on our current schema.
+          // Because arrays, booleans, and objects are not compatible with any other schem type
+          // other than null we're moving them into an isolated `oneOf`, and as such want to take
+          // with it its specific properties that may be present on our current schema.
           Object.entries({
-            // json-schema.org/understanding-json-schema/reference/array.html
+            // https://json-schema.org/understanding-json-schema/reference/array.html
             array: [
               'additionalItems',
               'contains',
@@ -482,6 +483,11 @@ export default function toJSONSchema(
               'minItems',
               'prefixItems',
               'uniqueItems',
+            ],
+
+            // https://json-schema.org/understanding-json-schema/reference/boolean.html
+            boolean: [
+              // Booleans don't have any boolean-specific properties.
             ],
 
             // https://json-schema.org/understanding-json-schema/reference/object.html
@@ -521,7 +527,7 @@ export default function toJSONSchema(
             nonPrimitives.push(reducedSchema);
           });
 
-          schema.type = schema.type.filter(t => t !== 'array' && t !== 'object');
+          schema.type = schema.type.filter(t => t !== 'array' && t !== 'boolean' && t !== 'object');
           if (schema.type.length === 1) {
             schema.type = schema.type.shift();
           }


### PR DESCRIPTION
## 🧰 Changes

Because booleans are a non-compatible schema with strings and numbers if we have a mixed JSON Schema type like `[string, boolean]` we'll now split them into their individual `oneOf` schemas like we do already with `array` and `object`.
