### PR TITLE
fix(oas-extensions): moving `oas` from being a peer to a hard dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20799,6 +20799,9 @@
       "name": "@readme/oas-extensions",
       "version": "20.0.2",
       "license": "ISC",
+      "dependencies": {
+        "oas": "file:../oas"
+      },
       "devDependencies": {
         "@readme/oas-examples": "^5.12.0",
         "@vitest/coverage-v8": "^0.34.3",
@@ -20809,9 +20812,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "oas": "file:../oas"
       }
     },
     "packages/oas-normalize": {

--- a/packages/oas-extensions/package.json
+++ b/packages/oas-extensions/package.json
@@ -39,7 +39,7 @@
     "prepack": "npm run build",
     "test": "vitest run --coverage"
   },
-  "peerDependencies": {
+  "dependencies": {
     "oas": "file:../oas"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🧰 Changes

Something I didn't know is that with Lerna if you use the `file:../<dirname>` syntax for loading dependencies in a monorepo, but do that for a peer dependency, Lerna and NPM won't change that `file:` reference when publishing a release. This was causing issues within `oas-extensions` where because `oas` was listed as a peer dependency when I loaded in the latest release of `oas-extensions` it was trying to load `oas` from the same `file:` path in another repository of mine. 

Yikes!
