### PR TITLE
fix(oas): slightly refactoring how our utilities are exported

### DIFF
--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -21,14 +21,12 @@ import lodashGet from 'lodash/get.js';
 import lodashSet from 'lodash/set.js';
 import Operation from 'oas/operation';
 import { isRef } from 'oas/rmoas.types';
-import utils from 'oas/utils';
+import { jsonSchemaTypes, matchesMimeType } from 'oas/utils';
 import removeUndefinedObjects from 'remove-undefined-objects';
 
 import configureSecurity from './lib/configure-security.js';
 import formatStyle from './lib/style-formatting/index.js';
 import { getSafeRequestBody, getTypedFormatsInSchema, hasSchemaType } from './lib/utils.js';
-
-const { jsonSchemaTypes, matchesMimeType } = utils;
 
 function formatter(
   values: DataForHAR,

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -9,7 +9,7 @@ import getAuth from './lib/get-auth.js';
 import getUserVariable from './lib/get-user-variable.js';
 import { isPrimitive } from './lib/helpers.js';
 import Operation, { Webhook } from './operation.js';
-import utils from './utils.js';
+import { findSchemaDefinition, supportedMethods } from './utils.js';
 
 interface PathMatch {
   match?: MatchResult;
@@ -686,11 +686,11 @@ export default class Oas {
       // Though this library is generally unaware of `$ref` pointers we're making a singular
       // exception with this accessor out of convenience.
       if ('$ref' in this.api.paths[path]) {
-        this.api.paths[path] = utils.findSchemaDefinition(this.api.paths[path].$ref, this.api);
+        this.api.paths[path] = findSchemaDefinition(this.api.paths[path].$ref, this.api);
       }
 
       Object.keys(this.api.paths[path]).forEach((method: RMOAS.HttpMethods) => {
-        if (!utils.supportedMethods.has(method)) return;
+        if (!supportedMethods.has(method)) return;
 
         paths[path][method] = this.operation(path, method);
       });

--- a/packages/oas/src/operation.ts
+++ b/packages/oas/src/operation.ts
@@ -13,7 +13,7 @@ import getRequestBodyExamples from './operation/get-requestbody-examples.js';
 import getResponseAsJSONSchema from './operation/get-response-as-json-schema.js';
 import getResponseExamples from './operation/get-response-examples.js';
 import * as RMOAS from './rmoas.types.js';
-import utils from './utils.js';
+import { supportedMethods } from './utils.js';
 
 type SecurityType = 'Basic' | 'Bearer' | 'Query' | 'Header' | 'Cookie' | 'OAuth2' | 'http' | 'apiKey';
 
@@ -742,7 +742,7 @@ export default class Operation {
 
           if (!RMOAS.isRef(exp)) {
             Object.keys(exp).forEach((method: RMOAS.HttpMethods) => {
-              if (!utils.supportedMethods.has(method)) return;
+              if (!supportedMethods.has(method)) return;
 
               callbackOperations.push(this.getCallback(callback, expression, method));
             });

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -4,9 +4,4 @@ import { types as jsonSchemaTypes } from './operation/get-parameters-as-json-sch
 
 const supportedMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
 
-export default {
-  findSchemaDefinition,
-  jsonSchemaTypes,
-  matchesMimeType,
-  supportedMethods,
-};
+export { findSchemaDefinition, jsonSchemaTypes, matchesMimeType, supportedMethods };

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -5,7 +5,6 @@ import { beforeAll, describe, test, it, expect, vi } from 'vitest';
 
 import Oas from '../src/index.js';
 import Operation, { Webhook } from '../src/operation.js';
-import utils from '../src/utils.js';
 
 let petstore: Oas;
 let webhooks: Oas;
@@ -19,15 +18,6 @@ beforeAll(async () => {
   pathMatchingQuirks = await import('./__datasets__/path-matching-quirks.json').then(r => r.default).then(Oas.init);
   pathVariableQuirks = await import('./__datasets__/path-variable-quirks.json').then(r => r.default).then(Oas.init);
   serverVariables = await import('./__datasets__/server-variables.json').then(r => r.default).then(Oas.init);
-});
-
-test('should export utils', () => {
-  expect(utils).toStrictEqual({
-    findSchemaDefinition: expect.any(Function),
-    jsonSchemaTypes: expect.any(Object),
-    matchesMimeType: expect.any(Object),
-    supportedMethods: expect.any(Object),
-  });
 });
 
 test('should be able to access properties on the class instance', () => {

--- a/packages/oas/test/utils.test.ts
+++ b/packages/oas/test/utils.test.ts
@@ -1,9 +1,9 @@
 import { test, expect } from 'vitest';
 
-import utils from '../src/utils.js';
+import { jsonSchemaTypes } from '../src/utils.js';
 
 test('should expose `jsonSchemaTypes`', () => {
-  expect(utils.jsonSchemaTypes).toStrictEqual({
+  expect(jsonSchemaTypes).toStrictEqual({
     path: 'Path Params',
     query: 'Query Params',
     body: 'Body Params',


### PR DESCRIPTION
## 🧰 Changes

Doing `export default { .. }` and then loading a specific utility as `import { ... } from 'oas/utils'` gets weird with `tsup`, and it thinks that our utilities don't exist there, so I'm refactoring `oas/utils` to no longer have a default export.