### PR TITLE
feat: support examples from openapi 3.1

### DIFF
--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -158,6 +158,10 @@ function sampleFromSchema(
         // eslint-disable-next-line no-continue
         continue;
       }
+      if (props[name].examples?.length) {
+        obj[name] = props[name].examples[0]
+        continue
+      }
 
       obj[name] = sampleFromSchema(props[name], opts);
     }

--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -158,9 +158,11 @@ function sampleFromSchema(
         // eslint-disable-next-line no-continue
         continue;
       }
+
       if (props[name].examples?.length) {
-        obj[name] = props[name].examples[0]
-        continue
+        obj[name] = props[name].examples[0];
+        // eslint-disable-next-line no-continue
+        continue;
       }
 
       obj[name] = sampleFromSchema(props[name], opts);

--- a/packages/oas/test/samples/index.test.ts
+++ b/packages/oas/test/samples/index.test.ts
@@ -112,6 +112,28 @@ describe('sampleFromSchema', () => {
     expect(sampleFromSchema(definition)).toStrictEqual(expected);
   });
 
+  it('returns early if it find an examples property', () => {
+    const definition: RMOAS.SchemaObject = {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+          examples: [2, 3],
+        },
+        writeOnlyDog: {
+          writeOnly: true,
+          type: 'string',
+        },
+      },
+    };
+
+    const expected = {
+      id: 2,
+    };
+
+    expect(sampleFromSchema(definition)).toStrictEqual(expected);
+  });
+
   it('returns object with writeonly fields for parameter, with includeWriteOnly', () => {
     const definition: RMOAS.SchemaObject = {
       type: 'object',


### PR DESCRIPTION
## 🧰 Changes

This supports OpenAPI "examples" property. This will notably fix all issues with FastAPI generating documentation.

## 🧬 QA & Testing

I ran it on multiple documentations with success but I might have missed something. Let me know if I did.
