### PR TITLE
revert: "fix(oas): numerous tweaks to our camelCase `operationId` generation"

### DIFF
--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -374,23 +374,6 @@ export class Operation {
 
     const method = this.method.toLowerCase();
     if (opts?.camelCase) {
-      // In order to generate friendlier operation IDs we should swap out underscores with spaces
-      // so the end result will be _slightly_ more camelCase.
-      operationId = operationId.replaceAll('_', ' ');
-
-      if (!this.hasOperationId()) {
-        // In another effort to generate friendly operation IDs we should prevent words from
-        // appearing in consecutive order (eg. `/candidate/{candidate}` should generate
-        // `getCandidate` not `getCandidateCandidate`). However we only want to do this if we're
-        // generating the operation ID as if they intentionally added a consecutive word into the
-        // operation ID then we should respect that.
-        operationId = operationId
-          .replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => ` ${chr}`)
-          .split(' ')
-          .filter((word, i, arr) => word !== arr[i - 1])
-          .join(' ');
-      }
-
       operationId = operationId.replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => chr.toUpperCase());
       if (this.hasOperationId()) {
         operationId = sanitize(operationId);
@@ -415,7 +398,7 @@ export class Operation {
       }
 
       // Because we're merging the `operationId` into an HTTP method we need to reset the first
-      // character of it back to lowercase so we end up with `getBuster`, not `getbuster`.
+      // character of it back to lowercase so end up with `getBuster`, not `getbuster`.
       operationId = operationId.charAt(0).toUpperCase() + operationId.slice(1);
       return `${method}${operationId}`;
     } else if (this.hasOperationId()) {

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -1072,7 +1072,7 @@ describe('#getOperationId()', () => {
       });
 
       const operation = spec.operation('/ac_eq_hazard/18.0', 'post');
-      expect(operation.getOperationId({ camelCase: true })).toBe('postAcEqHazard180');
+      expect(operation.getOperationId({ camelCase: true })).toBe('postAc_eq_hazard180');
     });
 
     it('should not double up on a method prefix if the path starts with the method', () => {
@@ -1110,25 +1110,7 @@ describe('#getOperationId()', () => {
       });
 
       const operation = spec.operation('/candidate/{candidate_id}/', 'get');
-      expect(operation.getOperationId({ camelCase: true })).toBe('getCandidateId');
-    });
-
-    it('should not create an operationId that includes the same word in a consecutive sequence', () => {
-      const spec = Oas.init({
-        openapi: '3.1.0',
-        info: {
-          title: 'testing',
-          version: '1.0.0',
-        },
-        paths: {
-          '/pet/{pet}/adoption': {
-            post: {},
-          },
-        },
-      });
-
-      const operation = spec.operation('/pet/{pet}/adoption', 'post');
-      expect(operation.getOperationId({ camelCase: true })).toBe('postPetAdoption');
+      expect(operation.getOperationId({ camelCase: true })).toBe('getCandidateCandidate_id');
     });
 
     it.each([
@@ -1138,7 +1120,7 @@ describe('#getOperationId()', () => {
           // This operationID is already fine to use as a JS method accessor we're just slightly
           // modifying it so it fits as a method accessor.
           operationId: 'ExchangeRESTAPI_GetAccounts',
-          expected: 'exchangeRESTAPIGetAccounts',
+          expected: 'exchangeRESTAPI_GetAccounts',
         },
       ],
       [
@@ -1169,7 +1151,7 @@ describe('#getOperationId()', () => {
         'should clean up an operationId that starts with a number',
         {
           operationId: '400oD_Browse_by_Date_Feed',
-          expected: '_400oDBrowseByDateFeed',
+          expected: '_400oD_Browse_by_Date_Feed',
         },
       ],
     ])('%s', (_, { operationId, expected }) => {


### PR DESCRIPTION
Reverts readmeio/oas#851

This is breaking a lot of tests in our main app and we're afraid that customers are relying on these trash-ass operation IDs we're currently generating.

I'm going to dump this fix behind another opt-in flag on `getOperationId` when I've got time.