### PR TITLE
refactor: build cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci
-
-      # With the way these libraries use each other we need to run our build step for linting in a
-      # specific order.
-      - run: npm run build
-        working-directory: ./packages/oas-normalize
-      - run: npm run build
-        working-directory: ./packages/oas
-      - run: npm run build
-        working-directory: ./packages/oas-extensions
-      - run: npm run build
-        working-directory: ./packages/oas-to-har
-
+      - run: npm build
       - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci
-      - run: npm build
+      - run: npm run build
       - run: npm run lint

--- a/packages/oas-extensions/package.json
+++ b/packages/oas-extensions/package.json
@@ -36,7 +36,6 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "pretest": "npm run lint",
     "test": "vitest run --coverage"
   },
   "peerDependencies": {

--- a/packages/oas-normalize/package.json
+++ b/packages/oas-normalize/package.json
@@ -58,7 +58,6 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "pretest": "npm run lint",
     "test": "vitest run --coverage"
   },
   "license": "MIT",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -45,7 +45,6 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "pretest": "npm run lint",
     "test": "vitest run --coverage"
   },
   "dependencies": {

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -75,7 +75,6 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "pretest": "npm run build",
     "test": "vitest run --coverage",
     "watch": "tsc --watch"
   },


### PR DESCRIPTION
## 🧰 Changes

Removed the `pretest` scripts so we're not doubly linting/building and swapped out the hand-defined `build` order for lerna, which seemingly takes care of it perfectly :buzzfeed-wow:

## 🧬 QA & Testing

Does everything still pass? I confirmed it does locally!
