### PR TITLE
fix: get exports working in TS `nodeNext`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,40 +7,75 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
     },
     "./analyzer": {
-      "types": "./dist/analyzer/index.d.ts",
-      "require": "./dist/analyzer/index.js",
-      "import": "./dist/analyzer/index.mjs"
+      "require": {
+        "types": "./dist/analyzer/index.d.ts",
+        "default": "./dist/analyzer/index.js"
+      },
+      "import": {
+        "types": "./dist/analyzer/index.d.mts",
+        "default": "./dist/analyzer/index.mjs"
+      }
     },
     "./lib/reducer": {
-      "types": "./dist/lib/reducer.d.ts",
-      "require": "./dist/lib/reducer.js",
-      "import": "./dist/lib/reducer.mjs"
+      "require": {
+        "types": "./dist/lib/reducer.d.ts",
+        "default": "./dist/lib/reducer.js"
+      },
+      "import": {
+        "types": "./dist/lib/reducer.d.mts",
+        "default": "./dist/lib/reducer.mjs"
+      }
     },
     "./rmoas.types": {
-      "types": "./dist/rmoas.types.d.ts",
-      "require": "./dist/rmoas.types.js",
-      "import": "./dist/rmoas.types.mjs"
+      "require": {
+        "types": "./dist/rmoas.types.d.ts",
+        "default": "./dist/rmoas.types.js"
+      },
+      "import": {
+        "types": "./dist/rmoas.types.d.mts",
+        "default": "./dist/rmoas.types.mjs"
+      }
     },
     "./operation": {
-      "types": "./dist/operation.d.ts",
-      "require": "./dist/operation.js",
-      "import": "./dist/operation.mjs"
+      "require": {
+        "types": "./dist/operation.d.ts",
+        "default": "./dist/operation.js"
+      },
+      "import": {
+        "types": "./dist/operation.d.mts",
+        "default": "./dist/operation.mjs"
+      }
     },
     "./operation/get-parameters-as-json-schema": {
-      "types": "./dist/operation/get-parameters-as-json-schema.d.ts",
-      "require": "./dist/operation/get-parameters-as-json-schema.js",
-      "import": "./dist/operation/get-parameters-as-json-schema.mjs"
+      "require": {
+        "types": "./dist/operation/get-parameters-as-json-schema.d.ts",
+        "default": "./dist/operation/get-parameters-as-json-schema.js"
+      },
+      "import": {
+        "types": "./dist/operation/get-parameters-as-json-schema.d.mts",
+        "default": "./dist/operation/get-parameters-as-json-schema.mjs"
+      }
     },
     "./package.json": "./package.json",
     "./utils": {
-      "types": "./dist/utils.d.ts",
-      "require": "./dist/utils.js",
-      "import": "./dist/utils.mjs"
+      "require": {
+        "types": "./dist/utils.d.ts",
+        "default": "./dist/utils.js"
+      },
+      "import": {
+        "types": "./dist/utils.d.mts",
+        "default": "./dist/utils.mjs"
+      }
     }
   },
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -8,75 +8,33 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      },
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     },
     "./analyzer": {
-      "require": {
-        "types": "./dist/analyzer/index.d.cts",
-        "default": "./dist/analyzer/index.cjs"
-      },
-      "import": {
-        "types": "./dist/analyzer/index.d.ts",
-        "default": "./dist/analyzer/index.js"
-      }
+      "require": "./dist/analyzer/index.cjs",
+      "import": "./dist/analyzer/index.js"
     },
     "./lib/reducer": {
-      "require": {
-        "types": "./dist/lib/reducer.d.cts",
-        "default": "./dist/lib/reducer.cjs"
-      },
-      "import": {
-        "types": "./dist/lib/reducer.d.ts",
-        "default": "./dist/lib/reducer.js"
-      }
+      "require": "./dist/lib/reducer.cjs",
+      "import": "./dist/lib/reducer.js"
     },
     "./rmoas.types": {
-      "require": {
-        "types": "./dist/rmoas.types.d.cts",
-        "default": "./dist/rmoas.types.cjs"
-      },
-      "import": {
-        "types": "./dist/rmoas.types.d.ts",
-        "default": "./dist/rmoas.types.js"
-      }
+      "require": "./dist/rmoas.types.cjs",
+      "import": "./dist/rmoas.types.js"
     },
     "./operation": {
-      "require": {
-        "types": "./dist/operation.d.cts",
-        "default": "./dist/operation.cjs"
-      },
-      "import": {
-        "types": "./dist/operation.d.ts",
-        "default": "./dist/operation.js"
-      }
+      "require": "./dist/operation.cjs",
+      "import": "./dist/operation.js"
     },
     "./operation/get-parameters-as-json-schema": {
-      "require": {
-        "types": "./dist/operation/get-parameters-as-json-schema.d.cts",
-        "default": "./dist/operation/get-parameters-as-json-schema.cjs"
-      },
-      "import": {
-        "types": "./dist/operation/get-parameters-as-json-schema.d.ts",
-        "default": "./dist/operation/get-parameters-as-json-schema.js"
-      }
+      "require": "./dist/operation/get-parameters-as-json-schema.cjs",
+      "import": "./dist/operation/get-parameters-as-json-schema.js"
     },
     "./package.json": "./package.json",
     "./utils": {
-      "require": {
-        "types": "./dist/utils.d.cts",
-        "default": "./dist/utils.cjs"
-      },
-      "import": {
-        "types": "./dist/utils.d.ts",
-        "default": "./dist/utils.js"
-      }
+      "require": "./dist/utils.cjs",
+      "import": "./dist/utils.js"
     }
   },
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -5,82 +5,83 @@
   "license": "MIT",
   "author": "ReadMe <support@readme.io> (https://readme.com)",
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": {
       "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
       },
       "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     },
     "./analyzer": {
       "require": {
-        "types": "./dist/analyzer/index.d.ts",
-        "default": "./dist/analyzer/index.js"
+        "types": "./dist/analyzer/index.d.cts",
+        "default": "./dist/analyzer/index.cjs"
       },
       "import": {
-        "types": "./dist/analyzer/index.d.mts",
-        "default": "./dist/analyzer/index.mjs"
+        "types": "./dist/analyzer/index.d.ts",
+        "default": "./dist/analyzer/index.js"
       }
     },
     "./lib/reducer": {
       "require": {
-        "types": "./dist/lib/reducer.d.ts",
-        "default": "./dist/lib/reducer.js"
+        "types": "./dist/lib/reducer.d.cts",
+        "default": "./dist/lib/reducer.cjs"
       },
       "import": {
-        "types": "./dist/lib/reducer.d.mts",
-        "default": "./dist/lib/reducer.mjs"
+        "types": "./dist/lib/reducer.d.ts",
+        "default": "./dist/lib/reducer.js"
       }
     },
     "./rmoas.types": {
       "require": {
-        "types": "./dist/rmoas.types.d.ts",
-        "default": "./dist/rmoas.types.js"
+        "types": "./dist/rmoas.types.d.cts",
+        "default": "./dist/rmoas.types.cjs"
       },
       "import": {
-        "types": "./dist/rmoas.types.d.mts",
-        "default": "./dist/rmoas.types.mjs"
+        "types": "./dist/rmoas.types.d.ts",
+        "default": "./dist/rmoas.types.js"
       }
     },
     "./operation": {
       "require": {
-        "types": "./dist/operation.d.ts",
-        "default": "./dist/operation.js"
+        "types": "./dist/operation.d.cts",
+        "default": "./dist/operation.cjs"
       },
       "import": {
-        "types": "./dist/operation.d.mts",
-        "default": "./dist/operation.mjs"
+        "types": "./dist/operation.d.ts",
+        "default": "./dist/operation.js"
       }
     },
     "./operation/get-parameters-as-json-schema": {
       "require": {
-        "types": "./dist/operation/get-parameters-as-json-schema.d.ts",
-        "default": "./dist/operation/get-parameters-as-json-schema.js"
+        "types": "./dist/operation/get-parameters-as-json-schema.d.cts",
+        "default": "./dist/operation/get-parameters-as-json-schema.cjs"
       },
       "import": {
-        "types": "./dist/operation/get-parameters-as-json-schema.d.mts",
-        "default": "./dist/operation/get-parameters-as-json-schema.mjs"
+        "types": "./dist/operation/get-parameters-as-json-schema.d.ts",
+        "default": "./dist/operation/get-parameters-as-json-schema.js"
       }
     },
     "./package.json": "./package.json",
     "./utils": {
       "require": {
-        "types": "./dist/utils.d.ts",
-        "default": "./dist/utils.js"
+        "types": "./dist/utils.d.cts",
+        "default": "./dist/utils.cjs"
       },
       "import": {
-        "types": "./dist/utils.d.mts",
-        "default": "./dist/utils.mjs"
+        "types": "./dist/utils.d.ts",
+        "default": "./dist/utils.js"
       }
     }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.cts",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
## 🧰 Changes

### 🧐 Background

When using the latest version of `oas` in https://github.com/readmeio/rdme/pull/856, I'm seeing the following TypeScript errors:

![CleanShot 2023-09-12 at 14 34 16@2x](https://github.com/readmeio/oas/assets/8854718/48c8ec9b-921a-445e-af90-ba715f262768)

This is happening because `tsup` generates two different type declaration files (one for CJS and one for ESM) that have slight differences...

<details>
<summary>Declaration files screenshot</summary>

![CleanShot 2023-09-12 at 14 48 09@2x](https://github.com/readmeio/oas/assets/8854718/0222f8a9-3321-4c88-b6a2-14bb72d2f999)

</details>

... but the problem is that our `package.json` `exports` field only references the CJS type declaration files:

https://github.com/readmeio/oas/blob/fcc0ec457cc2a823629ac9d0e4b82e4a0a63368c/package.json#L10

Per [the TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing:~:text=Attempting%20to%20use%20a%20single%20.d.ts%20file%20to%20type%20both%20an%20ES%20module%20entrypoint%20and%20a%20CommonJS%20entrypoint%20will%20cause%20TypeScript%20to%20think%20only%20one%20of%20those%20entrypoints%20exists%2C%20causing%20compiler%20errors%20for%20users%20of%20the%20package):

> Attempting to use a single .d.ts file to type both an ES module entrypoint and a CommonJS entrypoint will cause TypeScript to think only one of those entrypoints exists, causing compiler errors for users of the package.

### 🌱 Solution

This PR makes two changes our `package.json`:

- Dropped the `types` fields from the `exports` object. Turns out we don't have to specify the `types` fields at all since `tsup` names the declaration files properly so TypeScript automatically loads the co-located declaration files ([source](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing:~:text=If%20it%20finds%20them%2C%20it%20will%20look%20for%20a%20co%2Dlocated%20declaration%20file.))
- Flipped the package `type` over to a `module` and flipped the file extensions accordingly. This was required in order to get the sub-exports working properly in `rdme` ([`prettier@3` also is a module despite also having CJS exports](https://github.com/prettier/prettier/blob/4eaf68cd6cdce969d5b04981dd37f2856d87e9c3/package.json#L10)) — the following weird ass error shows up in `rdme` if attempting to build and load in `oas` when it's **_not_** a module:

```
../oas/dist/operation-8f5d4769.d.ts:1:204 - error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("./rmoas.types.mjs")' call instead.

1 import { SchemaObject, OASDocument, OperationObject, HttpMethods, SecurityRequirementObject, KeyedSecuritySchemeObject, TagObject, ParameterObject, MediaTypeObject, ResponseObject, PathItemObject } from './rmoas.types.mjs';
                                                                                                                                                                                                             ~~~~~~~~~~~~~~~~~~~


Found 1 error in ../oas/dist/operation-8f5d4769.d.ts:1
```

### 📖 Further Reading

You can read about all of this in the TypeScript and Node docs:

https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
https://nodejs.org/api/packages.html#nested-conditions

## 🧬 QA & Testing

If you check out [this commit of `rdme`](https://github.com/readmeio/rdme/pull/856/commits/7ab41bddce487b0574850ccf0480b85f96dc77da) and `npm link` it to this branch of `oas`, you shouldn't see any build errors.
