### PR TITLE
chore(deps): bumping openapi-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,14 +42,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@apidevtools/swagger-methods": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
@@ -2222,15 +2214,15 @@
       "link": true
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.5.1.tgz",
-      "integrity": "sha512-p9ndWhwjtP+DEiOOF6jeNMpdmYIPM4nl+JEIdnQNdq7b68esI024x7HiYACZpaYaSvISDSyKc7aiRJx4K4IDhg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-2.6.0.tgz",
+      "integrity": "sha512-pyFJXezWj9WI1O+gdp95CoxfY+i+Uq3kKk4zXIFuRAZi9YnHpHOpjumWWr67wkmRTw19Hskh9spyY0Iyikf3fA==",
       "dependencies": {
-        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.6.0",
         "@readme/json-schema-ref-parser": "^1.2.0",
+        "@readme/openapi-schemas": "^3.1.0",
         "ajv": "^8.12.0",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
@@ -2274,6 +2266,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@readme/openapi-schemas": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-schemas/-/openapi-schemas-3.1.0.tgz",
+      "integrity": "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@readme/postman-to-openapi": {
       "version": "4.1.0",
@@ -20316,7 +20316,7 @@
       },
       "devDependencies": {
         "@readme/oas-examples": "^5.13.0",
-        "@readme/openapi-parser": "^2.5.0",
+        "@readme/openapi-parser": "^2.6.0",
         "@types/json-schema-merge-allof": "^0.6.5",
         "@types/memoizee": "^0.4.11",
         "@types/node": "^20.12.5",
@@ -20333,7 +20333,7 @@
       "version": "11.0.7",
       "license": "MIT",
       "dependencies": {
-        "@readme/openapi-parser": "^2.5.0",
+        "@readme/openapi-parser": "^2.6.0",
         "@readme/postman-to-openapi": "^4.1.0",
         "js-yaml": "^4.1.0",
         "openapi-types": "^12.1.3",

--- a/packages/oas-normalize/package.json
+++ b/packages/oas-normalize/package.json
@@ -63,7 +63,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@readme/openapi-parser": "^2.5.0",
+    "@readme/openapi-parser": "^2.6.0",
     "@readme/postman-to-openapi": "^4.1.0",
     "js-yaml": "^4.1.0",
     "openapi-types": "^12.1.3",

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -101,7 +101,7 @@
   },
   "devDependencies": {
     "@readme/oas-examples": "^5.13.0",
-    "@readme/openapi-parser": "^2.5.0",
+    "@readme/openapi-parser": "^2.6.0",
     "@types/json-schema-merge-allof": "^0.6.5",
     "@types/memoizee": "^0.4.11",
     "@types/node": "^20.12.5",


### PR DESCRIPTION
## 🧰 Changes

This bumps `@readme/openapi-parser` to pull in the new schema changes @kanadgupta and @darrenyong did to resolve issues where folks couldn't use `description` in server variables.