### PR TITLE
chore(deps): lodash security vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3660,24 +3660,15 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==",
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
-    "node_modules/@types/lodash.get": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.8.tgz",
-      "integrity": "sha512-XK+co6sBkJxh1vaVP8al6cAA17dX//RNCknGG8JhpHFJfxq/GXKAYB9NKheG22pu2xpWpxfFd65W08EhH2IFlg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.set": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.8.tgz",
-      "integrity": "sha512-WYIWnVO5xkcEKehhZf0Whrf9wj9D1AuaGTpwT/mCEJXKgdC2UWcMpvRqJahKQNhnOjmGEhpUqbYNJ6gUgdGSQw==",
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -12912,15 +12903,15 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
@@ -12939,11 +12930,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -21423,8 +21409,7 @@
       "license": "ISC",
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
+        "lodash-es": "^4.17.21",
         "oas": "file:../oas",
         "qs": "^6.11.2",
         "remove-undefined-objects": "^5.0.0"
@@ -21432,8 +21417,7 @@
       "devDependencies": {
         "@readme/oas-examples": "^5.12.0",
         "@types/har-format": "^1.2.12",
-        "@types/lodash.get": "^4.4.8",
-        "@types/lodash.set": "^4.3.8",
+        "@types/lodash-es": "^4.17.12",
         "@types/qs": "^6.9.8",
         "@vitest/coverage-v8": "^0.34.4",
         "eslint": "^8.49.0",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -50,8 +50,7 @@
   },
   "dependencies": {
     "@readme/data-urls": "^3.0.0",
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2",
+    "lodash-es": "^4.17.21",
     "oas": "file:../oas",
     "qs": "^6.11.2",
     "remove-undefined-objects": "^5.0.0"
@@ -59,8 +58,7 @@
   "devDependencies": {
     "@readme/oas-examples": "^5.12.0",
     "@types/har-format": "^1.2.12",
-    "@types/lodash.get": "^4.4.8",
-    "@types/lodash.set": "^4.3.8",
+    "@types/lodash-es": "^4.17.12",
     "@types/qs": "^6.9.8",
     "@vitest/coverage-v8": "^0.34.4",
     "eslint": "^8.49.0",

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -16,8 +16,7 @@ import type {
 } from 'oas/types';
 
 import { parse as parseDataUrl } from '@readme/data-urls';
-import lodashGet from 'lodash.get';
-import lodashSet from 'lodash.set';
+import { get as lodashGet, set as lodashSet } from 'lodash-es';
 import { HEADERS, PROXY_ENABLED } from 'oas/extensions';
 import { Operation } from 'oas/operation';
 import { isRef } from 'oas/types';

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, SchemaObject } from 'oas/types';
 
-import lodashGet from 'lodash.get';
+import { get as lodashGet } from 'lodash-es';
 
 /**
  * Determine if a schema `type` is, or contains, a specific discriminator.


### PR DESCRIPTION
| 🚥 Resolves(?) https://github.com/readmeio/oas/security/dependabot/14 |
| :------------------- |

## 🧰 Changes

Swaps out our `lodash.get` and `lodash.set` packages for the more modern ES equivalents to hopefully take care of https://github.com/readmeio/oas/security/dependabot/14

## 🧬 QA & Testing

Do tests pass?
