### PR TITLE
refactor: random config file cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci
-      - run: npm run build
       - run: npm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,1 @@
-packages/**/coverage/
-packages/**/dist/
 CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prettier": "prettier --check .",
     "prettier:write": "prettier --check --write .",
     "publish": "npx lerna publish",
+    "prelint": "npm run build",
     "pretest": "npm run build",
     "test": "npx lerna run test --stream"
   },

--- a/packages/oas-extensions/.eslintignore
+++ b/packages/oas-extensions/.eslintignore
@@ -1,2 +1,0 @@
-coverage/
-dist/

--- a/packages/oas-extensions/.npmignore
+++ b/packages/oas-extensions/.npmignore
@@ -1,3 +1,0 @@
-coverage/
-test/
-.eslint*

--- a/packages/oas-extensions/package.json
+++ b/packages/oas-extensions/package.json
@@ -33,7 +33,7 @@
     "attw": "attw --pack --format table-flipped",
     "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
-    "lint:js": "eslint . --ext .js,.ts",
+    "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",

--- a/packages/oas-normalize/.eslintignore
+++ b/packages/oas-normalize/.eslintignore
@@ -1,2 +1,0 @@
-coverage/
-dist/

--- a/packages/oas-normalize/.npmignore
+++ b/packages/oas-normalize/.npmignore
@@ -1,3 +1,0 @@
-coverage/
-test/
-.eslint*

--- a/packages/oas-normalize/package.json
+++ b/packages/oas-normalize/package.json
@@ -55,7 +55,7 @@
     "attw": "attw --pack --format table-flipped",
     "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
-    "lint:js": "eslint . --ext .js,.ts",
+    "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",

--- a/packages/oas-to-har/.eslintignore
+++ b/packages/oas-to-har/.eslintignore
@@ -1,2 +1,0 @@
-coverage/
-dist/

--- a/packages/oas-to-har/.npmignore
+++ b/packages/oas-to-har/.npmignore
@@ -1,3 +1,0 @@
-coverage/
-test/
-.eslint*

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -42,7 +42,7 @@
     "attw": "attw --pack --format table-flipped",
     "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
-    "lint:js": "eslint . --ext .js,.ts",
+    "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",

--- a/packages/oas/.eslintignore
+++ b/packages/oas/.eslintignore
@@ -1,2 +1,0 @@
-coverage/
-dist/

--- a/packages/oas/.npmignore
+++ b/packages/oas/.npmignore
@@ -1,3 +1,0 @@
-coverage/
-test/
-.eslint*

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -72,7 +72,7 @@
     "attw": "attw --pack --format table-flipped",
     "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
-    "lint:js": "eslint . --ext .js,.ts",
+    "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",


### PR DESCRIPTION
## 🧰 Changes

Doing a little mess-around in this repo and refactored a few config files (some are a bit new and opinionated so feel free to push back on any of this)
- [x] **5b70e5370a01109536536fedfd94c8b56a464d32 Removed the `.npmignore` files** — these are no longer needed since we use [the `files` option](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files) (you can confirm this by running `npm pack` and looking at the file list in any of the subpackages)
- [x] **f4d0b92a02de8873c8308af04b036393c7cc2c3c added a `prelint` step** — it feels a bit counterintuitive that we need to build the `dist` before we lint, so I figured this made sense.
- [x] **91cacfd9f23fc437d11159ecd3d93116260dd0e3 cleaned up the `.prettierignore` file** — as of Prettier 3.0, files in the `.gitignore` are ignored by default: https://prettier.io/blog/2023/07/05/3.0.0.html#cli
- [x] **afc5fd88cace19fbad6e107aed2f7fed81f2ce66 removed the `.eslintignore` files in favor of the `--ignore-path` CLI option** — this is somewhat opinionated but I generally like being able to consolidate config file options when possible


## 🧬 QA & Testing

To confirm the `npmignore` changes, you can confirm this by running `npm pack` and looking at the file list in any of the subpackages. And if the linting step passes, the Prettier/ESLint config file changes should be safe.
