### PR TITLE
fix(oas): update memoizee(vulnerability)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11714,18 +11714,21 @@
       }
     },
     "node_modules/memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
       "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
         "es6-weak-map": "^2.0.3",
         "event-emitter": "^0.3.5",
         "is-promise": "^2.2.2",
         "lru-queue": "^0.1.0",
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/meow": {
@@ -20305,7 +20308,7 @@
         "json-schema-merge-allof": "^0.8.1",
         "jsonpath-plus": "^8.0.0",
         "jsonpointer": "^5.0.0",
-        "memoizee": "^0.4.14",
+        "memoizee": "^0.4.16",
         "oas-normalize": "file:../oas-normalize",
         "openapi-types": "^12.1.1",
         "path-to-regexp": "^6.2.2",

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -93,7 +93,7 @@
     "json-schema-merge-allof": "^0.8.1",
     "jsonpath-plus": "^8.0.0",
     "jsonpointer": "^5.0.0",
-    "memoizee": "^0.4.14",
+    "memoizee": "^0.4.16",
     "oas-normalize": "file:../oas-normalize",
     "openapi-types": "^12.1.1",
     "path-to-regexp": "^6.2.2",


### PR DESCRIPTION
| 🚥 Resolves |
| :------------------- |

## 🧰 Changes

Memoize had a vulnerability and was fixed with v0.4.16.
https://github.com/medikoo/memoizee/issues/133

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ low                 │ es5-ext vulnerable to Regular Expression Denial of     │
│                     │ Service in `function#copy` and                         │
│                     │ `function#toStringTokens`                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ es5-ext                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=0.10.0 <0.10.63                                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=0.10.63                                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @kubb/plugin-oas@2.18.9 > @kubb/oas@2.18.9 >       │
│                     │ oas@24.3.5 > memoizee@0.4.15 > d@1.0.1 >               │
│                     │ es5-ext@0.10.62 > es6-iterator@2.0.3 > es5-ext@0.10.62 │
│                     │                                                        │
│                     │ . > @kubb/plugin-oas@2.18.9 > @kubb/oas@2.18.9 >       │
│                     │ oas@24.3.5 > memoizee@0.4.15 > es5-ext@0.10.62 >       │
│                     │ es6-iterator@2.0.3 > d@1.0.1 > es5-ext@0.10.62         │
│                     │                                                        │
│                     │ . > @kubb/plugin-oas@2.18.9 > @kubb/oas@2.18.9 >       │
│                     │ oas@24.3.5 > memoizee@0.4.15 > es5-ext@0.10.62 >       │
│                     │ es6-iterator@2.0.3 > es5-ext@0.10.62                   │
│                     │                                                        │
│                     │ ... Found 54 paths, run `pnpm why es5-ext` for more    │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-4gmj-3p3h-gm8h      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```
It is linked to https://github.com/kubb-labs/kubb/issues/1014.
