### PR TITLE
fix: make `RequestBodyExamples` type stricter

### DIFF
--- a/packages/oas/src/operation/lib/get-requestbody-examples.ts
+++ b/packages/oas/src/operation/lib/get-requestbody-examples.ts
@@ -4,12 +4,7 @@ import type * as RMOAS from '../../types.js';
 import { getMediaTypeExamples } from './get-mediatype-examples.js';
 
 export type RequestBodyExamples = {
-  examples: (
-    | MediaTypeExample
-    | {
-        value: any;
-      }
-  )[];
+  examples: MediaTypeExample[];
   mediaType: string;
 }[];
 


### PR DESCRIPTION
## 🧰 Changes

I forgot to clean up some ugly typing that I wrote as part of my work on https://github.com/readmeio/oas/pull/866. This cleans that up

## 🧬 QA & Testing

Do tests still pass?
