### PR TITLE
refactor: strict mode, more helpful return types

### DIFF
--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -85,7 +85,7 @@ export default class OASNormalize {
    * @private
    */
   static convertPostmanToOpenAPI(schema: any) {
-    return postmanToOpenAPI(JSON.stringify(schema), null, { outputFormat: 'json', replaceVars: true }).then(JSON.parse);
+    return postmanToOpenAPI(JSON.stringify(schema), undefined, { outputFormat: 'json', replaceVars: true }).then(JSON.parse);
   }
 
   /**

--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -85,7 +85,9 @@ export default class OASNormalize {
    * @private
    */
   static convertPostmanToOpenAPI(schema: any) {
-    return postmanToOpenAPI(JSON.stringify(schema), undefined, { outputFormat: 'json', replaceVars: true }).then(JSON.parse);
+    return postmanToOpenAPI(JSON.stringify(schema), undefined, { outputFormat: 'json', replaceVars: true }).then(
+      JSON.parse,
+    );
   }
 
   /**

--- a/packages/oas-normalize/src/lib/utils.ts
+++ b/packages/oas-normalize/src/lib/utils.ts
@@ -9,7 +9,7 @@ export function isBuffer(obj: any) {
     obj != null &&
     obj.constructor != null &&
     typeof obj.constructor.isBuffer === 'function' &&
-    obj.constructor.isBuffer(obj)
+    !!obj.constructor.isBuffer(obj)
   );
 }
 

--- a/packages/oas-normalize/src/lib/utils.ts
+++ b/packages/oas-normalize/src/lib/utils.ts
@@ -83,14 +83,14 @@ export function isSwagger(schema: Record<string, unknown>) {
  * Convert a YAML blob or stringified JSON object into a JSON object.
  *
  */
-export function stringToJSON(string: Record<string, unknown> | string) {
+export function stringToJSON(string: Record<string, unknown> | string): Record<string, unknown> {
   if (typeof string === 'object') {
     return string;
   } else if (string.match(/^\s*{/)) {
     return JSON.parse(string);
   }
 
-  return YAML.load(string, { schema: JSON_SCHEMA });
+  return YAML.load(string, { schema: JSON_SCHEMA }) as Record<string, unknown>;
 }
 
 /**

--- a/packages/oas-normalize/tsconfig.json
+++ b/packages/oas-normalize/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     // DOM is needed because `oas-normalize` uses `fetch`.
-    "lib": ["DOM"]
+    "lib": ["DOM"],
+    "strict": true
   },
   "include": ["./src/**/*"],
   "exclude": ["dist"]

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -1,5 +1,5 @@
 import type { AuthForHAR, DataForHAR, oasToHarOptions } from './lib/types.js';
-import type { PostDataParams, Request } from 'har-format';
+import type { PostData, PostDataParams, Request } from 'har-format';
 import type Oas from 'oas';
 import type { Extensions } from 'oas/extensions';
 import type { SchemaWrapper } from 'oas/operation/get-parameters-as-json-schema';
@@ -13,6 +13,7 @@ import type {
   RequestBodyObject,
   ResponseObject,
   SchemaObject,
+  ServerVariable,
 } from 'oas/types';
 
 import { parse as parseDataUrl } from '@readme/data-urls';
@@ -95,7 +96,7 @@ function multipartBodyToFormatterParams(payload: unknown, oasMediaTypeObject: Me
     return Object.keys(payload)
       .map(key => {
         // If we have an incoming parameter, but it's not in the schema ignore it.
-        if (!schema.properties[key]) {
+        if (!schema.properties?.[key]) {
           return false;
         }
 
@@ -252,12 +253,15 @@ export default function oasToHar(
 
   const formData: DataForHAR = {
     ...defaultFormDataTypes,
-    server: {
-      selected: 0,
-      variables: oas.defaultVariables(0),
-    },
     ...values,
   };
+
+  if (!formData.server) {
+    formData.server = {
+      selected: 0,
+      variables: oas.defaultVariables(0),
+    };
+  }
 
   // If the incoming `server.variables` is missing variables let's pad it out with defaults.
   formData.server.variables = {
@@ -274,7 +278,10 @@ export default function oasToHar(
     postData: {},
     bodySize: 0,
     method: operation.method.toUpperCase(),
-    url: `${oas.url(formData.server.selected, formData.server.variables)}${operation.path}`.replace(/\s/g, '%20'),
+    url: `${oas.url(formData.server.selected, formData.server.variables as ServerVariable)}${operation.path}`.replace(
+      /\s/g,
+      '%20',
+    ),
     httpVersion: 'HTTP/1.1',
   };
 
@@ -321,14 +328,14 @@ export default function oasToHar(
   // Does this response have any documented content types?
   if (operation.schema.responses) {
     Object.keys(operation.schema.responses).some(response => {
-      if (isRef(operation.schema.responses[response])) return false;
+      if (isRef(operation.schema.responses?.[response])) return false;
 
-      const content = (operation.schema.responses[response] as ResponseObject).content;
+      const content = (operation.schema.responses?.[response] as ResponseObject).content;
       if (!content) return false;
 
       // If there's no `accept` header present we should add one so their eventual code snippet
       // follows best practices.
-      if (Object.keys(formData.header).find(h => h.toLowerCase() === 'accept')) return true;
+      if (Object.keys(formData.header || {}).find(h => h.toLowerCase() === 'accept')) return true;
 
       har.headers.push({
         name: 'accept',
@@ -393,7 +400,7 @@ export default function oasToHar(
     }
   }
 
-  let requestBody: SchemaWrapper;
+  let requestBody: SchemaWrapper | undefined;
   if (operation.hasRequestBody()) {
     requestBody = operation.getParametersAsJSONSchema().find(payload => {
       // `formData` is used in our API Explorer for `application/x-www-form-urlencoded` endpoints
@@ -407,18 +414,19 @@ export default function oasToHar(
     const requestBodySchema = requestBody.schema as SchemaObject;
 
     if (operation.isFormUrlEncoded()) {
-      if (Object.keys(formData.formData).length) {
+      if (Object.keys(formData.formData || {}).length) {
         const cleanFormData = removeUndefinedObjects(JSON.parse(JSON.stringify(formData.formData)));
         if (cleanFormData !== undefined) {
-          har.postData.params = [];
-          har.postData.mimeType = 'application/x-www-form-urlencoded';
+          const postData: PostData = { params: [], mimeType: 'application/x-www-form-urlencoded' };
 
           Object.keys(cleanFormData).forEach(name => {
-            har.postData.params.push({
+            postData.params.push({
               name,
               value: stringifyParameter(cleanFormData[name]),
             });
           });
+
+          har.postData = postData;
         }
       }
     } else if (
@@ -434,8 +442,7 @@ export default function oasToHar(
           let cleanBody = removeUndefinedObjects(JSON.parse(JSON.stringify(formData.body)));
 
           if (isMultipart) {
-            har.postData.mimeType = 'multipart/form-data';
-            har.postData.params = [];
+            har.postData = { params: [], mimeType: 'multipart/form-data' };
 
             // Because some request body schema shapes might not always be a top-level `properties`,
             // instead nesting it in an `oneOf` or `anyOf` we need to extract the first usable
@@ -503,13 +510,13 @@ export default function oasToHar(
                       }
                     }
 
-                    appendHarValue(har.postData.params, name, val, addtlData);
+                    appendHarValue((har.postData?.params || []), name, val, addtlData);
                   });
                 });
               }
             }
           } else {
-            har.postData.mimeType = contentType;
+            har.postData = { mimeType: contentType, text: '' };
 
             if (
               hasSchemaType(requestBody.schema, 'string') ||
@@ -531,9 +538,9 @@ export default function oasToHar(
 
               if (Array.isArray(jsonTypes) && jsonTypes.length) {
                 try {
-                  jsonTypes.forEach((prop: string) => {
+                  jsonTypes.forEach((prop: boolean | string) => {
                     try {
-                      lodashSet(cleanBody, prop, JSON.parse(lodashGet(cleanBody, prop)));
+                      lodashSet(cleanBody, String(prop), JSON.parse(lodashGet(cleanBody, String(prop))));
                     } catch (e) {
                       // leave the prop as a string value
                     }
@@ -557,11 +564,10 @@ export default function oasToHar(
         } catch (e) {
           // If anything above fails for whatever reason, assume that whatever we had is invalid
           // JSON and just treat it as raw text.
-          har.postData.text = stringify(formData.body);
+          har.postData = { mimeType: contentType, text: stringify(formData.body) };
         }
       } else {
-        har.postData.mimeType = contentType;
-        har.postData.text = encodeBodyForHAR(formData.body);
+        har.postData = { mimeType: contentType, text: encodeBodyForHAR(formData.body) };
       }
     }
   }
@@ -570,7 +576,7 @@ export default function oasToHar(
   // defined, but only do so if we don't already have a `content-type` present as it's impossible
   // for a request to have multiple.
   if (
-    (har.postData.text || (requestBody && requestBody.schema && Object.keys(requestBody.schema).length)) &&
+    (har.postData?.text || (requestBody && requestBody.schema && Object.keys(requestBody.schema).length)) &&
     !hasContentType
   ) {
     har.headers.push({
@@ -613,7 +619,7 @@ export default function oasToHar(
   }
 
   // If we didn't end up filling the `postData` object then we don't need it.
-  if (Object.keys(har.postData).length === 0) {
+  if (Object.keys(har.postData || {}).length === 0) {
     delete har.postData;
   }
 

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -488,30 +488,32 @@ export default function oasToHar(
                 Object.keys(cleanBody).forEach(name => {
                   const param = multipartParams.find(multipartParam => multipartParam.name === name);
 
-                  // If we're dealing with a binary type, and the value is a valid data URL we should
-                  // parse out any available filename and content type to send along with the
-                  // parameter to interpreters like `fetch-har` can make sense of it and send a usable
-                  // payload.
-                  const addtlData: { contentType?: string; fileName?: string } = {};
+                  if (param) {
+                    // If we're dealing with a binary type, and the value is a valid data URL we should
+                    // parse out any available filename and content type to send along with the
+                    // parameter to interpreters like `fetch-har` can make sense of it and send a usable
+                    // payload.
+                    const addtlData: { contentType?: string; fileName?: string } = {};
 
-                  let value = formatter(formData, param, 'body', true);
-                  if (!Array.isArray(value)) {
-                    value = [value];
-                  }
-
-                  value.forEach((val: string) => {
-                    if (binaryTypes.includes(name)) {
-                      const parsed = parseDataUrl(val);
-                      if (parsed) {
-                        addtlData.fileName = 'name' in parsed ? parsed.name : 'unknown';
-                        if ('contentType' in parsed) {
-                          addtlData.contentType = parsed.contentType;
-                        }
-                      }
+                    let value = formatter(formData, param, 'body', true);
+                    if (!Array.isArray(value)) {
+                      value = [value];
                     }
 
-                    appendHarValue((har.postData?.params || []), name, val, addtlData);
-                  });
+                    value.forEach((val: string) => {
+                      if (binaryTypes.includes(name)) {
+                        const parsed = parseDataUrl(val);
+                        if (parsed) {
+                          addtlData.fileName = 'name' in parsed ? parsed.name : 'unknown';
+                          if ('contentType' in parsed) {
+                            addtlData.contentType = parsed.contentType;
+                          }
+                        }
+                      }
+
+                      appendHarValue(har.postData?.params || [], name, val, addtlData);
+                    });
+                  }
                 });
               }
             }

--- a/packages/oas-to-har/src/lib/configure-security.ts
+++ b/packages/oas-to-har/src/lib/configure-security.ts
@@ -13,7 +13,7 @@ export default function configureSecurity(apiDefinition: OASDocument, values: Au
 
   if (Object.keys(values || {}).length === 0) return undefined;
 
-  if (!apiDefinition.components.securitySchemes[scheme]) return undefined;
+  if (!apiDefinition.components?.securitySchemes?.[scheme]) return undefined;
   const security = apiDefinition.components.securitySchemes[scheme] as SecuritySchemeObject & {
     'x-bearer-format'?: string;
   };

--- a/packages/oas-to-har/src/lib/style-formatting/index.ts
+++ b/packages/oas-to-har/src/lib/style-formatting/index.ts
@@ -7,7 +7,7 @@ import { stylize } from './style-serializer.js';
 
 // Certain styles don't support empty values.
 function shouldNotStyleEmptyValues(parameter: ParameterObject) {
-  return ['simple', 'spaceDelimited', 'pipeDelimited', 'deepObject'].includes(parameter.style);
+  return ['simple', 'spaceDelimited', 'pipeDelimited', 'deepObject'].includes(parameter.style || '');
 }
 
 function shouldNotStyleReservedHeader(parameter: ParameterObject) {

--- a/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
+++ b/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
@@ -88,7 +88,7 @@ export function encodeDisallowedCharacters(
 
 export interface StylizerConfig {
   escape: boolean | 'unsafe';
-  explode: boolean;
+  explode?: boolean;
   isAllowedReserved?: boolean;
   key: string;
   location: 'body' | 'query';

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -46,7 +46,7 @@ function getSubschemas(schema: any, opts: Options) {
     // If we don't have data for this parent schema in our body payload then we
     // shouldn't bother spidering further into the schema looking for more `format`s
     // for data that definitely doesn't exist.
-    const parentData = lodashGet(opts.payload, opts.parentKey);
+    const parentData = lodashGet(opts.payload, opts.parentKey || '');
     if (parentData === undefined || !Array.isArray(parentData)) {
       return false;
     }
@@ -58,14 +58,14 @@ function getSubschemas(schema: any, opts: Options) {
   if (subSchemaDataSize > 0) {
     for (let idx = 0; idx < subSchemaDataSize; idx += 1) {
       subschemas = subschemas.concat(
-        Object.entries(schema).map(([key, subschema]: [string, JSONSchema]) => ({
+        Object.entries<JSONSchema>(schema).map(([key, subschema]: [string, JSONSchema]) => ({
           key: opts.parentKey ? [opts.parentKey, idx, key].join('.') : key,
           schema: getSafeRequestBody(subschema),
         })),
       );
     }
   } else {
-    subschemas = Object.entries(schema).map(([key, subschema]: [string, JSONSchema]) => ({
+    subschemas = Object.entries<JSONSchema>(schema).map(([key, subschema]: [string, JSONSchema]) => ({
       key: opts.parentKey ? [opts.parentKey, key].join('.') : key,
       schema: getSafeRequestBody(subschema),
     }));
@@ -88,7 +88,7 @@ export function getTypedFormatsInSchema(
   try {
     if (schema?.format === format) {
       if (opts.parentIsArray) {
-        const parentData = lodashGet(opts.payload, opts.parentKey);
+        const parentData = lodashGet(opts.payload, opts.parentKey || '');
         if (parentData !== undefined && Array.isArray(parentData)) {
           return Object.keys(parentData)
             .map(pdk => {

--- a/packages/oas-to-har/tsconfig.json
+++ b/packages/oas-to-har/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "strict": true
   },
   "include": ["./src/**/*"],
   "exclude": ["dist"]

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -1,6 +1,6 @@
-import type { Language } from './languages.js';
+import type { Language, LanguageConfig } from './languages.js';
 import type { HarRequest } from '@readme/httpsnippet';
-import type { ClientPlugin, TargetId } from '@readme/httpsnippet/targets';
+import type { ClientId, ClientPlugin, TargetId } from '@readme/httpsnippet/targets';
 import type { AuthForHAR, DataForHAR } from '@readme/oas-to-har/lib/types';
 import type Oas from 'oas';
 import type { Operation } from 'oas/operation';
@@ -54,9 +54,9 @@ export default function oasToSnippet(
     plugins?: ClientPlugin<any>[];
   } = {},
 ) {
-  let config;
-  let language: TargetId;
-  let target;
+  let config: LanguageConfig | undefined;
+  let language: TargetId | undefined;
+  let target: ClientId | undefined;
 
   const plugins = opts.plugins || [];
 
@@ -78,13 +78,17 @@ export default function oasToSnippet(
     );
   }
 
+  if (!language || !target) {
+    return { code: '', highlightMode: false };
+  }
+
   const har = opts.harOverride || generateHar(oas, operation, values, auth);
   const snippet = new HTTPSnippet(har as HarRequest, {
     // We should only expect HAR's generated with `@readme/oas-to-har` to already be encoded.
     harIsAlreadyEncoded: !opts.harOverride,
   });
 
-  let targetOpts = config.httpsnippet.targets[target].opts || {};
+  let targetOpts = config.httpsnippet.targets[target || ''].opts || {};
   const highlightMode = config.highlight;
 
   plugins.forEach(plugin => {

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -88,7 +88,7 @@ export default function oasToSnippet(
     harIsAlreadyEncoded: !opts.harOverride,
   });
 
-  let targetOpts = config.httpsnippet.targets[target || ''].opts || {};
+  let targetOpts = config.httpsnippet.targets[target].opts || {};
   const highlightMode = config.highlight;
 
   plugins.forEach(plugin => {

--- a/packages/oas-to-snippet/src/languages.ts
+++ b/packages/oas-to-snippet/src/languages.ts
@@ -276,7 +276,7 @@ export function getSupportedLanguages(
     });
   });
 
-  plugins.forEach(({ target, client: { info: clientInfo } }) => {
+  (plugins || []).forEach(({ target, client: { info: clientInfo } }) => {
     const clientKey = clientInfo.key;
 
     languages[target as SupportedTargets].httpsnippet.targets[clientKey] = {
@@ -292,9 +292,9 @@ export function getSupportedLanguages(
 }
 
 export function getLanguageConfig(languages: SupportedLanguages, lang: Language) {
-  let config: LanguageConfig;
-  let language: TargetId;
-  let target: ClientId;
+  let config: LanguageConfig | undefined;
+  let language: TargetId | undefined;
+  let target: ClientId | undefined;
 
   // If `lang` is an array, then it's a mixture of language and targets like `[php, guzzle]` or
   // `[javascript, axios]` so we need to a bit of work to pull out the necessary information
@@ -337,10 +337,10 @@ export function getClientInstallationInstructions(
 ) {
   const { config, target } = getLanguageConfig(languages, lang);
 
-  const install = config?.httpsnippet.targets[target]?.install;
+  const install = config?.httpsnippet.targets[target || '']?.install;
   if (!install) {
     return undefined;
   }
 
-  return install.replace('{packageName}', registryIdentifier);
+  return registryIdentifier ? install.replace('{packageName}', registryIdentifier) : install;
 }

--- a/packages/oas-to-snippet/tsconfig.json
+++ b/packages/oas-to-snippet/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmit": true
+    "noEmit": true,
+    "strict": true
   },
   "include": ["./src/**/*"],
   "exclude": ["dist"]


### PR DESCRIPTION
## 🧰 Changes

- Enabled strict mode in `oas-normalize`, `oas-to-har`, and `oas-to-snippet`
- Added more specific types across the board in `oas-normalize`. It's always bugged me that `.validate()` returns a `Promise<any>`.

## 🧬 QA & Testing

Mostly stricter types, no real functional changes (except maybe slightly better error handling in certain cases).
