### PR TITLE
fix(oas): use of `typesVersions` for full support of `exports` in TypeScript

### DIFF
--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -8,38 +8,42 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "module": "./dist/index.js",
+      "default": "./dist/index.cjs"
     },
     "./analyzer": {
-      "require": "./dist/analyzer/index.cjs",
-      "import": "./dist/analyzer/index.js"
+      "import": "./dist/analyzer/index.js",
+      "module": "./dist/analyzer/index.js",
+      "default": "./dist/analyzer/index.cjs"
     },
     "./lib/reducer": {
-      "require": "./dist/lib/reducer.cjs",
-      "import": "./dist/lib/reducer.js"
+      "import": "./dist/lib/reducer.js",
+      "module": "./dist/lib/reducer.js",
+      "default": "./dist/lib/reducer.cjs"
     },
     "./rmoas.types": {
-      "require": "./dist/rmoas.types.cjs",
-      "import": "./dist/rmoas.types.js"
+      "import": "./dist/rmoas.types.js",
+      "module": "./dist/rmoas.types.js",
+      "default": "./dist/rmoas.types.cjs"
     },
     "./operation": {
-      "require": "./dist/operation.cjs",
-      "import": "./dist/operation.js"
+      "import": "./dist/operation.js",
+      "module": "./dist/operation.js",
+      "default": "./dist/operation.cjs"
     },
     "./operation/get-parameters-as-json-schema": {
-      "require": "./dist/operation/get-parameters-as-json-schema.cjs",
-      "import": "./dist/operation/get-parameters-as-json-schema.js"
+      "import": "./dist/operation/get-parameters-as-json-schema.js",
+      "module": "./dist/operation/get-parameters-as-json-schema.js",
+      "default": "./dist/operation/get-parameters-as-json-schema.cjs"
     },
     "./package.json": "./package.json",
     "./utils": {
-      "require": "./dist/utils.cjs",
-      "import": "./dist/utils.js"
+      "import": "./dist/utils.js",
+      "module": "./dist/utils.js",
+      "default": "./dist/utils.cjs"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.cts",
   "typesVersions": {
     "*": {
       "analyzer": [
@@ -62,6 +66,9 @@
       ]
     }
   },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.cts",
   "engines": {
     "node": ">=18"
   },

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -40,6 +40,28 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
+  "typesVersions": {
+    "*": {
+      "analyzer": [
+        "./dist/analyzer.d.ts"
+      ],
+      "lib/reducer": [
+        "./dist/lib/reducer.d.ts"
+      ],
+      "rmoas.types": [
+        "./dist/rmoas.types.d.ts"
+      ],
+      "operation": [
+        "./dist/operation.d.ts"
+      ],
+      "operation/get-parameters-as-json-schema": [
+        "./dist/operation/get-parameters-as-json-schema.d.ts"
+      ],
+      "utils": [
+        "./dist/utils.d.ts"
+      ]
+    }
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## 🧰 Changes

When using TypeScript with version `23.x.x` it will complain it can not find the subpackages(see `exports` in package.json). So to make it work `typesVersions` needs to be added and then the typecheck will be fine.

https://arethetypeswrong.github.io/?p=oas%4023.0.0

https://nodejs.org/api/packages.html#subpath-imports

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.