### PR TITLE
feat(oas): creation of a new `friendlyCase` option for `.getOperationId()`

### DIFF
--- a/packages/oas/test/__fixtures__/create-oas.ts
+++ b/packages/oas/test/__fixtures__/create-oas.ts
@@ -6,7 +6,7 @@ import Oas from '../../src/index.js';
  * @param operation Operation to create a fake API definition and Oas instance for.
  * @param components Schema components to add into the fake API definition.
  */
-export default function createOas(operation: RMOAS.OperationObject, components?: RMOAS.ComponentsObject): Oas {
+export function createOasForOperation(operation: RMOAS.OperationObject, components?: RMOAS.ComponentsObject): Oas {
   const schema = {
     openapi: '3.0.3',
     info: { title: 'testing', version: '1.0.0' },
@@ -14,6 +14,26 @@ export default function createOas(operation: RMOAS.OperationObject, components?:
       '/': {
         get: operation,
       },
+    },
+  } as RMOAS.OASDocument;
+
+  if (components) {
+    schema.components = components;
+  }
+
+  return new Oas(schema);
+}
+
+/**
+ * @param paths Path objects to create a fake API definition and Oas instance for.
+ * @param components Schema components to add into the fake API definition.
+ */
+export function createOasForPaths(paths: RMOAS.PathsObject, components?: RMOAS.ComponentsObject): Oas {
+  const schema = {
+    openapi: '3.0.3',
+    info: { title: 'testing', version: '1.0.0' },
+    paths: {
+      ...paths,
     },
   } as RMOAS.OASDocument;
 

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -5,7 +5,7 @@ import { beforeAll, expect, describe, it } from 'vitest';
 
 import Oas from '../../src/index.js';
 import { toJSONSchema } from '../../src/lib/openapi-to-json-schema.js';
-import createOas from '../__fixtures__/create-oas.js';
+import { createOasForOperation } from '../__fixtures__/create-oas.js';
 import generateJSONSchemaFixture from '../__fixtures__/json-schema.js';
 
 let petstore: Oas;
@@ -857,7 +857,7 @@ describe('`description` support', () => {
   });
 
   it('should add defaults for enums if default is present', () => {
-    const oas = createOas({
+    const oas = createOasForOperation({
       requestBody: {
         content: {
           'application/json': {

--- a/packages/oas/test/operation/lib/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/lib/get-parameters-as-json-schema.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, test, expect, it, describe } from 'vitest';
 
 import { PARAMETER_ORDERING } from '../../../src/extensions.js';
 import Oas from '../../../src/index.js';
-import createOas from '../../__fixtures__/create-oas.js';
+import { createOasForOperation } from '../../__fixtures__/create-oas.js';
 
 let ably: Oas;
 let circular: Oas;
@@ -52,8 +52,8 @@ beforeAll(async () => {
 });
 
 test('it should return with null if there are no parameters', () => {
-  expect(createOas({ parameters: [] }).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
-  expect(createOas({}).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
+  expect(createOasForOperation({ parameters: [] }).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
+  expect(createOasForOperation({}).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
 });
 
 describe('type sorting', () => {
@@ -84,7 +84,7 @@ describe('type sorting', () => {
       },
     };
 
-    const oas = createOas(operation);
+    const oas = createOasForOperation(operation);
     const jsonschema = oas.operation('/', 'get').getParametersAsJSONSchema();
 
     expect(jsonschema).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe('type sorting', () => {
       },
     };
 
-    const oas = createOas(operation);
+    const oas = createOasForOperation(operation);
     const jsonschema = oas.operation('/', 'get').getParametersAsJSONSchema();
 
     expect(jsonschema).toMatchSnapshot();
@@ -122,7 +122,7 @@ describe('type sorting', () => {
       [PARAMETER_ORDERING]: ['path', 'header', 'cookie', 'query', 'body', 'form'],
     };
 
-    const oas = createOas(custom);
+    const oas = createOasForOperation(custom);
     const jsonschema = oas.operation('/', 'get').getParametersAsJSONSchema();
 
     expect(
@@ -162,7 +162,7 @@ describe('parameters', () => {
 
   describe('`content` support', () => {
     it('should support `content` on parameters', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             name: 'userId',
@@ -182,7 +182,7 @@ describe('parameters', () => {
     });
 
     it('should prioritize `application/json` if present', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             name: 'userId',
@@ -203,7 +203,7 @@ describe('parameters', () => {
     });
 
     it("should prioritize JSON-like content types if they're present", () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             name: 'userId',
@@ -228,7 +228,7 @@ describe('parameters', () => {
     });
 
     it('should use the first content type if `application/json` is not present', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             name: 'userId',
@@ -282,7 +282,7 @@ describe('request bodies', () => {
   });
 
   it('should not return anything for an empty schema', () => {
-    const oas = createOas({
+    const oas = createOasForOperation({
       requestBody: {
         description: 'Body description',
         content: {
@@ -297,7 +297,7 @@ describe('request bodies', () => {
   });
 
   it('should not return anything for a requestBody that has no schema', () => {
-    const oas = createOas({
+    const oas = createOasForOperation({
       requestBody: {
         description: 'Body description',
         content: {
@@ -395,7 +395,7 @@ describe('type', () => {
   describe('request bodies', () => {
     describe('repair invalid schema that has no `type`', () => {
       it('should add a missing `type: object` on a schema that is clearly an object', () => {
-        const oas = createOas(
+        const oas = createOasForOperation(
           {
             requestBody: {
               content: {
@@ -457,7 +457,7 @@ describe('descriptions', () => {
   it.todo('should pass through description on requestBody');
 
   it('should pass through description on parameters', () => {
-    const oas = createOas({
+    const oas = createOasForOperation({
       parameters: [
         {
           in: 'header',
@@ -490,7 +490,7 @@ describe('descriptions', () => {
   });
 
   it('should pass through description on parameter when referenced as a `$ref` and a `requestBody` is present', async () => {
-    const oas = createOas(
+    const oas = createOasForOperation(
       {
         parameters: [
           {
@@ -574,7 +574,7 @@ describe('`example` / `examples` support', () => {
         };
       }
 
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             in: 'query',
@@ -625,7 +625,7 @@ describe('`example` / `examples` support', () => {
 describe('deprecated', () => {
   describe('parameters', () => {
     it('should pass through deprecated on parameters', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             in: 'header',
@@ -667,7 +667,7 @@ describe('deprecated', () => {
     });
 
     it('should pass through deprecated on parameter when referenced as a `$ref` and a `requestBody` is present', async () => {
-      const oas = createOas(
+      const oas = createOasForOperation(
         {
           parameters: [
             {
@@ -743,7 +743,7 @@ describe('deprecated', () => {
 
   describe('request bodies', () => {
     it('should pass through deprecated on a request body schema property', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         requestBody: {
           content: {
             'application/json': {
@@ -801,7 +801,7 @@ describe('deprecated', () => {
 
   describe('polymorphism', () => {
     it('should pass through deprecated on a (merged) allOf schema', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         requestBody: {
           content: {
             'application/json': {
@@ -839,7 +839,7 @@ describe('deprecated', () => {
     });
 
     it('should be able to merge enums within an allOf schema', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         requestBody: {
           content: {
             'application/json': {
@@ -938,7 +938,7 @@ describe('options', () => {
 
     describe('retainDeprecatedProperties (default behavior)', () => {
       it('should support merging `deprecatedProps` together', () => {
-        const oas = createOas({
+        const oas = createOasForOperation({
           parameters: [
             {
               in: 'header',
@@ -959,7 +959,7 @@ describe('options', () => {
 
   describe('retainDeprecatedProperties', () => {
     it('should retain deprecated properties within their original schemas', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         parameters: [
           {
             in: 'header',
@@ -987,7 +987,7 @@ describe('options', () => {
 
   describe('transformer', () => {
     it('should be able transform part of a schema', () => {
-      const oas = createOas({
+      const oas = createOasForOperation({
         requestBody: {
           content: {
             'application/json': {

--- a/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
@@ -5,7 +5,7 @@ import { beforeAll, describe, test, expect, it } from 'vitest';
 
 import Oas from '../../../src/index.js';
 import cloneObject from '../../../src/lib/clone-object.js';
-import createOas from '../../__fixtures__/create-oas.js';
+import { createOasForOperation } from '../../__fixtures__/create-oas.js';
 
 let circular: Oas;
 let petstore: Oas;
@@ -22,11 +22,11 @@ beforeAll(async () => {
 });
 
 test('it should return with null if there is not a response', () => {
-  expect(createOas({ responses: {} }).operation('/', 'get').getResponseAsJSONSchema('200')).toBeNull();
+  expect(createOasForOperation({ responses: {} }).operation('/', 'get').getResponseAsJSONSchema('200')).toBeNull();
 });
 
 test('it should return with null if there is empty content', () => {
-  const oas = createOas({
+  const oas = createOasForOperation({
     responses: {
       200: {
         description: 'OK',
@@ -99,7 +99,7 @@ describe('content type handling', () => {
 
   it("should return JSON Schema for a content type that isn't JSON-compatible", () => {
     expect(
-      createOas({
+      createOasForOperation({
         responses: {
           200: {
             description: 'response level description',
@@ -176,7 +176,7 @@ describe('`enum` handling', () => {
 describe('`headers` support', () => {
   // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responseObject
   it('should include headers if they exist', () => {
-    const oas = createOas({
+    const oas = createOasForOperation({
       responses: {
         200: {
           description: 'response level description',


### PR DESCRIPTION
| 🚥 Resolves https://github.com/readmeio/oas/pull/869 |
| :------------------- |

## 🧰 Changes

This resurrects the work I originally did in https://github.com/readmeio/oas/pull/851, but unfortunately had to revert, to create a new `friendlyCase` option on `Operation.getOperationId()` for generating friendlier camelCase operation IDs that we can use in our upcoming Git storage system for API references. 

## 🧬 QA & Testing

I reorganized a bunch of the tests for `camelCase` to retain them all along with this new option.
