### PR TITLE
fix(oas-to-har): use CJS lodash instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,19 +3730,10 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.13",
@@ -12876,11 +12867,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -22091,7 +22077,7 @@
       "license": "ISC",
       "dependencies": {
         "@readme/data-urls": "^3.0.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.21",
         "oas": "file:../oas",
         "qs": "^6.12.0",
         "remove-undefined-objects": "^5.0.0"
@@ -22099,7 +22085,7 @@
       "devDependencies": {
         "@readme/oas-examples": "^5.12.0",
         "@types/har-format": "^1.2.15",
-        "@types/lodash-es": "^4.17.12",
+        "@types/lodash": "^4.17.0",
         "@types/qs": "^6.9.14",
         "@vitest/coverage-v8": "^1.4.0",
         "eslint": "^8.57.0",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@readme/data-urls": "^3.0.0",
-    "lodash-es": "^4.17.21",
+    "lodash": "^4.17.21",
     "oas": "file:../oas",
     "qs": "^6.12.0",
     "remove-undefined-objects": "^5.0.0"
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@readme/oas-examples": "^5.12.0",
     "@types/har-format": "^1.2.15",
-    "@types/lodash-es": "^4.17.12",
+    "@types/lodash": "^4.17.0",
     "@types/qs": "^6.9.14",
     "@vitest/coverage-v8": "^1.4.0",
     "eslint": "^8.57.0",

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -17,7 +17,8 @@ import type {
 } from 'oas/types';
 
 import { parse as parseDataUrl } from '@readme/data-urls';
-import { get as lodashGet, set as lodashSet } from 'lodash-es';
+import lodashGet from 'lodash/get';
+import lodashSet from 'lodash/set';
 import { HEADERS, PROXY_ENABLED } from 'oas/extensions';
 import { Operation } from 'oas/operation';
 import { isRef } from 'oas/types';

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, SchemaObject } from 'oas/types';
 
-import { get as lodashGet } from 'lodash-es';
+import lodashGet from 'lodash/get';
 
 /**
  * Determine if a schema `type` is, or contains, a specific discriminator.


### PR DESCRIPTION
## 🧰 Changes

Looks like our CJS codebase doesn't like `lodash-es`:

<img width="1255" alt="image" src="https://github.com/readmeio/oas/assets/8854718/76f7d69d-0720-48a0-968d-a9aafdb95941">

This PR updates our lodash usage to the standard CJS package instead. If that doesn't solve the problem then I'm gonna look into the far less ideal option, which is including `lodash-es` in our `tsup` bundle, sort of like how we do in [the `api` repo](https://github.com/readmeio/api/blob/429fcf9d9343a52c3cc9fd423f0f8193ac7d17d4/packages/core/tsup.config.ts#L15-L21).


## 🧬 QA & Testing

Tests still pass, but when has that ever been an indicator of things working? 🤡
