### PR TITLE
fix: only add number bounds to number types

### DIFF
--- a/__tests__/lib/openapi-to-json-schema.test.ts
+++ b/__tests__/lib/openapi-to-json-schema.test.ts
@@ -774,6 +774,15 @@ describe('`format` support', () => {
       });
     });
   });
+
+  describe('does not generate constraints for non-numeric types', () => {
+    it('should not add `minimum` and `maximum` to string', () => {
+      expect(toJSONSchema({ type: 'string', format: 'uint64' })).toStrictEqual({
+        type: 'string',
+        format: 'uint64',
+      });
+    });
+  });
 });
 
 describe('`title` support', () => {

--- a/src/lib/openapi-to-json-schema.ts
+++ b/src/lib/openapi-to-json-schema.ts
@@ -810,7 +810,7 @@ export default function toJSONSchema(
 
   // Ensure that number schemas formats have properly constrained min/max attributes according to
   // whatever type of `format` and `type` they adhere to.
-  if ('format' in schema) {
+  if ((schema.type === 'number' || schema.type === 'integer') && 'format' in schema) {
     const formatUpper = schema.format.toUpperCase();
 
     if (`${formatUpper}_MIN` in FORMAT_OPTIONS) {


### PR DESCRIPTION
| 🚥 Resolves #794 |
| :------------------- |

## 🧰 Changes

Only add numeric bounds for numeric types
