### PR TITLE
feat(jsonschema): adding support for invalid `required: true` properties

### DIFF
--- a/__tests__/__fixtures__/json-schema.ts
+++ b/__tests__/__fixtures__/json-schema.ts
@@ -73,6 +73,7 @@ function buildSchemaCore(opts: Parameters<typeof generateJSONSchemaFixture>[0] =
     description?: string;
     example?: unknown;
     examples?: Record<string, unknown>;
+    required?: boolean;
   } = {};
   if (typeof opts.default === 'undefined' || opts.default === undefined) {
     // Should not add a default.
@@ -94,6 +95,10 @@ function buildSchemaCore(opts: Parameters<typeof generateJSONSchemaFixture>[0] =
     props.examples = opts.examples;
   }
 
+  if (opts.required !== undefined) {
+    props.required = opts.required;
+  }
+
   return props;
 }
 
@@ -108,6 +113,7 @@ function generateScenarioName(
   if (opts.description !== undefined) caseOptions.push(`description[${opts.description}]`);
   if (opts.example !== undefined) caseOptions.push(`example[${opts.example}]`);
   if (opts.examples !== undefined) caseOptions.push(`examples[${opts.examples}]`);
+  if (opts.required !== undefined) caseOptions.push(`required[${opts.required}]`);
 
   return `${scenario}:${caseOptions.join('')}`;
 }
@@ -119,6 +125,7 @@ export default function generateJSONSchemaFixture(
     description?: string;
     example?: unknown;
     examples?: Record<string, unknown>;
+    required?: boolean;
   } = {}
 ): SchemaObject {
   const props = buildSchemaCore(opts);

--- a/__tests__/lib/openapi-to-json-schema/__snapshots__/required.test.ts.snap
+++ b/__tests__/lib/openapi-to-json-schema/__snapshots__/required.test.ts.snap
@@ -1,0 +1,319 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`\`required\` support in \`openapi-to-json-schema\` should support complex cases of a nested \`required\` boolean 1`] = `
+{
+  "properties": {
+    "allOf:array of primitives:required[true]": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "allOf:array with an array of primitives:required[true]": {
+      "items": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "type": "array",
+    },
+    "allOf:mixed primitive:required[true]": {
+      "type": [
+        "string",
+        "number",
+      ],
+    },
+    "allOf:object with primitives and mixed arrays:required[true]": {
+      "properties": {
+        "param1": {
+          "type": "string",
+        },
+        "param2": {
+          "items": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "param1",
+      ],
+      "type": "object",
+    },
+    "allOf:primitive string:required[true]": {
+      "type": "string",
+    },
+    "anyOf:array of primitives:required[true]": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "anyOf:array with an array of primitives:required[true]": {
+      "anyOf": [
+        {
+          "items": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "anyOf:mixed primitive:required[true]": {
+      "anyOf": [
+        {
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+      ],
+    },
+    "anyOf:object with primitives and mixed arrays:required[true]": {
+      "anyOf": [
+        {
+          "properties": {
+            "param1": {
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "param1",
+          ],
+          "type": "object",
+        },
+        {
+          "properties": {
+            "param1": {
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "param1",
+          ],
+          "type": "object",
+        },
+      ],
+    },
+    "anyOf:primitive string:required[true]": {
+      "anyOf": [
+        {
+          "type": "string",
+        },
+        {
+          "type": "string",
+        },
+      ],
+    },
+    "array of primitives:required[true]": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "array with an array of primitives:required[true]": {
+      "items": {
+        "items": {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "type": "array",
+    },
+    "mixed primitive:required[true]": {
+      "type": [
+        "string",
+        "number",
+      ],
+    },
+    "object with primitives and mixed arrays:required[true]": {
+      "properties": {
+        "param1": {
+          "type": "string",
+        },
+        "param2": {
+          "items": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "param1",
+      ],
+      "type": "object",
+    },
+    "oneOf:array of primitives:required[true]": {
+      "oneOf": [
+        {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "oneOf:array with an array of primitives:required[true]": {
+      "oneOf": [
+        {
+          "items": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+        {
+          "items": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "type": "array",
+        },
+      ],
+    },
+    "oneOf:mixed primitive:required[true]": {
+      "oneOf": [
+        {
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+        {
+          "type": [
+            "string",
+            "number",
+          ],
+        },
+      ],
+    },
+    "oneOf:object with primitives and mixed arrays:required[true]": {
+      "oneOf": [
+        {
+          "properties": {
+            "param1": {
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "param1",
+          ],
+          "type": "object",
+        },
+        {
+          "properties": {
+            "param1": {
+              "type": "string",
+            },
+            "param2": {
+              "items": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "type": "array",
+            },
+          },
+          "required": [
+            "param1",
+          ],
+          "type": "object",
+        },
+      ],
+    },
+    "oneOf:primitive string:required[true]": {
+      "oneOf": [
+        {
+          "type": "string",
+        },
+        {
+          "type": "string",
+        },
+      ],
+    },
+    "primitive string:required[true]": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "primitive string:required[true]",
+    "allOf:primitive string:required[true]",
+    "mixed primitive:required[true]",
+    "allOf:mixed primitive:required[true]",
+  ],
+  "type": "object",
+}
+`;

--- a/__tests__/lib/openapi-to-json-schema/default.test.ts
+++ b/__tests__/lib/openapi-to-json-schema/default.test.ts
@@ -1,15 +1,7 @@
 import type { SchemaObject } from '../../../src/rmoas.types';
 
-import Oas from '../../../src';
 import toJSONSchema from '../../../src/lib/openapi-to-json-schema';
 import generateJSONSchemaFixture from '../../__fixtures__/json-schema';
-
-let petstore: Oas;
-
-beforeAll(async () => {
-  petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default).then(Oas.init);
-  await petstore.dereference();
-});
 
 describe('`default` support in `openapi-to-json-schema`', () => {
   it('should support default', () => {

--- a/__tests__/lib/openapi-to-json-schema/required.test.ts
+++ b/__tests__/lib/openapi-to-json-schema/required.test.ts
@@ -1,0 +1,128 @@
+import type { SchemaObject } from '../../../src/rmoas.types';
+
+import toJSONSchema from '../../../src/lib/openapi-to-json-schema';
+import generateJSONSchemaFixture from '../../__fixtures__/json-schema';
+
+describe('`required` support in `openapi-to-json-schema`', () => {
+  it('should support required', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      default: {
+        array_parent: [1, 2, 3],
+      },
+      properties: {
+        array: {
+          type: 'array',
+          default: ['foo', 'bar'],
+          items: {
+            type: 'string',
+          },
+        },
+        array_optional: {
+          type: 'array',
+          default: ['foo', 'bar'],
+          items: {
+            type: 'string',
+          },
+        },
+        array_parent: {
+          type: 'array',
+          items: {
+            type: 'number',
+          },
+        },
+      },
+      required: ['array'],
+    };
+
+    const compiled = toJSONSchema(schema);
+    expect(compiled.required).toStrictEqual(['array']);
+  });
+
+  describe('`required` boolean quirks', () => {
+    it('should support a nested object `required` boolean', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          buster: {
+            type: 'string',
+            required: true,
+          },
+        },
+      };
+
+      const compiled = toJSONSchema(schema);
+      expect(compiled).toStrictEqual({
+        type: 'object',
+        properties: {
+          buster: {
+            type: 'string',
+          },
+        },
+        required: ['buster'],
+      });
+    });
+
+    it('should not support a `required` boolean in a primitive array `items`', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          arr: {
+            type: 'array',
+            items: {
+              type: 'string',
+              required: true,
+            },
+          },
+        },
+      };
+
+      expect(toJSONSchema(schema)).toStrictEqual({
+        type: 'object',
+        properties: {
+          arr: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      });
+    });
+
+    it('should add a nested `required` boolea into an already existing parent `required` array', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          age: {
+            type: 'number',
+          },
+          buster: {
+            required: true,
+            type: 'string',
+          },
+        },
+        required: ['age'],
+      };
+
+      const compiled = toJSONSchema(schema);
+      expect(compiled).toStrictEqual({
+        type: 'object',
+        properties: {
+          age: {
+            type: 'number',
+          },
+          buster: {
+            type: 'string',
+          },
+        },
+        required: ['age', 'buster'],
+      });
+    });
+  });
+
+  it('should support complex cases of a nested `required` boolean', () => {
+    const schema: SchemaObject = generateJSONSchemaFixture({ required: true });
+    expect(toJSONSchema(schema)).toMatchSnapshot();
+  });
+});

--- a/__tests__/lib/openapi-to-json-schema/required.test.ts
+++ b/__tests__/lib/openapi-to-json-schema/required.test.ts
@@ -90,7 +90,7 @@ describe('`required` support in `openapi-to-json-schema`', () => {
       });
     });
 
-    it('should add a nested `required` boolea into an already existing parent `required` array', () => {
+    it('should add a nested `required` boolean into an already existing parent `required` array', () => {
       const schema: SchemaObject = {
         type: 'object',
         properties: {

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -738,10 +738,10 @@ export default function toJSONSchema(
 
               /**
                * JSON Schema does not have any support for `required: <boolean>` but because some
-               * of our users do this, and it does not throw OpenAPI validation becuase of some
-               * extremely loose typings around `schema` in the official JSON Schema definitions
-               * that the OAI offers, we're opting to support these users and upgrade their invalid
-               * `required` definitions into ones that our tooling can interpret.
+               * of our users do this, and it does not throw OpenAPI validation errors thanks to
+               * some extremely loose typings around `schema` in the official JSON Schema
+               * definitions that the OAI offers, we're opting to support these users and upgrade
+               * their invalid `required` definitions into ones that our tooling can interpret.
                *
                * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.1/schema.json#L1114-L1121}
                */


### PR DESCRIPTION
| 🚥 Resolves RM-7587 |
| :---------------- |

## 🧰 Changes

JSON Schema does not have any support for `required: <boolean>` but because some of our users do this, and it does not throw OpenAPI validation because of some extremely loose typings around `schema` in the official JSON Schema definitions that the OAI offers[^1], we're opting to support these users and upgrade their invalid `required` definitions into ones that our tooling can interpret.

[^1]: https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.1/schema.json#L1114-L1121