### PR TITLE
feat: surface what the default value is for an enum 

### DIFF
--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -3,6 +3,7 @@ import type { JSONSchema4, JSONSchema7, JSONSchema7Definition, JSONSchema7TypeNa
 
 import Oas from '../../src';
 import toJSONSchema from '../../src/lib/openapi-to-json-schema';
+import createOas from '../__fixtures__/create-oas';
 import generateJSONSchemaFixture from '../__fixtures__/json-schema';
 
 let petstore: Oas;
@@ -842,6 +843,67 @@ describe('`description` support', () => {
     };
 
     expect(toJSONSchema(schema)).toMatchSnapshot();
+  });
+
+  it('should add defaults for enums if default is present', () => {
+    const oas = createOas({
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              description: 'Provides details about the CP codes available for your contract.\n',
+              properties: {
+                required_enum_default: {
+                  type: 'string',
+                  enum: ['CP', 'NON_CP'],
+                  default: 'NON_CP',
+                  description: 'Enumed property with a default: `NON_CP`\n',
+                },
+                optional_enum_default: {
+                  type: 'string',
+                  enum: ['CP', 'NON_CP'],
+                  default: 'CP',
+                  description: 'Enumed property with a default: `NON_CP`\n',
+                },
+                enum_no_default: {
+                  type: 'string',
+                  enum: ['CP', 'NON_CP'],
+                  description: 'Enumed property without a default.\n',
+                },
+              },
+              required: ['required_enum_default'],
+            },
+          },
+        },
+      },
+    });
+
+    expect(oas.operation('/', 'get').getParametersAsJSONSchema()[0].schema).toStrictEqual({
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'object',
+      description: 'Provides details about the CP codes available for your contract.\n',
+      properties: {
+        required_enum_default: {
+          type: 'string',
+          enum: ['CP', 'NON_CP'],
+          default: 'NON_CP',
+          description: 'Enumed property with a default: `NON_CP`\n\nDefault: NON_CP',
+        },
+        optional_enum_default: {
+          type: 'string',
+          enum: ['CP', 'NON_CP'],
+          default: 'CP',
+          description: 'Enumed property with a default: `NON_CP`\n\nDefault: CP',
+        },
+        enum_no_default: {
+          type: 'string',
+          enum: ['CP', 'NON_CP'],
+          description: 'Enumed property without a default.\n',
+        },
+      },
+      required: ['required_enum_default'],
+    });
   });
 });
 

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -137,6 +137,7 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paramet
           "items": {
             "default": "available",
             "deprecated": true,
+            "description": "default: available",
             "enum": [
               "available",
               "pending",

--- a/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/__tests__/operation/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -137,7 +137,7 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paramet
           "items": {
             "default": "available",
             "deprecated": true,
-            "description": "default: available",
+            "description": "Default: available",
             "enum": [
               "available",
               "pending",

--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -493,67 +493,6 @@ describe('descriptions', () => {
       required: ['pathId'],
     });
   });
-
-  it('should add defaults for enums if default is present', () => {
-    const oas = createOas({
-      requestBody: {
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              description: 'Provides details about the CP codes available for your contract.\n',
-              properties: {
-                required_enum_default: {
-                  type: 'string',
-                  enum: ['CP', 'NON_CP'],
-                  default: 'NON_CP',
-                  description: 'Enumed property with a default: `NON_CP`\n',
-                },
-                optional_enum_default: {
-                  type: 'string',
-                  enum: ['CP', 'NON_CP'],
-                  default: 'CP',
-                  description: 'Enumed property with a default: `NON_CP`\n',
-                },
-                enum_no_default: {
-                  type: 'string',
-                  enum: ['CP', 'NON_CP'],
-                  description: 'Enumed property without a default.\n',
-                },
-              },
-              required: ['required_enum_default'],
-            },
-          },
-        },
-      },
-    });
-
-    expect(oas.operation('/', 'get').getParametersAsJSONSchema()[0].schema).toStrictEqual({
-      $schema: 'http://json-schema.org/draft-04/schema#',
-      type: 'object',
-      description: 'Provides details about the CP codes available for your contract.\n',
-      properties: {
-        required_enum_default: {
-          type: 'string',
-          enum: ['CP', 'NON_CP'],
-          default: 'NON_CP',
-          description: 'Enumed property with a default: `NON_CP`\n default: NON_CP',
-        },
-        optional_enum_default: {
-          type: 'string',
-          enum: ['CP', 'NON_CP'],
-          default: 'CP',
-          description: 'Enumed property with a default: `NON_CP`\n default: CP',
-        },
-        enum_no_default: {
-          type: 'string',
-          enum: ['CP', 'NON_CP'],
-          description: 'Enumed property without a default.\n',
-        },
-      },
-      required: ['required_enum_default'],
-    });
-  });
 });
 
 describe('required', () => {

--- a/__tests__/operation/get-parameters-as-json-schema.test.ts
+++ b/__tests__/operation/get-parameters-as-json-schema.test.ts
@@ -493,6 +493,67 @@ describe('descriptions', () => {
       required: ['pathId'],
     });
   });
+
+  it('should add defaults for enums if default is present', () => {
+    const oas = createOas({
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              description: 'Provides details about the CP codes available for your contract.\n',
+              properties: {
+                required_enum_default: {
+                  type: 'string',
+                  enum: ['CP', 'NON_CP'],
+                  default: 'NON_CP',
+                  description: 'Enumed property with a default: `NON_CP`\n',
+                },
+                optional_enum_default: {
+                  type: 'string',
+                  enum: ['CP', 'NON_CP'],
+                  default: 'CP',
+                  description: 'Enumed property with a default: `NON_CP`\n',
+                },
+                enum_no_default: {
+                  type: 'string',
+                  enum: ['CP', 'NON_CP'],
+                  description: 'Enumed property without a default.\n',
+                },
+              },
+              required: ['required_enum_default'],
+            },
+          },
+        },
+      },
+    });
+
+    expect(oas.operation('/', 'get').getParametersAsJSONSchema()[0].schema).toStrictEqual({
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'object',
+      description: 'Provides details about the CP codes available for your contract.\n',
+      properties: {
+        required_enum_default: {
+          type: 'string',
+          enum: ['CP', 'NON_CP'],
+          default: 'NON_CP',
+          description: 'Enumed property with a default: `NON_CP`\n default: NON_CP',
+        },
+        optional_enum_default: {
+          type: 'string',
+          enum: ['CP', 'NON_CP'],
+          default: 'CP',
+          description: 'Enumed property with a default: `NON_CP`\n default: CP',
+        },
+        enum_no_default: {
+          type: 'string',
+          enum: ['CP', 'NON_CP'],
+          description: 'Enumed property without a default.\n',
+        },
+      },
+      required: ['required_enum_default'],
+    });
+  });
 });
 
 describe('required', () => {

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -786,6 +786,13 @@ export default function toJSONSchema(
 
   // Only add a default value if we actually have one.
   if ('default' in schema && typeof schema.default !== 'undefined') {
+    // If it's an enum, add the default to the description if it's not in the response schema.
+    if ('enum' in schema && !addEnumsToDescriptions) {
+      schema.description = schema.description
+        ? `${schema.description} default: ${schema.default}`
+        : `default: ${schema.default}`;
+    }
+
     if (('allowEmptyValue' in schema && schema.allowEmptyValue && schema.default === '') || schema.default !== '') {
       // If we have `allowEmptyValue` present, and the default is actually an empty string, let it
       // through as it's allowed.

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -786,11 +786,12 @@ export default function toJSONSchema(
 
   // Only add a default value if we actually have one.
   if ('default' in schema && typeof schema.default !== 'undefined') {
-    // If it's an enum, add the default to the description if it's not in the response schema.
+    // If it's an enum and not the response schema, add the default to the description.
+    // If there's an existing description, trim trailing new lines so it doesn't look ugly.
     if ('enum' in schema && !addEnumsToDescriptions) {
       schema.description = schema.description
-        ? `${schema.description} default: ${schema.default}`
-        : `default: ${schema.default}`;
+        ? `${schema.description.replace(/\n$/, '')}\n\nDefault: ${schema.default}`
+        : `Default: ${schema.default}`;
     }
 
     if (('allowEmptyValue' in schema && schema.allowEmptyValue && schema.default === '') || schema.default !== '') {


### PR DESCRIPTION
| 🚥 Fixes RM-7104 |
| :---------------- |

## 🧰 Changes

Currently, we don't surface what the default value is for an enum anywhere so users won't know if there is a default available or not aside from the default form state. This change adds the default value to the schema description so users can tell what the description is. 