### PR TITLE
ci: dynamic args for `actions/setup-node`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18
-          - 20
+          - lts/-2
+          - lts/-1
+          - lts/*
+          - latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - lts/-2
+          # see the following:
+          # https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax
+          # https://github.com/nvm-sh/nvm/issues/1998#issuecomment-594958684
           - lts/-1
           - lts/*
           - latest


### PR DESCRIPTION
Node 22 just dropped — adding some funkier syntax so we can dynamically support all the Node releases we want to. Added some comments with links to resources on the subject!