### PR TITLE
feat(oas-to-snippet): exporting the `HarRequest` type for use

### DIFF
--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -15,6 +15,10 @@
       "require": "./dist/languages.cjs",
       "import": "./dist/languages.js"
     },
+    "./types": {
+      "require": "./dist/types.cjs",
+      "import": "./dist/types.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -1,5 +1,5 @@
 import type { Language } from './languages.js';
-import type { HarRequest } from '@readme/httpsnippet';
+import type { HarRequest } from './types.js';
 import type { ClientPlugin, TargetId } from '@readme/httpsnippet/targets';
 import type { AuthForHAR, DataForHAR } from '@readme/oas-to-har/lib/types';
 import type Oas from 'oas';

--- a/packages/oas-to-snippet/src/types.ts
+++ b/packages/oas-to-snippet/src/types.ts
@@ -1,0 +1,1 @@
+export type { HarRequest } from '@readme/httpsnippet';

--- a/packages/oas-to-snippet/tsup.config.ts
+++ b/packages/oas-to-snippet/tsup.config.ts
@@ -7,6 +7,6 @@ export default defineConfig(options => ({
   ...options,
   ...config,
 
-  entry: ['src/index.ts', 'src/languages.ts'],
+  entry: ['src/index.ts', 'src/languages.ts', 'src/types.ts'],
   silent: !options.watch,
 }));


### PR DESCRIPTION
## 🧰 Changes

This re-exports the `HarRequest` type out of `@readme/httpsnippet` from `oas-to-har` so it can be easily used from that instead of having to re-import, and have `@readme/httpsnippet` as a dependency, when you need it.
