### PR TITLE
refactor: update getTags() function to handle webhooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3056,9 +3056,9 @@
       }
     },
     "node_modules/@readme/oas-examples": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.12.0.tgz",
-      "integrity": "sha512-qFBl1HJVHOW9x+9k6Egi9zr0wHXitqsZnSjAiBExDFIH6aS9vLEkKehDdVnntcjnYi6HzmIG5Z/iDZb7q56P8g==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.12.1.tgz",
+      "integrity": "sha512-bKMk2gqpkvmaSvpTnVgfRXJ+sDWglRjNCHw/LFFMd02n+nYaXzn1ciOU3Uhn6C3VtDeZZjxGGTofS/xCqQGFLQ==",
       "dev": true
     },
     "node_modules/@readme/oas-to-har": {

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -758,6 +758,20 @@ export default class Oas {
       });
     });
 
+    Object.entries(this.getWebhooks()).forEach(([path, webhooks]) => {
+      Object.values(webhooks).forEach(webhook => {
+        const tags = webhook.getTags();
+        if (setIfMissing && !tags.length) {
+          allTags.add(path);
+          return;
+        }
+
+        tags.forEach(tag => {
+          allTags.add(tag.name);
+        });
+      });
+    });
+
     return Array.from(allTags);
   }
 

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -734,7 +734,6 @@ export default class Oas {
   /**
    * Return an array of all tag names that exist on this API definition.
    *
-   * Note: This method right now does **not** factor in webhooks that have tags.
    *
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1616,7 +1616,7 @@ describe('#getWebhooks()', () => {
 describe('#getTags()', () => {
   it('should return all tags that are present in a definition', () => {
     expect(petstore.getTags()).toStrictEqual(['pet', 'store', 'user']);
-    expect(webhooks.getTags()).toStrictEqual(['webhooks']);
+    expect(webhooks.getTags()).toStrictEqual(['Webhooks']);
   });
 
   describe('setIfMissing option', () => {

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -527,6 +527,7 @@ describe('#operation()', () => {
       responses: {
         200: expect.any(Object),
       },
+      tags: expect.any(Array),
     });
   });
 
@@ -1613,8 +1614,9 @@ describe('#getWebhooks()', () => {
 });
 
 describe('#getTags()', () => {
-  it('should all tags that are present in a definition', () => {
+  it('should return all tags that are present in a definition', () => {
     expect(petstore.getTags()).toStrictEqual(['pet', 'store', 'user']);
+    expect(webhooks.getTags()).toStrictEqual(['webhooks']);
   });
 
   describe('setIfMissing option', () => {


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes
I've updated the `.getTags()` function to be able to handle webhooks as well in preparation for our webhooks support. This makes it so that any webhooks present in the file will have their tags correctly generated and put in the correct category. Prior to this, it was just placing the endpoint pages in random places. 

This particular test will fail until the [updated](https://github.com/readmeio/oas-examples/pull/90) `webhooks.yaml` file on the `oas-examples` repo is pulled in.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
