### PR TITLE
feat(oas-to-snippet): surface installation instructions with snippets

### DIFF
--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -8,7 +8,7 @@ import type { Operation } from 'oas/operation';
 import { HTTPSnippet, addClientPlugin } from '@readme/httpsnippet';
 import generateHar from '@readme/oas-to-har';
 
-import { getSupportedLanguages, getLanguageConfig } from './languages.js';
+import { getSupportedLanguages, getLanguageConfig, getClientInstallationInstructions } from './languages.js';
 
 export default function oasToSnippet(
   oas: Oas,
@@ -53,7 +53,7 @@ export default function oasToSnippet(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     plugins?: ClientPlugin<any>[];
   } = {},
-): { code: string | false; highlightMode: string | false } {
+): { code: string | false; highlightMode: string | false; install: string | false; } {
   let config: LanguageConfig | undefined;
   let language: TargetId | undefined;
   let target: ClientId | undefined;
@@ -68,7 +68,7 @@ export default function oasToSnippet(
     ({ config, language, target } = getLanguageConfig(languages, lang));
   } catch (err) {
     if (!language || !target) {
-      return { code: '', highlightMode: false };
+      return { code: '', highlightMode: false, install: false };
     }
   }
 
@@ -79,7 +79,7 @@ export default function oasToSnippet(
   }
 
   if (!language || !target) {
-    return { code: '', highlightMode: false };
+    return { code: '', highlightMode: false, install: false };
   }
 
   const har = opts.harOverride || generateHar(oas, operation, values, auth);
@@ -104,11 +104,15 @@ export default function oasToSnippet(
     }
   });
 
+  const install = getClientInstallationInstructions(languages, lang, opts?.openapi?.variableName);
+
   try {
     const code = snippet.convert(language, target, targetOpts);
+
     return {
       code: code ? code[0] : false,
       highlightMode,
+      install: install || false,
     };
   } catch (err) {
     if (language !== 'node' && target !== 'api') {
@@ -127,6 +131,7 @@ export default function oasToSnippet(
     return {
       code: code ? code[0] : false,
       highlightMode,
+      install: install || false,
     };
   }
 }

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -129,7 +129,7 @@ export default function oasToSnippet(
     }
   });
 
-  const install = getClientInstallationInstructions(languages, lang, opts?.openapi?.variableName);
+  const install = getClientInstallationInstructions(languages, lang, opts?.openapi?.variableName) || false;
 
   try {
     const code = snippet.convert(language, target, targetOpts);

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -137,7 +137,7 @@ export default function oasToSnippet(
     return {
       code: code ? code[0] : false,
       highlightMode,
-      install: install || false,
+      install,
     };
   } catch (err) {
     if (language !== 'node' && target !== 'api') {

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -53,7 +53,32 @@ export default function oasToSnippet(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     plugins?: ClientPlugin<any>[];
   } = {},
-): { code: string | false; highlightMode: string | false; install: string | false } {
+): {
+  /**
+   * The resulting code snippet. Returns `false` if a snippet could not be generated.
+   *
+   * @example ```sh
+   * curl --request DELETE --url http://petstore.swagger.io/v2/pet/petId
+   * ```
+   */
+  code: string | false;
+  /**
+   * The programming language (used for syntax highlighting).
+   * Returns `false` if a language could not be determined.
+   *
+   * @example shell
+   */
+  highlightMode: string | false;
+  /**
+   * Installation instructions for using the snippet.
+   * Returns `false` if the snippet does not have an installation step.
+   *
+   * @example ```sh
+   * npm install node-fetch@2 --save
+   * ```
+   */
+  install: string | false;
+} {
   let config: LanguageConfig | undefined;
   let language: TargetId | undefined;
   let target: ClientId | undefined;

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -53,7 +53,7 @@ export default function oasToSnippet(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     plugins?: ClientPlugin<any>[];
   } = {},
-): { code: string | false; highlightMode: string | false; install: string | false; } {
+): { code: string | false; highlightMode: string | false; install: string | false } {
   let config: LanguageConfig | undefined;
   let language: TargetId | undefined;
   let target: ClientId | undefined;

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -156,7 +156,7 @@ export default function oasToSnippet(
     return {
       code: code ? code[0] : false,
       highlightMode,
-      install: install || false,
+      install,
     };
   }
 }

--- a/packages/oas-to-snippet/test/__snapshots__/index.test.ts.snap
+++ b/packages/oas-to-snippet/test/__snapshots__/index.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`oas-to-snippet > supported languages > c > should generate code for the default target 1`] = `
-"CURL *hnd = curl_easy_init();
+{
+  "code": "CURL *hnd = curl_easy_init();
 
 curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
 curl_easy_setopt(hnd, CURLOPT_WRITEDATA, stdout);
@@ -13,13 +14,15 @@ curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
 curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\\"name\\":\\"buster\\"}");
 
-CURLcode ret = curl_easy_perform(hnd);"
+CURLcode ret = curl_easy_perform(hnd);",
+  "highlightMode": "text/x-csrc",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > c > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > c > targets > libcurl > should support snippet generation 1`] = `
-"CURL *hnd = curl_easy_init();
+{
+  "code": "CURL *hnd = curl_easy_init();
 
 curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
 curl_easy_setopt(hnd, CURLOPT_WRITEDATA, stdout);
@@ -29,32 +32,38 @@ struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "accept: application/json");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-CURLcode ret = curl_easy_perform(hnd);"
+CURLcode ret = curl_easy_perform(hnd);",
+  "highlightMode": "text/x-csrc",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > c > targets > libcurl > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > clojure > should generate code for the default target 1`] = `
-"(require '[clj-http.client :as client])
+{
+  "code": "(require '[clj-http.client :as client])
 
 (client/post "http://petstore.swagger.io/v2/pet" {:content-type :json
-                                                  :form-params {:name "buster"}})"
+                                                  :form-params {:name "buster"}})",
+  "highlightMode": "clojure",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > clojure > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > clojure > targets > clj_http > should support snippet generation 1`] = `
-"(require '[clj-http.client :as client])
+{
+  "code": "(require '[clj-http.client :as client])
 
 (client/get "http://petstore.swagger.io/v2/user/login" {:query-params {:username "woof"
                                                                        :password "barkbarkbark"}
-                                                        :accept :json})"
+                                                        :accept :json})",
+  "highlightMode": "clojure",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > clojure > targets > clj_http > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > cplusplus > should generate code for the default target 1`] = `
-"CURL *hnd = curl_easy_init();
+{
+  "code": "CURL *hnd = curl_easy_init();
 
 curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
 curl_easy_setopt(hnd, CURLOPT_WRITEDATA, stdout);
@@ -66,13 +75,15 @@ curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
 curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\\"name\\":\\"buster\\"}");
 
-CURLcode ret = curl_easy_perform(hnd);"
+CURLcode ret = curl_easy_perform(hnd);",
+  "highlightMode": "text/x-c++src",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > cplusplus > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > cplusplus > targets > libcurl > should support snippet generation 1`] = `
-"CURL *hnd = curl_easy_init();
+{
+  "code": "CURL *hnd = curl_easy_init();
 
 curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");
 curl_easy_setopt(hnd, CURLOPT_WRITEDATA, stdout);
@@ -82,13 +93,15 @@ struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "accept: application/json");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
-CURLcode ret = curl_easy_perform(hnd);"
+CURLcode ret = curl_easy_perform(hnd);",
+  "highlightMode": "text/x-c++src",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > cplusplus > targets > libcurl > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > csharp > should generate code for the default target 1`] = `
-"using RestSharp;
+{
+  "code": "using RestSharp;
 
 
 var options = new RestClientOptions("http://petstore.swagger.io/v2/pet");
@@ -98,13 +111,15 @@ request.AddJsonBody("{\\"name\\":\\"buster\\"}", false);
 var response = await client.PostAsync(request);
 
 Console.WriteLine("{0}", response.Content);
-"
+",
+  "highlightMode": "text/x-csharp",
+  "install": "dotnet add package RestSharp",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > csharp > should generate code for the default target 2`] = `"dotnet add package RestSharp"`;
-
 exports[`oas-to-snippet > supported languages > csharp > targets > httpclient > should support snippet generation 1`] = `
-"using System.Net.Http.Headers;
+{
+  "code": "using System.Net.Http.Headers;
 var client = new HttpClient();
 var request = new HttpRequestMessage
 {
@@ -120,13 +135,15 @@ using (var response = await client.SendAsync(request))
     response.EnsureSuccessStatusCode();
     var body = await response.Content.ReadAsStringAsync();
     Console.WriteLine(body);
-}"
+}",
+  "highlightMode": "text/x-csharp",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > csharp > targets > httpclient > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > csharp > targets > restsharp > should support snippet generation 1`] = `
-"using RestSharp;
+{
+  "code": "using RestSharp;
 
 
 var options = new RestClientOptions("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark");
@@ -136,13 +153,15 @@ request.AddHeader("accept", "application/json");
 var response = await client.GetAsync(request);
 
 Console.WriteLine("{0}", response.Content);
-"
+",
+  "highlightMode": "text/x-csharp",
+  "install": "dotnet add package RestSharp",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > csharp > targets > restsharp > should support snippet generation 2`] = `"dotnet add package RestSharp"`;
-
 exports[`oas-to-snippet > supported languages > go > should generate code for the default target 1`] = `
-"package main
+{
+  "code": "package main
 
 import (
 	"fmt"
@@ -168,13 +187,15 @@ func main() {
 
 	fmt.Println(string(body))
 
-}"
+}",
+  "highlightMode": "go",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > go > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > go > targets > native > should support snippet generation 1`] = `
-"package main
+{
+  "code": "package main
 
 import (
 	"fmt"
@@ -197,34 +218,40 @@ func main() {
 
 	fmt.Println(string(body))
 
-}"
+}",
+  "highlightMode": "go",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > go > targets > native > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > http > should generate code for the default target 1`] = `
-"POST /v2/pet HTTP/1.1
+{
+  "code": "POST /v2/pet HTTP/1.1
 Content-Type: application/json
 Host: petstore.swagger.io
 Content-Length: 17
 
-{"name":"buster"}"
+{"name":"buster"}",
+  "highlightMode": "http",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > http > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > http > targets > http1.1 > should support snippet generation 1`] = `
-"GET /v2/user/login?username=woof&password=barkbarkbark HTTP/1.1
+{
+  "code": "GET /v2/user/login?username=woof&password=barkbarkbark HTTP/1.1
 Accept: application/json
 Host: petstore.swagger.io
 
-"
+",
+  "highlightMode": "http",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > http > targets > http1.1 > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > java > should generate code for the default target 1`] = `
-"OkHttpClient client = new OkHttpClient();
+{
+  "code": "OkHttpClient client = new OkHttpClient();
 
 MediaType mediaType = MediaType.parse("application/json");
 RequestBody body = RequestBody.create(mediaType, "{\\"name\\":\\"buster\\"}");
@@ -234,13 +261,15 @@ Request request = new Request.Builder()
   .addHeader("content-type", "application/json")
   .build();
 
-Response response = client.newCall(request).execute();"
+Response response = client.newCall(request).execute();",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > java > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > java > targets > asynchttp > should support snippet generation 1`] = `
-"AsyncHttpClient client = new DefaultAsyncHttpClient();
+{
+  "code": "AsyncHttpClient client = new DefaultAsyncHttpClient();
 client.prepare("GET", "http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
   .setHeader("accept", "application/json")
   .execute()
@@ -248,25 +277,29 @@ client.prepare("GET", "http://petstore.swagger.io/v2/user/login?username=woof&pa
   .thenAccept(System.out::println)
   .join();
 
-client.close();"
+client.close();",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > java > targets > asynchttp > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > java > targets > nethttp > should support snippet generation 1`] = `
-"HttpRequest request = HttpRequest.newBuilder()
+{
+  "code": "HttpRequest request = HttpRequest.newBuilder()
     .uri(URI.create("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark"))
     .header("accept", "application/json")
     .method("GET", HttpRequest.BodyPublishers.noBody())
     .build();
 HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-System.out.println(response.body());"
+System.out.println(response.body());",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > java > targets > nethttp > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > java > targets > okhttp > should support snippet generation 1`] = `
-"OkHttpClient client = new OkHttpClient();
+{
+  "code": "OkHttpClient client = new OkHttpClient();
 
 Request request = new Request.Builder()
   .url("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
@@ -274,21 +307,25 @@ Request request = new Request.Builder()
   .addHeader("accept", "application/json")
   .build();
 
-Response response = client.newCall(request).execute();"
+Response response = client.newCall(request).execute();",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > java > targets > okhttp > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > java > targets > unirest > should support snippet generation 1`] = `
-"HttpResponse<String> response = Unirest.get("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
+{
+  "code": "HttpResponse<String> response = Unirest.get("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
   .header("accept", "application/json")
-  .asString();"
+  .asString();",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > java > targets > unirest > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > javascript > should generate code for the default target 1`] = `
-"const options = {
+{
+  "code": "const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: JSON.stringify({name: 'buster'})
@@ -297,13 +334,15 @@ exports[`oas-to-snippet > supported languages > javascript > should generate cod
 fetch('http://petstore.swagger.io/v2/pet', options)
   .then(response => response.json())
   .then(response => console.log(response))
-  .catch(err => console.error(err));"
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > javascript > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > javascript > targets > axios > should support snippet generation 1`] = `
-"import axios from 'axios';
+{
+  "code": "import axios from 'axios';
 
 const options = {
   method: 'GET',
@@ -319,24 +358,28 @@ axios
   })
   .catch(function (error) {
     console.error(error);
-  });"
+  });",
+  "highlightMode": "javascript",
+  "install": "npm install axios --save",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > javascript > targets > axios > should support snippet generation 2`] = `"npm install axios --save"`;
-
 exports[`oas-to-snippet > supported languages > javascript > targets > fetch > should support snippet generation 1`] = `
-"const options = {method: 'GET', headers: {accept: 'application/json'}};
+{
+  "code": "const options = {method: 'GET', headers: {accept: 'application/json'}};
 
 fetch('http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark', options)
   .then(response => response.json())
   .then(response => console.log(response))
-  .catch(err => console.error(err));"
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > javascript > targets > fetch > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > javascript > targets > jquery > should support snippet generation 1`] = `
-"const settings = {
+{
+  "code": "const settings = {
   async: true,
   crossDomain: true,
   url: 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark',
@@ -348,13 +391,15 @@ exports[`oas-to-snippet > supported languages > javascript > targets > jquery > 
 
 $.ajax(settings).done(function (response) {
   console.log(response);
-});"
+});",
+  "highlightMode": "javascript",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > javascript > targets > jquery > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > javascript > targets > xhr > should support snippet generation 1`] = `
-"const data = null;
+{
+  "code": "const data = null;
 
 const xhr = new XMLHttpRequest();
 xhr.withCredentials = true;
@@ -368,25 +413,33 @@ xhr.addEventListener('readystatechange', function () {
 xhr.open('GET', 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark');
 xhr.setRequestHeader('accept', 'application/json');
 
-xhr.send(data);"
+xhr.send(data);",
+  "highlightMode": "javascript",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > javascript > targets > xhr > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > json > should generate code for the default target 1`] = `
-"{
+{
+  "code": "{
   "name": "buster"
-}"
+}",
+  "highlightMode": "json",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > json > should generate code for the default target 2`] = `false`;
-
-exports[`oas-to-snippet > supported languages > json > targets > native > should support snippet generation 1`] = `"No JSON body"`;
-
-exports[`oas-to-snippet > supported languages > json > targets > native > should support snippet generation 2`] = `false`;
+exports[`oas-to-snippet > supported languages > json > targets > native > should support snippet generation 1`] = `
+{
+  "code": "No JSON body",
+  "highlightMode": "json",
+  "install": false,
+}
+`;
 
 exports[`oas-to-snippet > supported languages > kotlin > should generate code for the default target 1`] = `
-"val client = OkHttpClient()
+{
+  "code": "val client = OkHttpClient()
 
 val mediaType = MediaType.parse("application/json")
 val body = RequestBody.create(mediaType, "{\\"name\\":\\"buster\\"}")
@@ -396,13 +449,15 @@ val request = Request.Builder()
   .addHeader("content-type", "application/json")
   .build()
 
-val response = client.newCall(request).execute()"
+val response = client.newCall(request).execute()",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > kotlin > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > kotlin > targets > okhttp > should support snippet generation 1`] = `
-"val client = OkHttpClient()
+{
+  "code": "val client = OkHttpClient()
 
 val request = Request.Builder()
   .url("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
@@ -410,13 +465,15 @@ val request = Request.Builder()
   .addHeader("accept", "application/json")
   .build()
 
-val response = client.newCall(request).execute()"
+val response = client.newCall(request).execute()",
+  "highlightMode": "java",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > kotlin > targets > okhttp > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > node > should generate code for the default target 1`] = `
-"const fetch = require('node-fetch');
+{
+  "code": "const fetch = require('node-fetch');
 
 const url = 'http://petstore.swagger.io/v2/pet';
 const options = {
@@ -428,31 +485,39 @@ const options = {
 fetch(url, options)
   .then(res => res.json())
   .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));"
+  .catch(err => console.error('error:' + err));",
+  "highlightMode": "javascript",
+  "install": "npm install node-fetch@2 --save",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > node > should generate code for the default target 2`] = `"npm install node-fetch@2 --save"`;
-
 exports[`oas-to-snippet > supported languages > node > targets > api > should support custom variable names 1`] = `
-"import developers from '@api/developers';
+{
+  "code": "import developers from '@api/developers';
 
 developers.loginUser({username: 'woof', password: 'barkbarkbark'})
   .then(({ data }) => console.log(data))
-  .catch(err => console.error(err));"
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+  "install": "npx api install developers",
+}
 `;
 
 exports[`oas-to-snippet > supported languages > node > targets > api > should support snippet generation 1`] = `
-"import sdk from '@api/developers';
+{
+  "code": "import sdk from '@api/developers';
 
 sdk.loginUser({username: 'woof', password: 'barkbarkbark'})
   .then(({ data }) => console.log(data))
-  .catch(err => console.error(err));"
+  .catch(err => console.error(err));",
+  "highlightMode": "javascript",
+  "install": "npx api install {packageName}",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > node > targets > api > should support snippet generation 2`] = `"npx api install {packageName}"`;
-
 exports[`oas-to-snippet > supported languages > node > targets > axios > should support snippet generation 1`] = `
-"const axios = require('axios');
+{
+  "code": "const axios = require('axios');
 
 const options = {
   method: 'GET',
@@ -467,13 +532,15 @@ axios
   })
   .catch(function (error) {
     console.error(error);
-  });"
+  });",
+  "highlightMode": "javascript",
+  "install": "npm install axios --save",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > node > targets > axios > should support snippet generation 2`] = `"npm install axios --save"`;
-
 exports[`oas-to-snippet > supported languages > node > targets > fetch > should support snippet generation 1`] = `
-"const fetch = require('node-fetch');
+{
+  "code": "const fetch = require('node-fetch');
 
 const url = 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark';
 const options = {method: 'GET', headers: {accept: 'application/json'}};
@@ -481,13 +548,15 @@ const options = {method: 'GET', headers: {accept: 'application/json'}};
 fetch(url, options)
   .then(res => res.json())
   .then(json => console.log(json))
-  .catch(err => console.error('error:' + err));"
+  .catch(err => console.error('error:' + err));",
+  "highlightMode": "javascript",
+  "install": "npm install node-fetch@2 --save",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > node > targets > fetch > should support snippet generation 2`] = `"npm install node-fetch@2 --save"`;
-
 exports[`oas-to-snippet > supported languages > node > targets > native > should support snippet generation 1`] = `
-"const http = require('http');
+{
+  "code": "const http = require('http');
 
 const options = {
   method: 'GET',
@@ -512,13 +581,15 @@ const req = http.request(options, function (res) {
   });
 });
 
-req.end();"
+req.end();",
+  "highlightMode": "javascript",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > node > targets > native > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > node > targets > request > should support snippet generation 1`] = `
-"const request = require('request');
+{
+  "code": "const request = require('request');
 
 const options = {
   method: 'GET',
@@ -530,13 +601,15 @@ request(options, function (error, response, body) {
   if (error) throw new Error(error);
 
   console.log(body);
-});"
+});",
+  "highlightMode": "javascript",
+  "install": "npm install request --save",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > node > targets > request > should support snippet generation 2`] = `"npm install request --save"`;
-
 exports[`oas-to-snippet > supported languages > objectivec > should generate code for the default target 1`] = `
-"#import <Foundation/Foundation.h>
+{
+  "code": "#import <Foundation/Foundation.h>
 
 NSDictionary *headers = @{ @"content-type": @"application/json" };
 NSDictionary *parameters = @{ @"name": @"buster" };
@@ -560,13 +633,15 @@ NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
                                                     NSLog(@"%@", httpResponse);
                                                 }
                                             }];
-[dataTask resume];"
+[dataTask resume];",
+  "highlightMode": "objectivec",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > objectivec > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > objectivec > targets > nsurlsession > should support snippet generation 1`] = `
-"#import <Foundation/Foundation.h>
+{
+  "code": "#import <Foundation/Foundation.h>
 
 NSDictionary *headers = @{ @"accept": @"application/json" };
 
@@ -586,13 +661,15 @@ NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
                                                     NSLog(@"%@", httpResponse);
                                                 }
                                             }];
-[dataTask resume];"
+[dataTask resume];",
+  "highlightMode": "objectivec",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > objectivec > targets > nsurlsession > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > ocaml > should generate code for the default target 1`] = `
-"open Cohttp_lwt_unix
+{
+  "code": "open Cohttp_lwt_unix
 open Cohttp
 open Lwt
 
@@ -602,13 +679,15 @@ let body = Cohttp_lwt_body.of_string "{\\"name\\":\\"buster\\"}" in
 
 Client.call ~headers ~body \`POST uri
 >>= fun (res, body_stream) ->
-  (* Do stuff with the result *)"
+  (* Do stuff with the result *)",
+  "highlightMode": "ocaml",
+  "install": "opam install cohttp-lwt-unix cohttp-async",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > ocaml > should generate code for the default target 2`] = `"opam install cohttp-lwt-unix cohttp-async"`;
-
 exports[`oas-to-snippet > supported languages > ocaml > targets > cohttp > should support snippet generation 1`] = `
-"open Cohttp_lwt_unix
+{
+  "code": "open Cohttp_lwt_unix
 open Cohttp
 open Lwt
 
@@ -617,13 +696,15 @@ let headers = Header.add (Header.init ()) "accept" "application/json" in
 
 Client.call ~headers \`GET uri
 >>= fun (res, body_stream) ->
-  (* Do stuff with the result *)"
+  (* Do stuff with the result *)",
+  "highlightMode": "ocaml",
+  "install": "opam install cohttp-lwt-unix cohttp-async",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > ocaml > targets > cohttp > should support snippet generation 2`] = `"opam install cohttp-lwt-unix cohttp-async"`;
-
 exports[`oas-to-snippet > supported languages > php > should generate code for the default target 1`] = `
-"<?php
+{
+  "code": "<?php
 require_once('vendor/autoload.php');
 
 $client = new \\GuzzleHttp\\Client();
@@ -635,13 +716,15 @@ $response = $client->request('POST', 'http://petstore.swagger.io/v2/pet', [
   ],
 ]);
 
-echo $response->getBody();"
+echo $response->getBody();",
+  "highlightMode": "php",
+  "install": "composer require guzzlehttp/guzzle",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > php > should generate code for the default target 2`] = `"composer require guzzlehttp/guzzle"`;
-
 exports[`oas-to-snippet > supported languages > php > targets > curl > should support snippet generation 1`] = `
-"<?php
+{
+  "code": "<?php
 
 $curl = curl_init();
 
@@ -667,13 +750,15 @@ if ($err) {
   echo "cURL Error #:" . $err;
 } else {
   echo $response;
-}"
+}",
+  "highlightMode": "php",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > php > targets > curl > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > php > targets > guzzle > should support snippet generation 1`] = `
-"<?php
+{
+  "code": "<?php
 require_once('vendor/autoload.php');
 
 $client = new \\GuzzleHttp\\Client();
@@ -684,37 +769,45 @@ $response = $client->request('GET', 'http://petstore.swagger.io/v2/user/login?us
   ],
 ]);
 
-echo $response->getBody();"
+echo $response->getBody();",
+  "highlightMode": "php",
+  "install": "composer require guzzlehttp/guzzle",
+}
 `;
-
-exports[`oas-to-snippet > supported languages > php > targets > guzzle > should support snippet generation 2`] = `"composer require guzzlehttp/guzzle"`;
 
 exports[`oas-to-snippet > supported languages > powershell > should generate code for the default target 1`] = `
-"$headers=@{}
+{
+  "code": "$headers=@{}
 $headers.Add("content-type", "application/json")
-$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/pet' -Method POST -Headers $headers -ContentType 'application/json' -Body '{"name":"buster"}'"
+$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/pet' -Method POST -Headers $headers -ContentType 'application/json' -Body '{"name":"buster"}'",
+  "highlightMode": "powershell",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > powershell > should generate code for the default target 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > powershell > targets > restmethod > should support snippet generation 1`] = `
-"$headers=@{}
+{
+  "code": "$headers=@{}
 $headers.Add("accept", "application/json")
-$response = Invoke-RestMethod -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers"
+$response = Invoke-RestMethod -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers",
+  "highlightMode": "powershell",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > powershell > targets > restmethod > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > powershell > targets > webrequest > should support snippet generation 1`] = `
-"$headers=@{}
+{
+  "code": "$headers=@{}
 $headers.Add("accept", "application/json")
-$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers"
+$response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers",
+  "highlightMode": "powershell",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > powershell > targets > webrequest > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > python > should generate code for the default target 1`] = `
-"import requests
+{
+  "code": "import requests
 
 url = "http://petstore.swagger.io/v2/pet"
 
@@ -723,13 +816,15 @@ headers = {"content-type": "application/json"}
 
 response = requests.post(url, json=payload, headers=headers)
 
-print(response.text)"
+print(response.text)",
+  "highlightMode": "python",
+  "install": "python -m pip install requests",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > python > should generate code for the default target 2`] = `"python -m pip install requests"`;
-
 exports[`oas-to-snippet > supported languages > python > targets > requests > should support snippet generation 1`] = `
-"import requests
+{
+  "code": "import requests
 
 url = "http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark"
 
@@ -737,13 +832,15 @@ headers = {"accept": "application/json"}
 
 response = requests.get(url, headers=headers)
 
-print(response.text)"
+print(response.text)",
+  "highlightMode": "python",
+  "install": "python -m pip install requests",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > python > targets > requests > should support snippet generation 2`] = `"python -m pip install requests"`;
-
 exports[`oas-to-snippet > supported languages > r > should generate code for the default target 1`] = `
-"library(httr)
+{
+  "code": "library(httr)
 
 url <- "http://petstore.swagger.io/v2/pet"
 
@@ -753,13 +850,15 @@ encode <- "json"
 
 response <- VERB("POST", url, body = payload, content_type("application/json"), encode = encode)
 
-content(response, "text")"
+content(response, "text")",
+  "highlightMode": "r",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > r > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > r > targets > httr > should support snippet generation 1`] = `
-"library(httr)
+{
+  "code": "library(httr)
 
 url <- "http://petstore.swagger.io/v2/user/login"
 
@@ -770,13 +869,15 @@ queryString <- list(
 
 response <- VERB("GET", url, query = queryString, content_type("application/octet-stream"), accept("application/json"))
 
-content(response, "text")"
+content(response, "text")",
+  "highlightMode": "r",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > r > targets > httr > should support snippet generation 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > ruby > should generate code for the default target 1`] = `
-"require 'uri'
+{
+  "code": "require 'uri'
 require 'net/http'
 
 url = URI("http://petstore.swagger.io/v2/pet")
@@ -788,13 +889,15 @@ request["content-type"] = 'application/json'
 request.body = "{\\"name\\":\\"buster\\"}"
 
 response = http.request(request)
-puts response.read_body"
+puts response.read_body",
+  "highlightMode": "ruby",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > ruby > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > ruby > targets > native > should support snippet generation 1`] = `
-"require 'uri'
+{
+  "code": "require 'uri'
 require 'net/http'
 
 url = URI("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
@@ -805,37 +908,45 @@ request = Net::HTTP::Get.new(url)
 request["accept"] = 'application/json'
 
 response = http.request(request)
-puts response.read_body"
+puts response.read_body",
+  "highlightMode": "ruby",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > ruby > targets > native > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > shell > should generate code for the default target 1`] = `
-"curl --request POST \\
+{
+  "code": "curl --request POST \\
      --url http://petstore.swagger.io/v2/pet \\
      --header 'content-type: application/json' \\
-     --data '{"name":"buster"}'"
+     --data '{"name":"buster"}'",
+  "highlightMode": "shell",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > shell > should generate code for the default target 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > shell > targets > curl > should support snippet generation 1`] = `
-"curl --request GET \\
+{
+  "code": "curl --request GET \\
      --url 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\
-     --header 'accept: application/json'"
+     --header 'accept: application/json'",
+  "highlightMode": "shell",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > shell > targets > curl > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > shell > targets > httpie > should support snippet generation 1`] = `
-"http GET 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\
-  accept:application/json"
+{
+  "code": "http GET 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\
+  accept:application/json",
+  "highlightMode": "shell",
+  "install": "brew install httpie",
+}
 `;
 
-exports[`oas-to-snippet > supported languages > shell > targets > httpie > should support snippet generation 2`] = `"brew install httpie"`;
-
 exports[`oas-to-snippet > supported languages > swift > should generate code for the default target 1`] = `
-"import Foundation
+{
+  "code": "import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
@@ -852,13 +963,15 @@ request.httpBody = postData
 
 let (data, response) = try await URLSession.shared.data(with: request)
 print(String(decoding: data, as: UTF8.self))
-"
+",
+  "highlightMode": "swift",
+  "install": false,
+}
 `;
 
-exports[`oas-to-snippet > supported languages > swift > should generate code for the default target 2`] = `false`;
-
 exports[`oas-to-snippet > supported languages > swift > targets > urlsession > should support snippet generation 1`] = `
-"import Foundation
+{
+  "code": "import Foundation
 #if canImport(FoundationNetworking)
   import FoundationNetworking
 #endif
@@ -871,7 +984,8 @@ request.allHTTPHeaderFields = headers
 
 let (data, response) = try await URLSession.shared.data(with: request)
 print(String(decoding: data, as: UTF8.self))
-"
+",
+  "highlightMode": "swift",
+  "install": false,
+}
 `;
-
-exports[`oas-to-snippet > supported languages > swift > targets > urlsession > should support snippet generation 2`] = `false`;

--- a/packages/oas-to-snippet/test/__snapshots__/index.test.ts.snap
+++ b/packages/oas-to-snippet/test/__snapshots__/index.test.ts.snap
@@ -16,6 +16,8 @@ curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\\"name\\":\\"buster\\"}");
 CURLcode ret = curl_easy_perform(hnd);"
 `;
 
+exports[`oas-to-snippet > supported languages > c > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > c > targets > libcurl > should support snippet generation 1`] = `
 "CURL *hnd = curl_easy_init();
 
@@ -30,12 +32,16 @@ curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 CURLcode ret = curl_easy_perform(hnd);"
 `;
 
+exports[`oas-to-snippet > supported languages > c > targets > libcurl > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > clojure > should generate code for the default target 1`] = `
 "(require '[clj-http.client :as client])
 
 (client/post "http://petstore.swagger.io/v2/pet" {:content-type :json
                                                   :form-params {:name "buster"}})"
 `;
+
+exports[`oas-to-snippet > supported languages > clojure > should generate code for the default target 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > clojure > targets > clj_http > should support snippet generation 1`] = `
 "(require '[clj-http.client :as client])
@@ -44,6 +50,8 @@ exports[`oas-to-snippet > supported languages > clojure > targets > clj_http > s
                                                                        :password "barkbarkbark"}
                                                         :accept :json})"
 `;
+
+exports[`oas-to-snippet > supported languages > clojure > targets > clj_http > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > cplusplus > should generate code for the default target 1`] = `
 "CURL *hnd = curl_easy_init();
@@ -61,6 +69,8 @@ curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, "{\\"name\\":\\"buster\\"}");
 CURLcode ret = curl_easy_perform(hnd);"
 `;
 
+exports[`oas-to-snippet > supported languages > cplusplus > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > cplusplus > targets > libcurl > should support snippet generation 1`] = `
 "CURL *hnd = curl_easy_init();
 
@@ -75,6 +85,8 @@ curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 CURLcode ret = curl_easy_perform(hnd);"
 `;
 
+exports[`oas-to-snippet > supported languages > cplusplus > targets > libcurl > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > csharp > should generate code for the default target 1`] = `
 "using RestSharp;
 
@@ -88,6 +100,8 @@ var response = await client.PostAsync(request);
 Console.WriteLine("{0}", response.Content);
 "
 `;
+
+exports[`oas-to-snippet > supported languages > csharp > should generate code for the default target 2`] = `"dotnet add package RestSharp"`;
 
 exports[`oas-to-snippet > supported languages > csharp > targets > httpclient > should support snippet generation 1`] = `
 "using System.Net.Http.Headers;
@@ -109,6 +123,8 @@ using (var response = await client.SendAsync(request))
 }"
 `;
 
+exports[`oas-to-snippet > supported languages > csharp > targets > httpclient > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > csharp > targets > restsharp > should support snippet generation 1`] = `
 "using RestSharp;
 
@@ -122,6 +138,8 @@ var response = await client.GetAsync(request);
 Console.WriteLine("{0}", response.Content);
 "
 `;
+
+exports[`oas-to-snippet > supported languages > csharp > targets > restsharp > should support snippet generation 2`] = `"dotnet add package RestSharp"`;
 
 exports[`oas-to-snippet > supported languages > go > should generate code for the default target 1`] = `
 "package main
@@ -153,6 +171,8 @@ func main() {
 }"
 `;
 
+exports[`oas-to-snippet > supported languages > go > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > go > targets > native > should support snippet generation 1`] = `
 "package main
 
@@ -180,6 +200,8 @@ func main() {
 }"
 `;
 
+exports[`oas-to-snippet > supported languages > go > targets > native > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > http > should generate code for the default target 1`] = `
 "POST /v2/pet HTTP/1.1
 Content-Type: application/json
@@ -189,6 +211,8 @@ Content-Length: 17
 {"name":"buster"}"
 `;
 
+exports[`oas-to-snippet > supported languages > http > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > http > targets > http1.1 > should support snippet generation 1`] = `
 "GET /v2/user/login?username=woof&password=barkbarkbark HTTP/1.1
 Accept: application/json
@@ -196,6 +220,8 @@ Host: petstore.swagger.io
 
 "
 `;
+
+exports[`oas-to-snippet > supported languages > http > targets > http1.1 > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > java > should generate code for the default target 1`] = `
 "OkHttpClient client = new OkHttpClient();
@@ -211,6 +237,8 @@ Request request = new Request.Builder()
 Response response = client.newCall(request).execute();"
 `;
 
+exports[`oas-to-snippet > supported languages > java > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > java > targets > asynchttp > should support snippet generation 1`] = `
 "AsyncHttpClient client = new DefaultAsyncHttpClient();
 client.prepare("GET", "http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
@@ -223,6 +251,8 @@ client.prepare("GET", "http://petstore.swagger.io/v2/user/login?username=woof&pa
 client.close();"
 `;
 
+exports[`oas-to-snippet > supported languages > java > targets > asynchttp > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > java > targets > nethttp > should support snippet generation 1`] = `
 "HttpRequest request = HttpRequest.newBuilder()
     .uri(URI.create("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark"))
@@ -232,6 +262,8 @@ exports[`oas-to-snippet > supported languages > java > targets > nethttp > shoul
 HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 System.out.println(response.body());"
 `;
+
+exports[`oas-to-snippet > supported languages > java > targets > nethttp > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > java > targets > okhttp > should support snippet generation 1`] = `
 "OkHttpClient client = new OkHttpClient();
@@ -245,11 +277,15 @@ Request request = new Request.Builder()
 Response response = client.newCall(request).execute();"
 `;
 
+exports[`oas-to-snippet > supported languages > java > targets > okhttp > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > java > targets > unirest > should support snippet generation 1`] = `
 "HttpResponse<String> response = Unirest.get("http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark")
   .header("accept", "application/json")
   .asString();"
 `;
+
+exports[`oas-to-snippet > supported languages > java > targets > unirest > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > javascript > should generate code for the default target 1`] = `
 "const options = {
@@ -263,6 +299,8 @@ fetch('http://petstore.swagger.io/v2/pet', options)
   .then(response => console.log(response))
   .catch(err => console.error(err));"
 `;
+
+exports[`oas-to-snippet > supported languages > javascript > should generate code for the default target 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > javascript > targets > axios > should support snippet generation 1`] = `
 "import axios from 'axios';
@@ -284,6 +322,8 @@ axios
   });"
 `;
 
+exports[`oas-to-snippet > supported languages > javascript > targets > axios > should support snippet generation 2`] = `"npm install axios --save"`;
+
 exports[`oas-to-snippet > supported languages > javascript > targets > fetch > should support snippet generation 1`] = `
 "const options = {method: 'GET', headers: {accept: 'application/json'}};
 
@@ -292,6 +332,8 @@ fetch('http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkb
   .then(response => console.log(response))
   .catch(err => console.error(err));"
 `;
+
+exports[`oas-to-snippet > supported languages > javascript > targets > fetch > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > javascript > targets > jquery > should support snippet generation 1`] = `
 "const settings = {
@@ -308,6 +350,8 @@ $.ajax(settings).done(function (response) {
   console.log(response);
 });"
 `;
+
+exports[`oas-to-snippet > supported languages > javascript > targets > jquery > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > javascript > targets > xhr > should support snippet generation 1`] = `
 "const data = null;
@@ -327,13 +371,19 @@ xhr.setRequestHeader('accept', 'application/json');
 xhr.send(data);"
 `;
 
+exports[`oas-to-snippet > supported languages > javascript > targets > xhr > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > json > should generate code for the default target 1`] = `
 "{
   "name": "buster"
 }"
 `;
 
+exports[`oas-to-snippet > supported languages > json > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > json > targets > native > should support snippet generation 1`] = `"No JSON body"`;
+
+exports[`oas-to-snippet > supported languages > json > targets > native > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > kotlin > should generate code for the default target 1`] = `
 "val client = OkHttpClient()
@@ -349,6 +399,8 @@ val request = Request.Builder()
 val response = client.newCall(request).execute()"
 `;
 
+exports[`oas-to-snippet > supported languages > kotlin > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > kotlin > targets > okhttp > should support snippet generation 1`] = `
 "val client = OkHttpClient()
 
@@ -360,6 +412,8 @@ val request = Request.Builder()
 
 val response = client.newCall(request).execute()"
 `;
+
+exports[`oas-to-snippet > supported languages > kotlin > targets > okhttp > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > node > should generate code for the default target 1`] = `
 "const fetch = require('node-fetch');
@@ -377,6 +431,8 @@ fetch(url, options)
   .catch(err => console.error('error:' + err));"
 `;
 
+exports[`oas-to-snippet > supported languages > node > should generate code for the default target 2`] = `"npm install node-fetch@2 --save"`;
+
 exports[`oas-to-snippet > supported languages > node > targets > api > should support custom variable names 1`] = `
 "import developers from '@api/developers';
 
@@ -392,6 +448,8 @@ sdk.loginUser({username: 'woof', password: 'barkbarkbark'})
   .then(({ data }) => console.log(data))
   .catch(err => console.error(err));"
 `;
+
+exports[`oas-to-snippet > supported languages > node > targets > api > should support snippet generation 2`] = `"npx api install {packageName}"`;
 
 exports[`oas-to-snippet > supported languages > node > targets > axios > should support snippet generation 1`] = `
 "const axios = require('axios');
@@ -412,6 +470,8 @@ axios
   });"
 `;
 
+exports[`oas-to-snippet > supported languages > node > targets > axios > should support snippet generation 2`] = `"npm install axios --save"`;
+
 exports[`oas-to-snippet > supported languages > node > targets > fetch > should support snippet generation 1`] = `
 "const fetch = require('node-fetch');
 
@@ -423,6 +483,8 @@ fetch(url, options)
   .then(json => console.log(json))
   .catch(err => console.error('error:' + err));"
 `;
+
+exports[`oas-to-snippet > supported languages > node > targets > fetch > should support snippet generation 2`] = `"npm install node-fetch@2 --save"`;
 
 exports[`oas-to-snippet > supported languages > node > targets > native > should support snippet generation 1`] = `
 "const http = require('http');
@@ -453,6 +515,8 @@ const req = http.request(options, function (res) {
 req.end();"
 `;
 
+exports[`oas-to-snippet > supported languages > node > targets > native > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > node > targets > request > should support snippet generation 1`] = `
 "const request = require('request');
 
@@ -468,6 +532,8 @@ request(options, function (error, response, body) {
   console.log(body);
 });"
 `;
+
+exports[`oas-to-snippet > supported languages > node > targets > request > should support snippet generation 2`] = `"npm install request --save"`;
 
 exports[`oas-to-snippet > supported languages > objectivec > should generate code for the default target 1`] = `
 "#import <Foundation/Foundation.h>
@@ -497,6 +563,8 @@ NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
 [dataTask resume];"
 `;
 
+exports[`oas-to-snippet > supported languages > objectivec > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > objectivec > targets > nsurlsession > should support snippet generation 1`] = `
 "#import <Foundation/Foundation.h>
 
@@ -521,6 +589,8 @@ NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
 [dataTask resume];"
 `;
 
+exports[`oas-to-snippet > supported languages > objectivec > targets > nsurlsession > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > ocaml > should generate code for the default target 1`] = `
 "open Cohttp_lwt_unix
 open Cohttp
@@ -535,6 +605,8 @@ Client.call ~headers ~body \`POST uri
   (* Do stuff with the result *)"
 `;
 
+exports[`oas-to-snippet > supported languages > ocaml > should generate code for the default target 2`] = `"opam install cohttp-lwt-unix cohttp-async"`;
+
 exports[`oas-to-snippet > supported languages > ocaml > targets > cohttp > should support snippet generation 1`] = `
 "open Cohttp_lwt_unix
 open Cohttp
@@ -547,6 +619,8 @@ Client.call ~headers \`GET uri
 >>= fun (res, body_stream) ->
   (* Do stuff with the result *)"
 `;
+
+exports[`oas-to-snippet > supported languages > ocaml > targets > cohttp > should support snippet generation 2`] = `"opam install cohttp-lwt-unix cohttp-async"`;
 
 exports[`oas-to-snippet > supported languages > php > should generate code for the default target 1`] = `
 "<?php
@@ -563,6 +637,8 @@ $response = $client->request('POST', 'http://petstore.swagger.io/v2/pet', [
 
 echo $response->getBody();"
 `;
+
+exports[`oas-to-snippet > supported languages > php > should generate code for the default target 2`] = `"composer require guzzlehttp/guzzle"`;
 
 exports[`oas-to-snippet > supported languages > php > targets > curl > should support snippet generation 1`] = `
 "<?php
@@ -594,6 +670,8 @@ if ($err) {
 }"
 `;
 
+exports[`oas-to-snippet > supported languages > php > targets > curl > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > php > targets > guzzle > should support snippet generation 1`] = `
 "<?php
 require_once('vendor/autoload.php');
@@ -609,11 +687,15 @@ $response = $client->request('GET', 'http://petstore.swagger.io/v2/user/login?us
 echo $response->getBody();"
 `;
 
+exports[`oas-to-snippet > supported languages > php > targets > guzzle > should support snippet generation 2`] = `"composer require guzzlehttp/guzzle"`;
+
 exports[`oas-to-snippet > supported languages > powershell > should generate code for the default target 1`] = `
 "$headers=@{}
 $headers.Add("content-type", "application/json")
 $response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/pet' -Method POST -Headers $headers -ContentType 'application/json' -Body '{"name":"buster"}'"
 `;
+
+exports[`oas-to-snippet > supported languages > powershell > should generate code for the default target 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > powershell > targets > restmethod > should support snippet generation 1`] = `
 "$headers=@{}
@@ -621,11 +703,15 @@ $headers.Add("accept", "application/json")
 $response = Invoke-RestMethod -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers"
 `;
 
+exports[`oas-to-snippet > supported languages > powershell > targets > restmethod > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > powershell > targets > webrequest > should support snippet generation 1`] = `
 "$headers=@{}
 $headers.Add("accept", "application/json")
 $response = Invoke-WebRequest -Uri 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' -Method GET -Headers $headers"
 `;
+
+exports[`oas-to-snippet > supported languages > powershell > targets > webrequest > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > python > should generate code for the default target 1`] = `
 "import requests
@@ -640,6 +726,8 @@ response = requests.post(url, json=payload, headers=headers)
 print(response.text)"
 `;
 
+exports[`oas-to-snippet > supported languages > python > should generate code for the default target 2`] = `"python -m pip install requests"`;
+
 exports[`oas-to-snippet > supported languages > python > targets > requests > should support snippet generation 1`] = `
 "import requests
 
@@ -651,6 +739,8 @@ response = requests.get(url, headers=headers)
 
 print(response.text)"
 `;
+
+exports[`oas-to-snippet > supported languages > python > targets > requests > should support snippet generation 2`] = `"python -m pip install requests"`;
 
 exports[`oas-to-snippet > supported languages > r > should generate code for the default target 1`] = `
 "library(httr)
@@ -666,6 +756,8 @@ response <- VERB("POST", url, body = payload, content_type("application/json"), 
 content(response, "text")"
 `;
 
+exports[`oas-to-snippet > supported languages > r > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > r > targets > httr > should support snippet generation 1`] = `
 "library(httr)
 
@@ -680,6 +772,8 @@ response <- VERB("GET", url, query = queryString, content_type("application/octe
 
 content(response, "text")"
 `;
+
+exports[`oas-to-snippet > supported languages > r > targets > httr > should support snippet generation 2`] = `false`;
 
 exports[`oas-to-snippet > supported languages > ruby > should generate code for the default target 1`] = `
 "require 'uri'
@@ -697,6 +791,8 @@ response = http.request(request)
 puts response.read_body"
 `;
 
+exports[`oas-to-snippet > supported languages > ruby > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > ruby > targets > native > should support snippet generation 1`] = `
 "require 'uri'
 require 'net/http'
@@ -712,6 +808,8 @@ response = http.request(request)
 puts response.read_body"
 `;
 
+exports[`oas-to-snippet > supported languages > ruby > targets > native > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > shell > should generate code for the default target 1`] = `
 "curl --request POST \\
      --url http://petstore.swagger.io/v2/pet \\
@@ -719,16 +817,22 @@ exports[`oas-to-snippet > supported languages > shell > should generate code for
      --data '{"name":"buster"}'"
 `;
 
+exports[`oas-to-snippet > supported languages > shell > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > shell > targets > curl > should support snippet generation 1`] = `
 "curl --request GET \\
      --url 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\
      --header 'accept: application/json'"
 `;
 
+exports[`oas-to-snippet > supported languages > shell > targets > curl > should support snippet generation 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > shell > targets > httpie > should support snippet generation 1`] = `
 "http GET 'http://petstore.swagger.io/v2/user/login?username=woof&password=barkbarkbark' \\
   accept:application/json"
 `;
+
+exports[`oas-to-snippet > supported languages > shell > targets > httpie > should support snippet generation 2`] = `"brew install httpie"`;
 
 exports[`oas-to-snippet > supported languages > swift > should generate code for the default target 1`] = `
 "import Foundation
@@ -751,6 +855,8 @@ print(String(decoding: data, as: UTF8.self))
 "
 `;
 
+exports[`oas-to-snippet > supported languages > swift > should generate code for the default target 2`] = `false`;
+
 exports[`oas-to-snippet > supported languages > swift > targets > urlsession > should support snippet generation 1`] = `
 "import Foundation
 #if canImport(FoundationNetworking)
@@ -767,3 +873,5 @@ let (data, response) = try await URLSession.shared.data(with: request)
 print(String(decoding: data, as: UTF8.self))
 "
 `;
+
+exports[`oas-to-snippet > supported languages > swift > targets > urlsession > should support snippet generation 2`] = `false`;

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -435,9 +435,7 @@ fetch(url, options)
       it('should generate code for the default target', () => {
         const snippet = oasToSnippet(petstore, petstore.operation('/pet', 'post'), formData, {}, lang);
 
-        expect(snippet.code).toMatchSnapshot();
-        expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
-        expect(snippet.install).toMatchSnapshot();
+        expect(snippet).toMatchSnapshot();
       });
 
       describe('targets', () => {
@@ -474,9 +472,7 @@ fetch(url, options)
               },
             );
 
-            expect(snippet.code).toMatchSnapshot();
-            expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
-            expect(snippet.install).toMatchSnapshot();
+            expect(snippet).toMatchSnapshot();
           });
 
           if (lang === 'node' && target === 'api') {
@@ -498,9 +494,7 @@ fetch(url, options)
                 },
               );
 
-              expect(snippet.code).toMatchSnapshot();
-              expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
-              expect(snippet.install).toBe('npx api install developers');
+              expect(snippet).toMatchSnapshot();
             });
           }
         });

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -81,6 +81,7 @@ fetch(url, options)
     expect(codeSnippet).toStrictEqual({
       code: '',
       highlightMode: false,
+      install: false,
     });
   });
 
@@ -436,6 +437,7 @@ fetch(url, options)
 
         expect(snippet.code).toMatchSnapshot();
         expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
+        expect(snippet.install).toMatchSnapshot()
       });
 
       describe('targets', () => {
@@ -474,6 +476,7 @@ fetch(url, options)
 
             expect(snippet.code).toMatchSnapshot();
             expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
+            expect(snippet.install).toMatchSnapshot();
           });
 
           if (lang === 'node' && target === 'api') {
@@ -497,6 +500,7 @@ fetch(url, options)
 
               expect(snippet.code).toMatchSnapshot();
               expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
+              expect(snippet.install).toBe('npx api install developers');
             });
           }
         });

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -437,7 +437,7 @@ fetch(url, options)
 
         expect(snippet.code).toMatchSnapshot();
         expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
-        expect(snippet.install).toMatchSnapshot()
+        expect(snippet.install).toMatchSnapshot();
       });
 
       describe('targets', () => {

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -437,6 +437,7 @@ fetch(url, options)
 
         expect(snippet.code).toMatchSnapshot();
         expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
+        console.log('snippet.install:', snippet.install);
         expect(snippet.install).toMatchSnapshot();
       });
 

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -437,7 +437,6 @@ fetch(url, options)
 
         expect(snippet.code).toMatchSnapshot();
         expect(snippet.highlightMode).toBe(supportedLanguages[lang].highlight);
-        console.log('snippet.install:', snippet.install);
         expect(snippet.install).toMatchSnapshot();
       });
 

--- a/packages/oas-to-snippet/test/languages.test.ts
+++ b/packages/oas-to-snippet/test/languages.test.ts
@@ -32,6 +32,11 @@ describe('#getClientInstallationInstructions', () => {
     );
   });
 
+  it('should not pull back instructions for a language that has none', () => {
+    const languages = getSupportedLanguages();
+    expect(getClientInstallationInstructions(languages, 'objectivec')).toBeUndefined();
+  });
+
   it('should retrieve a templated `api` install command if the `api` plugin is loaded', () => {
     const languages = getSupportedLanguages({
       plugins: [httpsnippetClientAPIPlugin],


### PR DESCRIPTION
## 🧰 Changes

I don't know why I thought this was a good idea but having to manually invoke `getClientInstallationInstructions()` to pull back installation instructions for a client you're generating a snippet for makes absolutely no sense. This modifies the returned object from `oas-to-snippet` to now include an `install` property that includes this data.