### PR TITLE
feat: addition of new JSON Schema generation options for hiding r/o schemas

### DIFF
--- a/__tests__/__datasets__/readonly-writeonly.json
+++ b/__tests__/__datasets__/readonly-writeonly.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
     "title": "Operation with readOnly and writeOnly properties",
     "version": "1.0"
@@ -95,6 +95,58 @@
           }
         }
       }
+    },
+    "/readOnly": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/readOnly"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/readOnly-partially"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/writeOnly": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/writeOnly"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/writeOnly-partially"
+              }
+            }
+          },
+          "required": true
+        }
+      }
     }
   },
   "components": {
@@ -143,6 +195,96 @@
           "end_hour": {
             "type": "string",
             "readOnly": true
+          }
+        }
+      },
+      "readOnly-partially": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid",
+            "readOnly": true
+          }
+        }
+      },
+      "readOnly": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "readOnly": true
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid",
+            "readOnly": true
+          },
+          "start_date": {
+            "type": "string",
+            "format": "YYYY-MM-DD",
+            "readOnly": true
+          },
+          "end_date": {
+            "type": "string",
+            "format": "YYYY-MM-DD",
+            "readOnly": true
+          },
+          "start_hour": {
+            "type": "string",
+            "readOnly": true
+          },
+          "end_hour": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
+      },
+      "writeOnly-partially": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid",
+            "writeOnly": true
+          }
+        }
+      },
+      "writeOnly": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "product_id": {
+            "type": "string",
+            "format": "uuid",
+            "writeOnly": true
+          },
+          "start_date": {
+            "type": "string",
+            "format": "YYYY-MM-DD",
+            "writeOnly": true
+          },
+          "end_date": {
+            "type": "string",
+            "format": "YYYY-MM-DD",
+            "writeOnly": true
+          },
+          "start_hour": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "end_hour": {
+            "type": "string",
+            "writeOnly": true
           }
         }
       }

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -1,4 +1,5 @@
 import type { CallbackExamples } from './operation/get-callback-examples';
+import type { getParametersAsJSONSchemaOptions } from './operation/get-parameters-as-json-schema';
 import type { RequestBodyExamples } from './operation/get-requestbody-examples';
 import type { ResponseExamples } from './operation/get-response-examples';
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
@@ -472,39 +473,7 @@ export default class Operation {
    * parameter available on the operation.
    *
    */
-  getParametersAsJSONSchema(
-    opts: {
-      /**
-       * Contains an object of user defined schema defaults.
-       */
-      globalDefaults?: Record<string, unknown>;
-
-      /**
-       * If you wish to include discriminator mapping `$ref` components alongside your
-       * `discriminator` in schemas. Defaults to `true`.
-       */
-      includeDiscriminatorMappingRefs?: boolean;
-
-      /**
-       * If you want the output to be two objects: body (contains `body` and `formData` JSON
-       * Schema) and metadata (contains `path`, `query`, `cookie`, and `header`).
-       */
-      mergeIntoBodyAndMetadata?: boolean;
-
-      /**
-       * If you wish to **not** split out deprecated properties into a separate `deprecatedProps`
-       * object.
-       */
-      retainDeprecatedProperties?: boolean;
-
-      /**
-       * With a transformer you can transform any data within a given schema, like say if you want
-       * to rewrite a potentially unsafe `title` that might be eventually used as a JS variable
-       * name, just make sure to return your transformed schema.
-       */
-      transformer?: (schema: RMOAS.SchemaObject) => RMOAS.SchemaObject;
-    } = {}
-  ) {
+  getParametersAsJSONSchema(opts: getParametersAsJSONSchemaOptions = {}) {
     return getParametersAsJSONSchema(this, this.api, {
       includeDiscriminatorMappingRefs: true,
       transformer: (s: RMOAS.SchemaObject) => s,

--- a/src/operation/get-parameters-as-json-schema.ts
+++ b/src/operation/get-parameters-as-json-schema.ts
@@ -7,8 +7,6 @@ import { isPrimitive } from '../lib/helpers';
 import matchesMimetype from '../lib/matches-mimetype';
 import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
 
-const isJSON = matchesMimetype.json;
-
 export interface SchemaWrapper {
   $schema?: string;
   type: string;
@@ -35,16 +33,52 @@ export const types: Record<keyof OASDocument, string> = {
   metadata: 'Metadata', // This a special type reserved for https://npm.im/api
 };
 
+export interface getParametersAsJSONSchemaOptions {
+  /**
+   * Contains an object of user defined schema defaults.
+   */
+  globalDefaults?: Record<string, unknown>;
+
+  /**
+   * If you wish to include discriminator mapping `$ref` components alongside your
+   * `discriminator` in schemas. Defaults to `true`.
+   */
+  includeDiscriminatorMappingRefs?: boolean;
+
+  /**
+   * If you wish to hide properties that are marked as being `readOnly`.
+   */
+  hideReadOnlyProperties?: boolean;
+
+  /**
+   * If you wish to hide properties that are marked as being `writeOnly`.
+   */
+  hideWriteOnlyProperties?: boolean;
+
+  /**
+   * If you want the output to be two objects: body (contains `body` and `formData` JSON
+   * Schema) and metadata (contains `path`, `query`, `cookie`, and `header`).
+   */
+  mergeIntoBodyAndMetadata?: boolean;
+
+  /**
+   * If you wish to **not** split out deprecated properties into a separate `deprecatedProps`
+   * object.
+   */
+  retainDeprecatedProperties?: boolean;
+
+  /**
+   * With a transformer you can transform any data within a given schema, like say if you want
+   * to rewrite a potentially unsafe `title` that might be eventually used as a JS variable
+   * name, just make sure to return your transformed schema.
+   */
+  transformer?: (schema: SchemaObject) => SchemaObject;
+}
+
 export default function getParametersAsJSONSchema(
   operation: Operation,
   api: OASDocument,
-  opts?: {
-    globalDefaults?: Record<string, unknown>;
-    includeDiscriminatorMappingRefs?: boolean;
-    mergeIntoBodyAndMetadata?: boolean;
-    retainDeprecatedProperties?: boolean;
-    transformer?: (schema: SchemaObject) => SchemaObject;
-  }
+  opts?: getParametersAsJSONSchemaOptions
 ) {
   let hasCircularRefs = false;
   let hasDiscriminatorMappingRefs = false;
@@ -89,6 +123,8 @@ export default function getParametersAsJSONSchema(
     (deprecatedBody.properties as Record<string, SchemaObject>) = allDeprecatedProps;
     const deprecatedSchema = toJSONSchema(deprecatedBody, {
       globalDefaults: opts.globalDefaults,
+      hideReadOnlyProperties: opts.hideReadOnlyProperties,
+      hideWriteOnlyProperties: opts.hideWriteOnlyProperties,
       prevSchemas: [],
       refLogger,
       transformer: opts.transformer,
@@ -151,6 +187,8 @@ export default function getParametersAsJSONSchema(
 
     const cleanedSchema = toJSONSchema(requestSchema, {
       globalDefaults: opts.globalDefaults,
+      hideReadOnlyProperties: opts.hideReadOnlyProperties,
+      hideWriteOnlyProperties: opts.hideWriteOnlyProperties,
       prevSchemas,
       refLogger,
       transformer: opts.transformer,
@@ -209,6 +247,8 @@ export default function getParametersAsJSONSchema(
           const componentSchema = cloneObject(api.components[componentType][schemaName]);
           components[componentType][schemaName] = toJSONSchema(componentSchema as SchemaObject, {
             globalDefaults: opts.globalDefaults,
+            hideReadOnlyProperties: opts.hideReadOnlyProperties,
+            hideWriteOnlyProperties: opts.hideWriteOnlyProperties,
             refLogger,
             transformer: opts.transformer,
           });
@@ -270,6 +310,8 @@ export default function getParametersAsJSONSchema(
             const interimSchema = toJSONSchema(currentSchema, {
               currentLocation: `/${current.name}`,
               globalDefaults: opts.globalDefaults,
+              hideReadOnlyProperties: opts.hideReadOnlyProperties,
+              hideWriteOnlyProperties: opts.hideWriteOnlyProperties,
               refLogger,
               transformer: opts.transformer,
             });
@@ -293,7 +335,7 @@ export default function getParametersAsJSONSchema(
               } else {
                 // We should always try to prioritize `application/json` over any other possible
                 // content that might be present on this schema.
-                const jsonLikeContentTypes = contentKeys.filter(k => isJSON(k));
+                const jsonLikeContentTypes = contentKeys.filter(k => matchesMimetype.json(k));
                 if (jsonLikeContentTypes.length) {
                   contentType = jsonLikeContentTypes[0];
                 } else {
@@ -322,6 +364,8 @@ export default function getParametersAsJSONSchema(
                 const interimSchema = toJSONSchema(currentSchema, {
                   currentLocation: `/${current.name}`,
                   globalDefaults: opts.globalDefaults,
+                  hideReadOnlyProperties: opts.hideReadOnlyProperties,
+                  hideWriteOnlyProperties: opts.hideWriteOnlyProperties,
                   refLogger,
                   transformer: opts.transformer,
                 });

--- a/src/operation/get-response-as-json-schema.ts
+++ b/src/operation/get-response-as-json-schema.ts
@@ -93,6 +93,11 @@ export default function getResponseAsJSONSchema(
   statusCode: string | number,
   opts?: {
     includeDiscriminatorMappingRefs?: boolean;
+    /**
+     * With a transformer you can transform any data within a given schema, like say if you want
+     * to rewrite a potentially unsafe `title` that might be eventually used as a JS variable
+     * name, just make sure to return your transformed schema.
+     */
     transformer?: (schema: SchemaObject) => SchemaObject;
   }
 ) {


### PR DESCRIPTION
## 🧰 Changes

We've got a fun quirk in our API Explorer where if you have a `requestBody` that just happens to have a schema full of entirely `readOnly` properties we end up rendering a blank form like this:

![Screen Shot 2023-06-30 at 3 00 59 PM](https://github.com/readmeio/oas/assets/33762/82c88676-43f4-4720-811a-a75eed825dfc)

Reason this is happening is because the form itself does its own "is this a readOnly schema? then dont render anything" and there's no way for the form to know if a schema is **completely** readOnly until it's its shell (which you see in that screenshot).

The work I've done here is to add two new options to `Operation.getParametersAsJSONSchema()`, `hideReadOnlyProperties` and `hideWriteOnlyProperties`, that will allow us to completely hide these unwanted schemas from our generated JSON Schema object -- which also gives us the flexibility to completely eliminate a `requestBody` schema from being surfaced at all if it can't be used.