### PR TITLE
fix: get response example return type

### DIFF
--- a/__tests__/operation/get-response-examples.test.ts
+++ b/__tests__/operation/get-response-examples.test.ts
@@ -1,3 +1,4 @@
+import type { MediaTypeExample } from '../../src/lib/get-mediatype-examples';
 import type * as RMOAS from '../../src/rmoas.types';
 
 import { beforeAll, describe, test, expect, it } from 'vitest';
@@ -71,7 +72,7 @@ test('should do its best at handling circular schemas', async () => {
   //    offsetAfter: { id: 'string', rules: { transitions: [ undefined ] } },
   //    offsetBefore: { id: 'string', rules: { transitions: [ undefined ] } }
   //  }
-  expect((examples[0] as Record<string, RMOAS.MediaTypeObject>).mediaTypes['application/json']).toStrictEqual([
+  expect((examples[0] as Record<string, MediaTypeExample[]>).mediaTypes['application/json']).toStrictEqual([
     {
       value: {
         dateTime: expect.any(String),

--- a/src/operation/get-response-examples.ts
+++ b/src/operation/get-response-examples.ts
@@ -5,8 +5,9 @@ import getMediaTypeExamples from '../lib/get-mediatype-examples';
 import { isRef } from '../rmoas.types';
 
 export type ResponseExamples = {
-  mediaTypes: Record<string, RMOAS.MediaTypeObject>;
+  mediaTypes: Record<string, MediaTypeExample[]>;
   status: string;
+  onlyHeaders?: boolean;
 }[];
 
 /**


### PR DESCRIPTION
## 🧰 Changes

Hey 👋  I was using the library and noticed that the `getResponseExamples()` declares to use incorrect type. The returned data is not in the shape the type definition claims.

The function casts the returned type incorrectly in [L68](https://github.com/readmeio/oas/blob/main/src/operation/get-response-examples.ts#L68). The used type is shaped like

```ts
type ResponseExamples = {
  mediaTypes: Record<string, RMOAS.MediaTypeObject>;
  status: string;
}[];
```

but the code actually transforms it into type shaped like

```ts
interface MediaTypeExample {
  description?: string;
  summary?: string;
  title?: string;
  value: unknown;
}
```

The actually used type is defined in [L28](https://github.com/mskri/oas/blob/main/src/operation/get-response-examples.ts#L28) which is then returned from the `getResponseExamples()` in [L56](https://github.com/mskri/oas/blob/main/src/operation/get-response-examples.ts#L56).

The type is also missing `onlyHeaders?: boolean` which is added conditionally in [L57](https://github.com/readmeio/oas/blob/main/src/operation/get-response-examples.ts#L57).

Taking a look at the [tests](https://github.com/mskri/oas/blob/main/__tests__/operation/get-response-examples.test.ts)
for `getResponseExamples()` reveals that the `mediaTypes` type is expected to be `Record<string, MediaTypeExample[]>` instead of `Record<string, RMOAS.MediaTypeObject>`. The used tests data doesn't  conform to `RMOAS.MediaTypeObject`'s shape.

## 🧬 QA & Testing

Since the change is about the types there wasn't any changes to the existing tests. The tests ran green before the change and after change.
