### PR TITLE
fix(oas): numerous tweaks to our camelCase `operationId` generation

### DIFF
--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -1072,7 +1072,7 @@ describe('#getOperationId()', () => {
       });
 
       const operation = spec.operation('/ac_eq_hazard/18.0', 'post');
-      expect(operation.getOperationId({ camelCase: true })).toBe('postAc_eq_hazard180');
+      expect(operation.getOperationId({ camelCase: true })).toBe('postAcEqHazard180');
     });
 
     it('should not double up on a method prefix if the path starts with the method', () => {
@@ -1110,7 +1110,25 @@ describe('#getOperationId()', () => {
       });
 
       const operation = spec.operation('/candidate/{candidate_id}/', 'get');
-      expect(operation.getOperationId({ camelCase: true })).toBe('getCandidateCandidate_id');
+      expect(operation.getOperationId({ camelCase: true })).toBe('getCandidateId');
+    });
+
+    it('should not create an operationId that includes the same word in a consequtive sequence', () => {
+      const spec = Oas.init({
+        openapi: '3.1.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        paths: {
+          '/pet/{pet}/adoption': {
+            post: {},
+          },
+        },
+      });
+
+      const operation = spec.operation('/pet/{pet}/adoption', 'post');
+      expect(operation.getOperationId({ camelCase: true })).toBe('postPetAdoption');
     });
 
     it.each([
@@ -1120,7 +1138,7 @@ describe('#getOperationId()', () => {
           // This operationID is already fine to use as a JS method accessor we're just slightly
           // modifying it so it fits as a method accessor.
           operationId: 'ExchangeRESTAPI_GetAccounts',
-          expected: 'exchangeRESTAPI_GetAccounts',
+          expected: 'exchangeRESTAPIGetAccounts',
         },
       ],
       [
@@ -1151,7 +1169,7 @@ describe('#getOperationId()', () => {
         'should clean up an operationId that starts with a number',
         {
           operationId: '400oD_Browse_by_Date_Feed',
-          expected: '_400oD_Browse_by_Date_Feed',
+          expected: '_400oDBrowseByDateFeed',
         },
       ],
     ])('%s', (_, { operationId, expected }) => {

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -1113,7 +1113,7 @@ describe('#getOperationId()', () => {
       expect(operation.getOperationId({ camelCase: true })).toBe('getCandidateId');
     });
 
-    it('should not create an operationId that includes the same word in a consequtive sequence', () => {
+    it('should not create an operationId that includes the same word in a consecutive sequence', () => {
       const spec = Oas.init({
         openapi: '3.1.0',
         info: {


### PR DESCRIPTION
## 🧰 Changes

Talking with @julshotal this afternoon I stumbled upon some oversight with our Git project planning where I wasn't sure what we'd use for endpoint pages we're storing in Git, either alternating between using `title` (when present) or the `camelCase` option on `Operation.getOperationId()`. Long story short working it out with her I discovered a bug in this method where we weren't camelcasing underscores in auto-generated IDs (like `postAc_eq_hazard180` -> `postAcEqHazard180`). Frustratingly enough I had a test that was testing for this very specific thing, the test just wasn't asserting the right expectation.

Additionally while working on a fix for this I'm also proposing another small tweak to this same method to no longer generate operation IDs with consecutive words. This issue is admittedly pretty rare but when it does happen we end up with some bunk-ass IDs like `GET /pet/{pet_id}` being transformed into `getPetPetId`. The new work I've put in here will now filter out consecutive words and generate `getPetId` in this case. Still not the _best_ operation ID for this endpoint because it's not returning a pet ID but it at least doesn't look like total ass.