### PR TITLE
feat(esm): flipping on our ESM ESLint config in all packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript", "@readme/eslint-config/esm"],
+  "root": true
+}

--- a/packages/oas-extensions/.eslintrc
+++ b/packages/oas-extensions/.eslintrc
@@ -1,6 +1,4 @@
 {
-  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript"],
-  "root": true,
   "rules": {
     "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off"

--- a/packages/oas-extensions/test/index.test.ts
+++ b/packages/oas-extensions/test/index.test.ts
@@ -2,7 +2,7 @@ import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 import Oas from 'oas';
 import { describe, beforeEach, it, expect } from 'vitest';
 
-import * as extensions from '../src';
+import * as extensions from '../src/index.js';
 
 describe('oas-extensions', () => {
   it.each([

--- a/packages/oas-extensions/tsup.config.ts
+++ b/packages/oas-extensions/tsup.config.ts
@@ -3,7 +3,7 @@ import type { Options } from 'tsup';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig } from 'tsup';
 
-import config from '../../tsup.config';
+import config from '../../tsup.config.js';
 
 export default defineConfig((options: Options) => ({
   ...options,

--- a/packages/oas-normalize/.eslintrc
+++ b/packages/oas-normalize/.eslintrc
@@ -1,13 +1,9 @@
 {
-  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript"],
-  "root": true,
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
 
     "camelcase": ["error", { "allow": ["OpenAPIV3_1"] }],
 
-    "no-case-declarations": "off",
-
-    "unicorn/prefer-node-protocol": "error"
+    "no-case-declarations": "off"
   }
 }

--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -1,4 +1,4 @@
-import type { Options } from './lib/types';
+import type { Options } from './lib/types.js';
 import type { OpenAPI } from 'openapi-types';
 
 import fs from 'node:fs';
@@ -7,7 +7,7 @@ import openapiParser from '@readme/openapi-parser';
 import postmanToOpenAPI from '@readme/postman-to-openapi';
 import converter from 'swagger2openapi';
 
-import * as utils from './lib/utils';
+import * as utils from './lib/utils.js';
 
 export default class OASNormalize {
   cache: {

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/prefer-module -- We use `require.resolve` for reading YAML fixtures. */
 import type { OpenAPIV3 } from 'openapi-types';
 
 import fs from 'node:fs';
@@ -6,8 +7,8 @@ import path from 'node:path';
 import fetchMock from 'fetch-mock';
 import { describe, afterEach, beforeAll, beforeEach, it, expect } from 'vitest';
 
-import OASNormalize from '../src';
-import { getAPIDefinitionType, isAPIDefinition, isOpenAPI, isPostman, isSwagger } from '../src/lib/utils';
+import OASNormalize from '../src/index.js';
+import { getAPIDefinitionType, isAPIDefinition, isOpenAPI, isPostman, isSwagger } from '../src/lib/utils.js';
 
 function cloneObject(obj) {
   return JSON.parse(JSON.stringify(obj));

--- a/packages/oas-normalize/tsup.config.ts
+++ b/packages/oas-normalize/tsup.config.ts
@@ -3,7 +3,7 @@ import type { Options } from 'tsup';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig } from 'tsup';
 
-import config from '../../tsup.config';
+import config from '../../tsup.config.js';
 
 export default defineConfig((options: Options) => ({
   ...options,

--- a/packages/oas-to-har/.eslintrc
+++ b/packages/oas-to-har/.eslintrc
@@ -1,6 +1,4 @@
 {
-  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript", "@readme/eslint-config/esm"],
-  "root": true,
   "rules": {
     // `any` types are fine because we're dealing with a lot of unknown data.
     "@typescript-eslint/no-explicit-any": "off",

--- a/packages/oas/.eslintrc
+++ b/packages/oas/.eslintrc
@@ -1,6 +1,4 @@
 {
-  "extends": ["@readme/eslint-config", "@readme/eslint-config/typescript"],
-  "root": true,
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-use-before-define": ["error", { "classes": false }],
@@ -8,6 +6,18 @@
     "camelcase": "off",
 
     "max-classes-per-file": "off",
+
+    "node/no-extraneous-import": [
+      "error",
+      {
+        "allowModules": [
+          // When we use this module we only load TS types which come from our `@types/json-schema`
+          // dependency.
+          "json-schema"
+        ]
+      }
+    ],
+
     "no-param-reassign": "off",
 
     "no-underscore-dangle": [

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -1,7 +1,7 @@
-import type { OASDocument } from '../rmoas.types';
+import type { OASDocument } from '../rmoas.types.js';
 
-import * as OPENAPI_QUERIES from './queries/openapi';
-import * as README_QUERIES from './queries/readme';
+import * as OPENAPI_QUERIES from './queries/openapi.js';
+import * as README_QUERIES from './queries/readme.js';
 
 export interface OASAnalysisFeature {
   locations: string[];

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -1,7 +1,7 @@
-import type { OASDocument } from '../../rmoas.types';
+import type { OASDocument } from '../../rmoas.types.js';
 
-import Oas from '../..';
-import { query, refizePointer } from '../util';
+import Oas from '../../index.js';
+import { query, refizePointer } from '../util.js';
 
 /**
  * Determine if a given API definition uses the `additionalProperties` schema property.

--- a/packages/oas/src/analyzer/queries/readme.ts
+++ b/packages/oas/src/analyzer/queries/readme.ts
@@ -1,6 +1,6 @@
-import type { OASDocument } from '../../rmoas.types';
+import type { OASDocument } from '../../rmoas.types.js';
 
-import { query, refizePointer } from '../util';
+import { query, refizePointer } from '../util.js';
 
 /**
  * Determine if a given API definition is using our `x-default` extension for defining auth

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -1,15 +1,15 @@
-import type * as RMOAS from './rmoas.types';
+import type * as RMOAS from './rmoas.types.js';
 import type { OpenAPIV3_1 } from 'openapi-types';
 import type { MatchResult } from 'path-to-regexp';
 
 import $RefParser from '@readme/json-schema-ref-parser';
 import { pathToRegexp, match } from 'path-to-regexp';
 
-import getAuth from './lib/get-auth';
-import getUserVariable from './lib/get-user-variable';
-import { isPrimitive } from './lib/helpers';
-import Operation, { Webhook } from './operation';
-import utils from './utils';
+import getAuth from './lib/get-auth.js';
+import getUserVariable from './lib/get-user-variable.js';
+import { isPrimitive } from './lib/helpers.js';
+import Operation, { Webhook } from './operation.js';
+import utils from './utils.js';
 
 interface PathMatch {
   match?: MatchResult;

--- a/packages/oas/src/lib/dedupe-common-parameters.ts
+++ b/packages/oas/src/lib/dedupe-common-parameters.ts
@@ -1,4 +1,4 @@
-import * as RMOAS from '../rmoas.types';
+import * as RMOAS from '../rmoas.types.js';
 
 /**
  * With an array of common parameters filter down them to what isn't already present in a list of

--- a/packages/oas/src/lib/get-auth.ts
+++ b/packages/oas/src/lib/get-auth.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
 type authKey = null | unknown | { password: string | number; user: string | number };

--- a/packages/oas/src/lib/get-mediatype-examples.ts
+++ b/packages/oas/src/lib/get-mediatype-examples.ts
@@ -1,8 +1,8 @@
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 
-import sampleFromSchema from '../samples';
+import sampleFromSchema from '../samples/index.js';
 
-import matchesMimeType from './matches-mimetype';
+import matchesMimeType from './matches-mimetype.js';
 
 export interface MediaTypeExample {
   description?: string;

--- a/packages/oas/src/lib/get-user-variable.ts
+++ b/packages/oas/src/lib/get-user-variable.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 
 /**
  * Retrieve a user variable off of a given user.

--- a/packages/oas/src/lib/helpers.ts
+++ b/packages/oas/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import type { SchemaObject } from '../rmoas.types';
+import type { SchemaObject } from '../rmoas.types.js';
 
 export function hasSchemaType(schema: SchemaObject, discriminator: 'array' | 'object') {
   if (Array.isArray(schema.type)) {

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-continue */
-import type { SchemaObject } from '../rmoas.types';
+import type { SchemaObject } from '../rmoas.types.js';
 import type { JSONSchema7TypeName } from 'json-schema';
 import type { OpenAPIV3_1 } from 'openapi-types';
 
@@ -7,9 +7,9 @@ import mergeJSONSchemaAllOf from 'json-schema-merge-allof';
 import jsonpointer from 'jsonpointer';
 import removeUndefinedObjects from 'remove-undefined-objects';
 
-import * as RMOAS from '../rmoas.types';
+import * as RMOAS from '../rmoas.types.js';
 
-import { hasSchemaType, isObject, isPrimitive } from './helpers';
+import { hasSchemaType, isObject, isPrimitive } from './helpers.js';
 
 /**
  * This list has been pulled from `openapi-schema-to-json-schema` but been slightly modified to fit

--- a/packages/oas/src/lib/reducer.ts
+++ b/packages/oas/src/lib/reducer.ts
@@ -1,9 +1,9 @@
-import type { ComponentsObject, HttpMethods, OASDocument, TagObject } from '../rmoas.types';
+import type { ComponentsObject, HttpMethods, OASDocument, TagObject } from '../rmoas.types.js';
 
 import jsonPointer from 'jsonpointer';
 import { getAPIDefinitionType } from 'oas-normalize/lib/utils';
 
-import { query } from '../analyzer/util';
+import { query } from '../analyzer/util.js';
 
 export interface ReducerOptions {
   /** A key-value object of path + method combinations to reduce by. */

--- a/packages/oas/src/operation.ts
+++ b/packages/oas/src/operation.ts
@@ -1,19 +1,19 @@
-import type { CallbackExamples } from './operation/get-callback-examples';
-import type { getParametersAsJSONSchemaOptions } from './operation/get-parameters-as-json-schema';
-import type { RequestBodyExamples } from './operation/get-requestbody-examples';
-import type { ResponseExamples } from './operation/get-response-examples';
+import type { CallbackExamples } from './operation/get-callback-examples.js';
+import type { getParametersAsJSONSchemaOptions } from './operation/get-parameters-as-json-schema.js';
+import type { RequestBodyExamples } from './operation/get-requestbody-examples.js';
+import type { ResponseExamples } from './operation/get-response-examples.js';
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
-import dedupeCommonParameters from './lib/dedupe-common-parameters';
-import findSchemaDefinition from './lib/find-schema-definition';
-import matchesMimeType from './lib/matches-mimetype';
-import getCallbackExamples from './operation/get-callback-examples';
-import getParametersAsJSONSchema from './operation/get-parameters-as-json-schema';
-import getRequestBodyExamples from './operation/get-requestbody-examples';
-import getResponseAsJSONSchema from './operation/get-response-as-json-schema';
-import getResponseExamples from './operation/get-response-examples';
-import * as RMOAS from './rmoas.types';
-import utils from './utils';
+import dedupeCommonParameters from './lib/dedupe-common-parameters.js';
+import findSchemaDefinition from './lib/find-schema-definition.js';
+import matchesMimeType from './lib/matches-mimetype.js';
+import getCallbackExamples from './operation/get-callback-examples.js';
+import getParametersAsJSONSchema from './operation/get-parameters-as-json-schema.js';
+import getRequestBodyExamples from './operation/get-requestbody-examples.js';
+import getResponseAsJSONSchema from './operation/get-response-as-json-schema.js';
+import getResponseExamples from './operation/get-response-examples.js';
+import * as RMOAS from './rmoas.types.js';
+import utils from './utils.js';
 
 type SecurityType = 'Basic' | 'Bearer' | 'Query' | 'Header' | 'Cookie' | 'OAuth2' | 'http' | 'apiKey';
 

--- a/packages/oas/src/operation/get-callback-examples.ts
+++ b/packages/oas/src/operation/get-callback-examples.ts
@@ -1,6 +1,6 @@
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 
-import getResponseExamples from './get-response-examples';
+import getResponseExamples from './get-response-examples.js';
 
 export type CallbackExamples = {
   example: unknown;

--- a/packages/oas/src/operation/get-parameters-as-json-schema.ts
+++ b/packages/oas/src/operation/get-parameters-as-json-schema.ts
@@ -1,12 +1,12 @@
-import type { toJSONSchemaOptions } from '../lib/openapi-to-json-schema';
-import type Operation from '../operation';
-import type { ComponentsObject, ExampleObject, OASDocument, ParameterObject, SchemaObject } from '../rmoas.types';
+import type { toJSONSchemaOptions } from '../lib/openapi-to-json-schema.js';
+import type Operation from '../operation.js';
+import type { ComponentsObject, ExampleObject, OASDocument, ParameterObject, SchemaObject } from '../rmoas.types.js';
 import type { OpenAPIV3_1 } from 'openapi-types';
 
-import cloneObject from '../lib/clone-object';
-import { isPrimitive } from '../lib/helpers';
-import matchesMimetype from '../lib/matches-mimetype';
-import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
+import cloneObject from '../lib/clone-object.js';
+import { isPrimitive } from '../lib/helpers.js';
+import matchesMimetype from '../lib/matches-mimetype.js';
+import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema.js';
 
 export interface SchemaWrapper {
   $schema?: string;

--- a/packages/oas/src/operation/get-requestbody-examples.ts
+++ b/packages/oas/src/operation/get-requestbody-examples.ts
@@ -1,6 +1,6 @@
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 
-import getMediaTypeExamples from '../lib/get-mediatype-examples';
+import getMediaTypeExamples from '../lib/get-mediatype-examples.js';
 
 export type RequestBodyExamples = {
   examples: any;

--- a/packages/oas/src/operation/get-response-as-json-schema.ts
+++ b/packages/oas/src/operation/get-response-as-json-schema.ts
@@ -1,4 +1,4 @@
-import type Operation from '../operation';
+import type Operation from '../operation.js';
 import type {
   ComponentsObject,
   MediaTypeObject,
@@ -6,12 +6,12 @@ import type {
   ResponseObject,
   SchemaObject,
   HeaderObject,
-} from '../rmoas.types';
+} from '../rmoas.types.js';
 
-import cloneObject from '../lib/clone-object';
-import { isPrimitive } from '../lib/helpers';
-import matches from '../lib/matches-mimetype';
-import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema';
+import cloneObject from '../lib/clone-object.js';
+import { isPrimitive } from '../lib/helpers.js';
+import matches from '../lib/matches-mimetype.js';
+import toJSONSchema, { getSchemaVersionString } from '../lib/openapi-to-json-schema.js';
 
 const isJSON = matches.json;
 

--- a/packages/oas/src/operation/get-response-examples.ts
+++ b/packages/oas/src/operation/get-response-examples.ts
@@ -1,8 +1,8 @@
-import type { MediaTypeExample } from '../lib/get-mediatype-examples';
-import type * as RMOAS from '../rmoas.types';
+import type { MediaTypeExample } from '../lib/get-mediatype-examples.js';
+import type * as RMOAS from '../rmoas.types.js';
 
-import getMediaTypeExamples from '../lib/get-mediatype-examples';
-import { isRef } from '../rmoas.types';
+import getMediaTypeExamples from '../lib/get-mediatype-examples.js';
+import { isRef } from '../rmoas.types.js';
 
 export type ResponseExamples = {
   mediaTypes: Record<string, MediaTypeExample[]>;

--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -4,12 +4,12 @@
  * @license Apache-2.0
  * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/samples/fn.js}
  */
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 
 import mergeJSONSchemaAllOf from 'json-schema-merge-allof';
 import memoize from 'memoizee';
 
-import { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } from './utils';
+import { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } from './utils.js';
 
 const sampleDefaults = (genericSample: string | number | boolean) => {
   return (schema: RMOAS.SchemaObject): typeof genericSample =>

--- a/packages/oas/src/samples/utils.ts
+++ b/packages/oas/src/samples/utils.ts
@@ -4,9 +4,9 @@
  * @license Apache-2.0
  * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/src/core/utils.js}
  */
-import type * as RMOAS from '../rmoas.types';
+import type * as RMOAS from '../rmoas.types.js';
 
-import { isObject } from '../lib/helpers';
+import { isObject } from '../lib/helpers.js';
 
 export function usesPolymorphism(schema: RMOAS.SchemaObject) {
   if (schema.oneOf) {

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -1,6 +1,6 @@
-import findSchemaDefinition from './lib/find-schema-definition';
-import matchesMimeType from './lib/matches-mimetype';
-import { types as jsonSchemaTypes } from './operation/get-parameters-as-json-schema';
+import findSchemaDefinition from './lib/find-schema-definition.js';
+import matchesMimeType from './lib/matches-mimetype.js';
+import { types as jsonSchemaTypes } from './operation/get-parameters-as-json-schema.js';
 
 const supportedMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
 

--- a/packages/oas/test/__fixtures__/create-oas.ts
+++ b/packages/oas/test/__fixtures__/create-oas.ts
@@ -1,6 +1,6 @@
-import type * as RMOAS from '../../src/rmoas.types';
+import type * as RMOAS from '../../src/rmoas.types.js';
 
-import Oas from '../../src';
+import Oas from '../../src/index.js';
 
 /**
  * @param operation Operation to create a fake API definition and Oas instance for.

--- a/packages/oas/test/__fixtures__/json-schema.ts
+++ b/packages/oas/test/__fixtures__/json-schema.ts
@@ -1,4 +1,4 @@
-import type { SchemaObject } from '../../src/rmoas.types';
+import type { SchemaObject } from '../../src/rmoas.types.js';
 
 const SCHEMA_SCENARIOS = {
   'array of primitives': (props, allowEmptyValue) => {

--- a/packages/oas/test/__fixtures__/json-stringify-clean.js
+++ b/packages/oas/test/__fixtures__/json-stringify-clean.js
@@ -1,3 +1,0 @@
-export default function jsonStringifyClean(obj) {
-  return JSON.stringify(obj, undefined, 2);
-}

--- a/packages/oas/test/__fixtures__/json-stringify-clean.ts
+++ b/packages/oas/test/__fixtures__/json-stringify-clean.ts
@@ -1,0 +1,3 @@
+export default function jsonStringifyClean(obj: any) {
+  return JSON.stringify(obj, undefined, 2);
+}

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -1,8 +1,8 @@
-import type { OASDocument } from '../../src/rmoas.types';
+import type { OASDocument } from '../../src/rmoas.types.js';
 
 import { describe, beforeAll, it, expect } from 'vitest';
 
-import analyzer from '../../src/analyzer';
+import analyzer from '../../src/analyzer/index.js';
 
 let petstore: OASDocument;
 

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -1,8 +1,8 @@
-import type { OASDocument } from '../../../src/rmoas.types';
+import type { OASDocument } from '../../../src/rmoas.types.js';
 
 import { describe, beforeAll, expect, it } from 'vitest';
 
-import * as QUERIES from '../../../src/analyzer/queries/openapi';
+import * as QUERIES from '../../../src/analyzer/queries/openapi.js';
 
 function loadSpec(r: any) {
   return r.default as unknown as OASDocument;

--- a/packages/oas/test/analyzer/queries/readme.test.ts
+++ b/packages/oas/test/analyzer/queries/readme.test.ts
@@ -1,8 +1,8 @@
-import type { OASDocument } from '../../../src/rmoas.types';
+import type { OASDocument } from '../../../src/rmoas.types.js';
 
 import { describe, beforeAll, expect, it } from 'vitest';
 
-import * as QUERIES from '../../../src/analyzer/queries/readme';
+import * as QUERIES from '../../../src/analyzer/queries/readme.js';
 
 function loadSpec(r: any) {
   return r.default as unknown as OASDocument;

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1,11 +1,11 @@
-import type * as RMOAS from '../src/rmoas.types';
+import type * as RMOAS from '../src/rmoas.types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 import { beforeAll, describe, test, it, expect, vi } from 'vitest';
 
-import Oas from '../src';
-import Operation, { Webhook } from '../src/operation';
-import utils from '../src/utils';
+import Oas from '../src/index.js';
+import Operation, { Webhook } from '../src/operation.js';
+import utils from '../src/utils.js';
 
 let petstore: Oas;
 let webhooks: Oas;

--- a/packages/oas/test/lib/find-schema-definition.test.ts
+++ b/packages/oas/test/lib/find-schema-definition.test.ts
@@ -1,7 +1,7 @@
 import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 import { test, expect } from 'vitest';
 
-import findSchemaDefinition from '../../src/lib/find-schema-definition';
+import findSchemaDefinition from '../../src/lib/find-schema-definition.js';
 
 test('should return a definition for a given ref', () => {
   expect(findSchemaDefinition('#/components/schemas/Pet', petstore)).toStrictEqual(petstore.components.schemas.Pet);

--- a/packages/oas/test/lib/get-auth.test.ts
+++ b/packages/oas/test/lib/get-auth.test.ts
@@ -1,7 +1,7 @@
 import { test, describe, it, expect } from 'vitest';
 
-import Oas from '../../src';
-import getAuth, { getByScheme } from '../../src/lib/get-auth';
+import Oas from '../../src/index.js';
+import getAuth, { getByScheme } from '../../src/lib/get-auth.js';
 import multipleSecurities from '../__datasets__/multiple-securities.json';
 
 // We need to forcetype this definition to an OASDocument because it's got weird use cases in it

--- a/packages/oas/test/lib/get-user-variable.test.ts
+++ b/packages/oas/test/lib/get-user-variable.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-import getUserVariable from '../../src/lib/get-user-variable';
+import getUserVariable from '../../src/lib/get-user-variable.js';
 
 const topLevelUser = { apiKey: '123456', user: 'user', pass: 'pass' };
 const keysUser = {

--- a/packages/oas/test/lib/matches-mimetype.test.ts
+++ b/packages/oas/test/lib/matches-mimetype.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import matchesMimeType from '../../src/lib/matches-mimetype';
+import matchesMimeType from '../../src/lib/matches-mimetype.js';
 
 describe('#formUrlEncoded', () => {
   it('should recognize `application/x-www-form-urlencoded`', () => {

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -1,12 +1,12 @@
-import type { SchemaObject } from '../../src/rmoas.types';
+import type { SchemaObject } from '../../src/rmoas.types.js';
 import type { JSONSchema4, JSONSchema7, JSONSchema7Definition, JSONSchema7TypeName } from 'json-schema';
 
 import { beforeAll, expect, describe, it } from 'vitest';
 
-import Oas from '../../src';
-import toJSONSchema from '../../src/lib/openapi-to-json-schema';
-import createOas from '../__fixtures__/create-oas';
-import generateJSONSchemaFixture from '../__fixtures__/json-schema';
+import Oas from '../../src/index.js';
+import toJSONSchema from '../../src/lib/openapi-to-json-schema.js';
+import createOas from '../__fixtures__/create-oas.js';
+import generateJSONSchemaFixture from '../__fixtures__/json-schema.js';
 
 let petstore: Oas;
 

--- a/packages/oas/test/lib/openapi-to-json-schema/default.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema/default.test.ts
@@ -1,9 +1,9 @@
-import type { SchemaObject } from '../../../src/rmoas.types';
+import type { SchemaObject } from '../../../src/rmoas.types.js';
 
 import { describe, it, expect } from 'vitest';
 
-import toJSONSchema from '../../../src/lib/openapi-to-json-schema';
-import generateJSONSchemaFixture from '../../__fixtures__/json-schema';
+import toJSONSchema from '../../../src/lib/openapi-to-json-schema.js';
+import generateJSONSchemaFixture from '../../__fixtures__/json-schema.js';
 
 describe('`default` support in `openapi-to-json-schema`', () => {
   it('should support default', () => {

--- a/packages/oas/test/lib/openapi-to-json-schema/required.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema/required.test.ts
@@ -1,9 +1,9 @@
-import type { SchemaObject } from '../../../src/rmoas.types';
+import type { SchemaObject } from '../../../src/rmoas.types.js';
 
 import { describe, it, expect } from 'vitest';
 
-import toJSONSchema from '../../../src/lib/openapi-to-json-schema';
-import generateJSONSchemaFixture from '../../__fixtures__/json-schema';
+import toJSONSchema from '../../../src/lib/openapi-to-json-schema.js';
+import generateJSONSchemaFixture from '../../__fixtures__/json-schema.js';
 
 describe('`required` support in `openapi-to-json-schema`', () => {
   it('should support required', () => {

--- a/packages/oas/test/lib/reducer.test.ts
+++ b/packages/oas/test/lib/reducer.test.ts
@@ -4,7 +4,7 @@ import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 import uspto from '@readme/oas-examples/3.0/json/uspto.json';
 import { expect, describe, it } from 'vitest';
 
-import reducer from '../../src/lib/reducer';
+import reducer from '../../src/lib/reducer.js';
 import complexNesting from '../__datasets__/complex-nesting.json';
 import petstoreRefQuirks from '../__datasets__/petstore-ref-quirks.json';
 import securityRootLevel from '../__datasets__/security-root-level.json';

--- a/packages/oas/test/operation.test.ts
+++ b/packages/oas/test/operation.test.ts
@@ -1,11 +1,11 @@
-import type * as RMOAS from '../src/rmoas.types';
+import type * as RMOAS from '../src/rmoas.types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 import openapiParser from '@readme/openapi-parser';
 import { beforeAll, describe, it, expect } from 'vitest';
 
-import Oas from '../src';
-import Operation, { Callback } from '../src/operation';
+import Oas from '../src/index.js';
+import Operation, { Callback } from '../src/operation.js';
 
 let petstore: Oas;
 let callbackSchema: Oas;

--- a/packages/oas/test/operation/get-callback-examples.test.ts
+++ b/packages/oas/test/operation/get-callback-examples.test.ts
@@ -1,8 +1,8 @@
-import type { HttpMethods } from '../../src/rmoas.types';
+import type { HttpMethods } from '../../src/rmoas.types.js';
 
 import { beforeAll, test, expect, describe, it } from 'vitest';
 
-import Oas from '../../src';
+import Oas from '../../src/index.js';
 
 let operationExamples: Oas;
 let callbacks: Oas;

--- a/packages/oas/test/operation/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/get-parameters-as-json-schema.test.ts
@@ -1,9 +1,9 @@
-import type { OperationObject, RequestBodyObject, SchemaObject } from '../../src/rmoas.types';
+import type { OperationObject, RequestBodyObject, SchemaObject } from '../../src/rmoas.types.js';
 
 import { beforeAll, test, expect, it, describe } from 'vitest';
 
-import Oas from '../../src';
-import createOas from '../__fixtures__/create-oas';
+import Oas from '../../src/index.js';
+import createOas from '../__fixtures__/create-oas.js';
 
 let ably: Oas;
 let circular: Oas;

--- a/packages/oas/test/operation/get-requestbody-examples.test.ts
+++ b/packages/oas/test/operation/get-requestbody-examples.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, test, expect, it, describe } from 'vitest';
 
-import Oas from '../../src';
-import cleanStringify from '../__fixtures__/json-stringify-clean';
+import Oas from '../../src/index.js';
+import cleanStringify from '../__fixtures__/json-stringify-clean.js';
 
 let operationExamples: Oas;
 let petstore: Oas;

--- a/packages/oas/test/operation/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/get-response-as-json-schema.test.ts
@@ -1,11 +1,11 @@
-import type { HttpMethods, ResponseObject, SchemaObject } from '../../src/rmoas.types';
+import type { HttpMethods, ResponseObject, SchemaObject } from '../../src/rmoas.types.js';
 
 import openapiParser from '@readme/openapi-parser';
 import { beforeAll, describe, test, expect, it } from 'vitest';
 
-import Oas from '../../src';
-import cloneObject from '../../src/lib/clone-object';
-import createOas from '../__fixtures__/create-oas';
+import Oas from '../../src/index.js';
+import cloneObject from '../../src/lib/clone-object.js';
+import createOas from '../__fixtures__/create-oas.js';
 
 let circular: Oas;
 let petstore: Oas;

--- a/packages/oas/test/operation/get-response-examples.test.ts
+++ b/packages/oas/test/operation/get-response-examples.test.ts
@@ -1,10 +1,10 @@
-import type { MediaTypeExample } from '../../src/lib/get-mediatype-examples';
-import type * as RMOAS from '../../src/rmoas.types';
+import type { MediaTypeExample } from '../../src/lib/get-mediatype-examples.js';
+import type * as RMOAS from '../../src/rmoas.types.js';
 
 import { beforeAll, describe, test, expect, it } from 'vitest';
 
-import Oas from '../../src';
-import cleanStringify from '../__fixtures__/json-stringify-clean';
+import Oas from '../../src/index.js';
+import cleanStringify from '../__fixtures__/json-stringify-clean.js';
 
 let operationExamples: Oas;
 let petstore: Oas;

--- a/packages/oas/test/samples/index.test.ts
+++ b/packages/oas/test/samples/index.test.ts
@@ -4,11 +4,11 @@
  * @license Apache-2.0
  * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/test/unit/core/plugins/samples/fn.js}
  */
-import type * as RMOAS from '../../src/rmoas.types';
+import type * as RMOAS from '../../src/rmoas.types.js';
 
 import { describe, it, expect } from 'vitest';
 
-import sampleFromSchema from '../../src/samples';
+import sampleFromSchema from '../../src/samples/index.js';
 
 describe('sampleFromSchema', () => {
   it('should be memoized', async () => {

--- a/packages/oas/test/ts-quirks.test.js
+++ b/packages/oas/test/ts-quirks.test.js
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-// eslint-disable-next-line import/extensions
+// eslint-disable-next-line import/extensions, require-extensions/require-index
 import Oas from '..';
 
 /**

--- a/packages/oas/test/utils.test.ts
+++ b/packages/oas/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-import utils from '../src/utils';
+import utils from '../src/utils.js';
 
 test('should expose `jsonSchemaTypes`', () => {
   expect(utils.jsonSchemaTypes).toStrictEqual({

--- a/packages/oas/tsup.config.ts
+++ b/packages/oas/tsup.config.ts
@@ -3,7 +3,7 @@ import type { Options } from 'tsup';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig } from 'tsup';
 
-import config from '../../tsup.config';
+import config from '../../tsup.config.js';
 
 export default defineConfig((options: Options) => ({
   ...options,


### PR DESCRIPTION
## 🧰 Changes

Enables our `@readme/eslint-config/esm` ESLint config in all packages.