### PR TITLE
feat(oas-to-har): reducing the `lodash` footprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3718,10 +3718,28 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.199",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
-      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==",
+      "version": "4.14.200",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
       "dev": true
+    },
+    "node_modules/@types/lodash.get": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.8.tgz",
+      "integrity": "sha512-XK+co6sBkJxh1vaVP8al6cAA17dX//RNCknGG8JhpHFJfxq/GXKAYB9NKheG22pu2xpWpxfFd65W08EhH2IFlg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.set": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.8.tgz",
+      "integrity": "sha512-WYIWnVO5xkcEKehhZf0Whrf9wj9D1AuaGTpwT/mCEJXKgdC2UWcMpvRqJahKQNhnOjmGEhpUqbYNJ6gUgdGSQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.13",
@@ -13098,6 +13116,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -13139,6 +13162,11 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -20996,7 +21024,8 @@
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
         "@readme/oas-extensions": "file:../oas-extensions",
-        "lodash": "^4.17.21",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
         "oas": "file:../oas",
         "qs": "^6.11.2",
         "remove-undefined-objects": "^5.0.0"
@@ -21004,7 +21033,8 @@
       "devDependencies": {
         "@readme/oas-examples": "^5.12.0",
         "@types/har-format": "^1.2.12",
-        "@types/lodash": "^4.14.198",
+        "@types/lodash.get": "^4.4.8",
+        "@types/lodash.set": "^4.3.8",
         "@types/qs": "^6.9.8",
         "@vitest/coverage-v8": "^0.34.4",
         "eslint": "^8.49.0",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "@readme/data-urls": "^3.0.0",
     "@readme/oas-extensions": "file:../oas-extensions",
-    "lodash": "^4.17.21",
+    "lodash.get": "^4.4.2",
+    "lodash.set": "^4.3.2",
     "oas": "file:../oas",
     "qs": "^6.11.2",
     "remove-undefined-objects": "^5.0.0"
@@ -59,7 +60,8 @@
   "devDependencies": {
     "@readme/oas-examples": "^5.12.0",
     "@types/har-format": "^1.2.12",
-    "@types/lodash": "^4.14.198",
+    "@types/lodash.get": "^4.4.8",
+    "@types/lodash.set": "^4.3.8",
     "@types/qs": "^6.9.8",
     "@vitest/coverage-v8": "^0.34.4",
     "eslint": "^8.49.0",

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -17,8 +17,8 @@ import type {
 
 import { parse as parseDataUrl } from '@readme/data-urls';
 import { getExtension, PROXY_ENABLED, HEADERS } from '@readme/oas-extensions';
-import lodashGet from 'lodash/get.js';
-import lodashSet from 'lodash/set.js';
+import lodashGet from 'lodash.get';
+import lodashSet from 'lodash.set';
 import Operation from 'oas/operation';
 import { isRef } from 'oas/rmoas.types';
 import { jsonSchemaTypes, matchesMimeType } from 'oas/utils';

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, SchemaObject } from 'oas/rmoas.types';
 
-import lodashGet from 'lodash/get.js';
+import lodashGet from 'lodash.get';
 
 /**
  * Determine if a schema `type` is, or contains, a specific discriminator.


### PR DESCRIPTION
| 🚥 Resolves #815 |
| :------------------- |

## 🧰 Changes

This slightly reduces our `lodash` footprint in `oas-to-har` by loading the dedicated packages for `lodash.get` and `lodash.set` instead of grabbing those methods out of the larger package.

#815 also was curious about removing `qs` in favor of `URLSearchParams` because `URLSearchParams` doesn't support deep objects the same way `qs` does.
