### PR TITLE
feat: add support for ordering via `tags` array

### DIFF
--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -743,6 +743,11 @@ export default class Oas {
   getTags(setIfMissing = false) {
     const allTags = new Set<string>();
 
+    const oasTags =
+      this.api.tags?.map(tag => {
+        return tag.name;
+      }) || [];
+
     Object.entries(this.getPaths()).forEach(([path, operations]) => {
       Object.values(operations).forEach(operation => {
         const tags = operation.getTags();
@@ -771,7 +776,29 @@ export default class Oas {
       });
     });
 
-    return Array.from(allTags);
+    // Tags that exist only on the endpoint
+    const endpointTags: string[] = [];
+    // Tags that the user has defined in the `tags` array
+    const tagsArray: string[] = [];
+
+    // Distinguish between which tags exist in the `tags` array and which tags
+    // exist only at the endpoint level. For tags that exist only at the
+    // endpoint level, we'll just tack that on to the end of the sorted tags.
+    Array.from(allTags).forEach(tag => {
+      if (oasTags.includes(tag)) {
+        tagsArray.push(tag);
+      } else {
+        endpointTags.push(tag);
+      }
+    });
+
+    let sortedTags = tagsArray.sort((a, b) => {
+      return oasTags.indexOf(a) - oasTags.indexOf(b);
+    });
+
+    sortedTags = sortedTags.concat(endpointTags);
+
+    return sortedTags;
   }
 
   /**

--- a/packages/oas/test/__datasets__/ordered-tags.json
+++ b/packages/oas/test/__datasets__/ordered-tags.json
@@ -75,7 +75,7 @@
           "200": {
             "description": "successful operation"
           }
-        }      
+        }
       }
     }
   }

--- a/packages/oas/test/__datasets__/ordered-tags.json
+++ b/packages/oas/test/__datasets__/ordered-tags.json
@@ -1,0 +1,82 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore"
+  },
+  "tags": [
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        }
+      },
+      "put": {
+        "tags": ["endpoint"],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "responses": {
+          "200": {
+            "description": "successful operation"
+          }
+        }      
+      }
+    }
+  }
+}

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -11,6 +11,7 @@ let webhooks: Oas;
 let pathMatchingQuirks: Oas;
 let pathVariableQuirks: Oas;
 let serverVariables: Oas;
+let orderedTags: Oas;
 
 beforeAll(async () => {
   petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default).then(Oas.init);
@@ -18,6 +19,7 @@ beforeAll(async () => {
   pathMatchingQuirks = await import('./__datasets__/path-matching-quirks.json').then(r => r.default).then(Oas.init);
   pathVariableQuirks = await import('./__datasets__/path-variable-quirks.json').then(r => r.default).then(Oas.init);
   serverVariables = await import('./__datasets__/server-variables.json').then(r => r.default).then(Oas.init);
+  orderedTags = await import('./__datasets__/ordered-tags.json').then(r => r.default).then(Oas.init);
 });
 
 test('should be able to access properties on the class instance', () => {
@@ -1617,6 +1619,10 @@ describe('#getTags()', () => {
   it('should return all tags that are present in a definition', () => {
     expect(petstore.getTags()).toStrictEqual(['pet', 'store', 'user']);
     expect(webhooks.getTags()).toStrictEqual(['Webhooks']);
+  });
+
+  it('should respect `tags` array ordering', () => {
+    expect(orderedTags.getTags()).toStrictEqual(['user', 'store', 'pet', 'endpoint']);
   });
 
   describe('setIfMissing option', () => {


### PR DESCRIPTION
| 🚥 Resolves CX-514 |
| :------------------- |

## 🧰 Changes
These changes adds support for ordering pages by the `tags` array as defined in OAS spec.

Per [OAS Spec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#fixed-fields):
`The order of the tags can be used to reflect on their order by the parsing tools.`

The tags on `this.api.tags` comes in in the correct order, however, we create a new array `Array.from(allTags)` with tags added as we parse the file from top down. With these changes, I sort this array against the correctly ordered `oasTags`. Since the sorting will put tags that exist only at the endpoint level to the front, I also separate them and tack them on to the end of the sorted tags.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
