### PR TITLE
feat(breaking): drop node 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 16
           - 18
           - 20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "vitest": "^0.34.4"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "files": [
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "bundler",
     "noImplicitAny": true,
     "outDir": "./dist",
-    "target": "ES2022"
+    "target": "ES2020"
   },
   "include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,12 @@
     "baseUrl": "./src/",
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noImplicitAny": true,
     "outDir": "./dist",
-    "resolveJsonModule": true,
-    "target": "ES2020"
+    "target": "ES2022"
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## 🧰 Changes

With the latest `oas-normalize` and `@readme/eslint-config` updates in #802, this library now requires Node 18.
