### PR TITLE
feat(extensions/code-samples): add support for correspondingExample

### DIFF
--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -171,6 +171,10 @@ export const SIMPLE_MODE = 'simple-mode';
 export interface Extensions {
   [CODE_SAMPLES]: {
     code: string;
+    /**
+     * @see {@link https://docs.readme.com/main/docs/openapi-extensions#corresponding-response-examples}
+     */
+    correspondingExample?: string;
     install?: string;
     language: string;
     name?: string;


### PR DESCRIPTION
## 🧰 Changes

Adds a type definition + docs for our new `correspondingExample`.