### PR TITLE
feat: new library to expose typings for postman collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20541,11 +20541,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.8.7",
-        "@vitest/coverage-v8": "^1.4.0",
         "tsup": "^8.0.2",
-        "typescript": "^5.2.2",
-        "vitest": "^1.4.0"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3633,7 +3633,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6151,7 +6150,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -6161,7 +6159,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7795,8 +7792,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -10562,8 +10558,7 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -15247,6 +15242,10 @@
         }
       }
     },
+    "node_modules/postman-types": {
+      "resolved": "packages/postman-types",
+      "link": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -16642,7 +16641,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -20536,6 +20535,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/postman-types": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.8.7",
+        "@vitest/coverage-v8": "^1.4.0",
+        "tsup": "^8.0.2",
+        "typescript": "^5.2.2",
+        "vitest": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/packages/postman-types/.eslintrc
+++ b/packages/postman-types/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-namespace": "off",
+  },
+}

--- a/packages/postman-types/LICENSE
+++ b/packages/postman-types/LICENSE
@@ -1,0 +1,18 @@
+Copyright © 2024 ReadMe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/postman-types/README.md
+++ b/packages/postman-types/README.md
@@ -1,23 +1,10 @@
-<p align="center">
-  <a href="https://npm.im/postman-types">
-    <img src="https://user-images.githubusercontent.com/33762/200434622-23946869-1965-46f8-8deb-f284b8d0b92c.png" alt="postman-types" />
-  </a>
-</p>
+# postman-types
 
-<p align="center">
-  Types for Postman colletions
-</p>
+Types for [Postman collections](https://www.postman.com/collection/).
 
-<p align="center">
-  <a href="https://npm.im/postman-types"><img src="https://img.shields.io/npm/v/postman-types?style=for-the-badge" alt="NPM Version"></a>
-  <a href="https://npm.im/postman-types"><img src="https://img.shields.io/node/v/postman-types?style=for-the-badge" alt="Node Version"></a>
-  <a href="https://npm.im/postman-types"><img src="https://img.shields.io/npm/l/postman-types?style=for-the-badge" alt="MIT License"></a>
-  <a href="https://github.com/readmeio/oas/tree/main/packages/postman-types"><img src="https://img.shields.io/github/actions/workflow/status/readmeio/oas/ci.yml?branch=main&style=for-the-badge" alt="Build status"></a>
-</p>
+[![Build](https://github.com/readmeio/oas/workflows/CI/badge.svg)](https://github.com/readmeio/oas/tree/main/packages/postman-types) [![](https://img.shields.io/npm/v/postman-types)](https://npm.im/postman-types)
 
-<p align="center">
-  <a href="https://readme.com"><img src="https://raw.githubusercontent.com/readmeio/.github/main/oss-badge.svg" /></a>
-</p>
+[![](https://raw.githubusercontent.com/readmeio/.github/main/oss-header.png)](https://readme.com)
 
 ## Installation
 
@@ -28,9 +15,11 @@ npm install postman-types
 ## Usage
 
 ```ts
-import { PostmanV2, PostmanV2_1 } from 'postman-types';
+import { Postman, PostmanV2, PostmanV2_1 } from 'postman-types';
 
-function processV2(collection: PostmanV2.Document) {}
+function process(collection: Postman.Collection) {}
 
-function processV2_1(collection: PostmanV2_1.Document) {}
+function processV2(collection: PostmanV2.Collection) {}
+
+function processV2_1(collection: PostmanV2_1.Collection) {}
 ```

--- a/packages/postman-types/README.md
+++ b/packages/postman-types/README.md
@@ -1,0 +1,36 @@
+<p align="center">
+  <a href="https://npm.im/postman-types">
+    <img src="https://user-images.githubusercontent.com/33762/200434622-23946869-1965-46f8-8deb-f284b8d0b92c.png" alt="postman-types" />
+  </a>
+</p>
+
+<p align="center">
+  Types for Postman colletions
+</p>
+
+<p align="center">
+  <a href="https://npm.im/postman-types"><img src="https://img.shields.io/npm/v/postman-types?style=for-the-badge" alt="NPM Version"></a>
+  <a href="https://npm.im/postman-types"><img src="https://img.shields.io/node/v/postman-types?style=for-the-badge" alt="Node Version"></a>
+  <a href="https://npm.im/postman-types"><img src="https://img.shields.io/npm/l/postman-types?style=for-the-badge" alt="MIT License"></a>
+  <a href="https://github.com/readmeio/oas/tree/main/packages/postman-types"><img src="https://img.shields.io/github/actions/workflow/status/readmeio/oas/ci.yml?branch=main&style=for-the-badge" alt="Build status"></a>
+</p>
+
+<p align="center">
+  <a href="https://readme.com"><img src="https://raw.githubusercontent.com/readmeio/.github/main/oss-badge.svg" /></a>
+</p>
+
+## Installation
+
+```bash
+npm install postman-types
+```
+
+## Usage
+
+```ts
+import { PostmanV2, PostmanV2_1 } from 'postman-types';
+
+function processV2(collection: PostmanV2.Document) {}
+
+function processV2_1(collection: PostmanV2_1.Document) {}
+```

--- a/packages/postman-types/package.json
+++ b/packages/postman-types/package.json
@@ -37,15 +37,11 @@
     "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
-    "prepack": "npm run build",
-    "test": "vitest run --coverage"
+    "prepack": "npm run build"
   },
   "devDependencies": {
-    "@types/node": "^20.8.7",
-    "@vitest/coverage-v8": "^1.4.0",
     "tsup": "^8.0.2",
-    "typescript": "^5.2.2",
-    "vitest": "^1.4.0"
+    "typescript": "^5.2.2"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/postman-types/package.json
+++ b/packages/postman-types/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "postman-types",
+  "description": "Types for Postman colletions",
+  "version": "0.0.0",
+  "author": "Jon Ursenbach <jon@readme.io>",
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.cts",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/readmeio/oas.git",
+    "directory": "packages/postman-types"
+  },
+  "bugs": {
+    "url": "https://github.com/readmeio/oas/issues"
+  },
+  "scripts": {
+    "attw": "attw --pack --format table-flipped",
+    "build": "tsup",
+    "lint": "npm run lint:types && npm run lint:js",
+    "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
+    "lint:types": "tsc --noEmit",
+    "prebuild": "rm -rf dist/",
+    "prepack": "npm run build",
+    "test": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.7",
+    "@vitest/coverage-v8": "^1.4.0",
+    "tsup": "^8.0.2",
+    "typescript": "^5.2.2",
+    "vitest": "^1.4.0"
+  },
+  "prettier": "@readme/eslint-config/prettier"
+}

--- a/packages/postman-types/schemas/v2.0.0.json
+++ b/packages/postman-types/schemas/v2.0.0.json
@@ -1,0 +1,1029 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schema.getpostman.com/json/draft-07/collection/v2.0.0/",
+  "type": "object",
+  "properties": {
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "item": {
+      "type": "array",
+      "description": "Items are the basic unit for a Postman collection. You can think of them as corresponding to a single API endpoint. Each Item has one request and may have multiple API responses associated with it.",
+      "items": {
+        "title": "Items",
+        "oneOf": [
+          {
+            "$ref": "#/definitions/item"
+          },
+          {
+            "$ref": "#/definitions/item-group"
+          }
+        ]
+      }
+    },
+    "event": {
+      "$ref": "#/definitions/event-list"
+    },
+    "variable": {
+      "$ref": "#/definitions/variable-list"
+    },
+    "auth": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/auth"
+        }
+      ]
+    },
+    "protocolProfileBehavior": {
+      "$ref": "#/definitions/protocol-profile-behavior"
+    }
+  },
+  "required": ["info", "item"],
+  "definitions": {
+    "auth": {
+      "type": "object",
+      "title": "Auth",
+      "$id": "#/definitions/auth",
+      "description": "Represents authentication helpers provided by Postman",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apikey",
+            "awsv4",
+            "basic",
+            "bearer",
+            "digest",
+            "edgegrid",
+            "hawk",
+            "ntlm",
+            "noauth",
+            "oauth1",
+            "oauth2"
+          ]
+        },
+        "noauth": {},
+        "apikey": {
+          "type": "object",
+          "title": "API Key Authentication",
+          "description": "The attributes for API Key Authentication. e.g. key, value, in."
+        },
+        "awsv4": {
+          "type": "object",
+          "title": "AWS Signature v4",
+          "description": "The attributes for [AWS Auth](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html). e.g. accessKey, secretKey, region, service."
+        },
+        "basic": {
+          "type": "object",
+          "title": "Basic Authentication",
+          "description": "The attributes for [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). e.g. username, password."
+        },
+        "bearer": {
+          "type": "object",
+          "title": "Bearer Token Authentication",
+          "description": "The attributes for [Bearer Token Authentication](https://tools.ietf.org/html/rfc6750). e.g. token."
+        },
+        "digest": {
+          "type": "object",
+          "title": "Digest Authentication",
+          "description": "The attributes for [Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication). e.g. username, password, realm, nonce, nonceCount, algorithm, qop, opaque, clientNonce."
+        },
+        "edgegrid": {
+          "type": "object",
+          "title": "EdgeGrid Authentication",
+          "description": "The attributes for [Akamai EdgeGrid Authentication](https://developer.akamai.com/legacy/introduction/Client_Auth.html). e.g. accessToken, clientToken, clientSecret, baseURL, nonce, timestamp, headersToSign."
+        },
+        "hawk": {
+          "type": "object",
+          "title": "Hawk Authentication",
+          "description": "The attributes for [Hawk Authentication](https://github.com/hueniverse/hawk). e.g. authId, authKey, algorith, user, nonce, extraData, appId, delegation, timestamp."
+        },
+        "ntlm": {
+          "type": "object",
+          "title": "NTLM Authentication",
+          "description": "The attributes for [NTLM Authentication](https://msdn.microsoft.com/en-us/library/cc237488.aspx). e.g. username, password, domain, workstation."
+        },
+        "oauth1": {
+          "type": "object",
+          "title": "OAuth1",
+          "description": "The attributes for [OAuth1](https://oauth.net/1/). e.g. consumerKey, consumerSecret, token, tokenSecret, signatureMethod, timestamp, nonce, version, realm, encodeOAuthSign."
+        },
+        "oauth2": {
+          "type": "object",
+          "title": "OAuth2",
+          "description": "The attributes for [OAuth2](https://oauth.net/2/). e.g. accessToken, addTokenTo."
+        }
+      },
+      "required": ["type"]
+    },
+    "certificate-list": {
+      "$id": "#/definitions/certificate-list",
+      "title": "Certificate List",
+      "description": "A representation of a list of ssl certificates",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/certificate"
+      }
+    },
+    "certificate": {
+      "$id": "#/definitions/certificate",
+      "title": "Certificate",
+      "description": "A representation of an ssl certificate",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "A name for the certificate for user reference",
+          "type": "string"
+        },
+        "matches": {
+          "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "An Url match pattern string"
+          }
+        },
+        "key": {
+          "description": "An object containing path to file containing private key, on the file system",
+          "type": "object",
+          "properties": {
+            "src": {
+              "description": "The path to file containing key for certificate, on the file system"
+            }
+          }
+        },
+        "cert": {
+          "description": "An object containing path to file certificate, on the file system",
+          "type": "object",
+          "properties": {
+            "src": {
+              "description": "The path to file containing key for certificate, on the file system"
+            }
+          }
+        },
+        "passphrase": {
+          "description": "The passphrase for the certificate",
+          "type": "string"
+        }
+      }
+    },
+    "cookie-list": {
+      "$id": "#/definitions/cookie-list",
+      "title": "Certificate List",
+      "description": "A representation of a list of cookies",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/cookie"
+      }
+    },
+    "cookie": {
+      "type": "object",
+      "title": "Cookie",
+      "$id": "#/definitions/cookie",
+      "description": "A Cookie, that follows the [Google Chrome format](https://developer.chrome.com/extensions/cookies)",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The domain for which this cookie is valid."
+        },
+        "expires": {
+          "type": ["string", "null"],
+          "description": "When the cookie expires."
+        },
+        "maxAge": {
+          "type": "string"
+        },
+        "hostOnly": {
+          "type": "boolean",
+          "description": "True if the cookie is a host-only cookie. (i.e. a request's URL domain must exactly match the domain of the cookie)."
+        },
+        "httpOnly": {
+          "type": "boolean",
+          "description": "Indicates if this cookie is HTTP Only. (if True, the cookie is inaccessible to client-side scripts)"
+        },
+        "name": {
+          "type": "string",
+          "description": "This is the name of the Cookie."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path associated with the Cookie."
+        },
+        "secure": {
+          "type": "boolean",
+          "description": "Indicates if the 'secure' flag is set on the Cookie, meaning that it is transmitted over secure connections only. (typically HTTPS)"
+        },
+        "session": {
+          "type": "boolean",
+          "description": "True if the cookie is a session cookie."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the Cookie."
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Custom attributes for a cookie go here, such as the [Priority Field](https://code.google.com/p/chromium/issues/detail?id=232693)"
+        }
+      },
+      "required": ["domain", "path"]
+    },
+    "description": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/description",
+      "description": "A Description can be a raw text, or be an object, which holds the description along with its format.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Description",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The content of the description goes here, as a raw string."
+            },
+            "type": {
+              "type": "string",
+              "description": "Holds the mime type of the raw description content. E.g: 'text/markdown' or 'text/html'.\nThe type is used to correctly render the description when generating documentation, or in the Postman app."
+            },
+            "version": {
+              "description": "Description can have versions associated with it, which should be put in this property."
+            }
+          }
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "event-list": {
+      "$id": "#/definitions/event-list",
+      "title": "Event List",
+      "type": "array",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Postman allows you to configure scripts to run when specific events occur. These scripts are stored here, and can be referenced in the collection by their ID.",
+      "items": {
+        "$ref": "#/definitions/event"
+      }
+    },
+    "event": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/event",
+      "title": "Event",
+      "description": "Defines a script associated with an associated event name",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the enclosing event."
+        },
+        "listen": {
+          "type": "string",
+          "description": "Can be set to `test` or `prerequest` for test scripts or pre-request scripts respectively."
+        },
+        "script": {
+          "$ref": "#/definitions/script"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates whether the event is disabled. If absent, the event is assumed to be enabled."
+        }
+      },
+      "required": ["listen"]
+    },
+    "header-list": {
+      "$id": "#/definitions/header-list",
+      "title": "Header List",
+      "description": "A representation for a list of headers",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/header"
+      }
+    },
+    "header": {
+      "type": "object",
+      "title": "Header",
+      "$id": "#/definitions/header",
+      "description": "Represents a single HTTP Header",
+      "properties": {
+        "key": {
+          "description": "This holds the LHS of the HTTP Header, e.g ``Content-Type`` or ``X-Custom-Header``",
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value (or the RHS) of the Header is stored in this field."
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true, the current header will not be sent with requests."
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/info",
+      "title": "Information",
+      "description": "Detailed description of the info block",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name of the collection",
+          "description": "A collection's friendly name is defined by this field. You would want to set this field to a value that would allow you to easily identify this collection among a bunch of other collections, as such outlining its usage or content."
+        },
+        "_postman_id": {
+          "type": "string",
+          "description": "Every collection is identified by the unique value of this field. The value of this field is usually easiest to generate using a UID generator function. If you already have a collection, it is recommended that you maintain the same id since changing the id usually implies that is a different collection than it was originally.\n *Note: This field exists for compatibility reasons with Collection Format V1.*"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "version": {
+          "$ref": "#/definitions/version"
+        },
+        "schema": {
+          "description": "This should ideally hold a link to the Postman schema that is used to validate this collection. E.g: https://schema.getpostman.com/collection/v1",
+          "type": "string"
+        }
+      },
+      "required": ["name", "schema"]
+    },
+    "item-group": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Folder",
+      "$id": "#/definitions/item-group",
+      "description": "One of the primary goals of Postman is to organize the development of APIs. To this end, it is necessary to be able to group requests together. This can be achived using 'Folders'. A folder just is an ordered set of requests.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "A folder's friendly name is defined by this field. You would want to set this field to a value that would allow you to easily identify this folder."
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "variable": {
+          "$ref": "#/definitions/variable-list"
+        },
+        "item": {
+          "description": "Items are entities which contain an actual HTTP request, and sample responses attached to it. Folders may contain many items.",
+          "type": "array",
+          "items": {
+            "title": "Items",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/item"
+              },
+              {
+                "$ref": "#/definitions/item-group"
+              }
+            ]
+          }
+        },
+        "event": {
+          "$ref": "#/definitions/event-list"
+        },
+        "auth": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/auth"
+            }
+          ]
+        },
+        "protocolProfileBehavior": {
+          "$ref": "#/definitions/protocol-profile-behavior"
+        }
+      },
+      "required": ["item"]
+    },
+    "item": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "title": "Item",
+      "$id": "#/definitions/item",
+      "description": "Items are entities which contain an actual HTTP request, and sample responses attached to it.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique ID that is used to identify collections internally"
+        },
+        "name": {
+          "type": "string",
+          "description": "A human readable identifier for the current item."
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "variable": {
+          "$ref": "#/definitions/variable-list"
+        },
+        "event": {
+          "$ref": "#/definitions/event-list"
+        },
+        "request": {
+          "$ref": "#/definitions/request"
+        },
+        "response": {
+          "type": "array",
+          "title": "Responses",
+          "items": {
+            "$ref": "#/definitions/response"
+          }
+        },
+        "protocolProfileBehavior": {
+          "$ref": "#/definitions/protocol-profile-behavior"
+        }
+      },
+      "required": ["request"]
+    },
+    "protocol-profile-behavior": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "title": "Protocol Profile Behavior",
+      "$id": "#/definitions/protocol-profile-behavior",
+      "description": "Set of configurations used to alter the usual behavior of sending the request"
+    },
+    "proxy-config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/proxy-config",
+      "title": "Proxy Config",
+      "description": "Using the Proxy, you can configure your custom proxy into the postman for particular url match",
+      "type": "object",
+      "properties": {
+        "match": {
+          "default": "http+https://*/*",
+          "description": "The Url match for which the proxy config is defined",
+          "type": "string"
+        },
+        "host": {
+          "type": "string",
+          "description": "The proxy server host"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 8080,
+          "description": "The proxy server port"
+        },
+        "tunnel": {
+          "description": "The tunneling details for the proxy config",
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, ignores this proxy configuration entity"
+        }
+      }
+    },
+    "request": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/request",
+      "title": "Request",
+      "description": "A request represents an HTTP request. If a string, the string is assumed to be the request URL and the method is assumed to be 'GET'.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Request",
+          "properties": {
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "auth": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/auth"
+                }
+              ]
+            },
+            "proxy": {
+              "$ref": "#/definitions/proxy-config"
+            },
+            "certificate": {
+              "$ref": "#/definitions/certificate"
+            },
+            "method": {
+              "anyOf": [
+                {
+                  "description": "The Standard HTTP method associated with this request.",
+                  "type": "string",
+                  "enum": [
+                    "GET",
+                    "PUT",
+                    "POST",
+                    "PATCH",
+                    "DELETE",
+                    "COPY",
+                    "HEAD",
+                    "OPTIONS",
+                    "LINK",
+                    "UNLINK",
+                    "PURGE",
+                    "LOCK",
+                    "UNLOCK",
+                    "PROPFIND",
+                    "VIEW"
+                  ]
+                },
+                {
+                  "description": "The Custom HTTP method associated with this request.",
+                  "type": "string"
+                }
+              ]
+            },
+            "description": {
+              "$ref": "#/definitions/description"
+            },
+            "header": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/header-list"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "description": "This field contains the data usually contained in the request body.",
+                  "properties": {
+                    "mode": {
+                      "description": "Postman stores the type of data associated with this request in this field.",
+                      "enum": ["raw", "urlencoded", "formdata", "file", "graphql"]
+                    },
+                    "raw": {
+                      "type": "string"
+                    },
+                    "graphql": {
+                      "type": "object"
+                    },
+                    "urlencoded": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "UrlEncodedParameter",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "disabled": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "description": {
+                            "$ref": "#/definitions/description"
+                          }
+                        },
+                        "required": ["key"]
+                      }
+                    },
+                    "formdata": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "FormParameter",
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "disabled": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "When set to true, prevents this form data entity from being sent."
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "text"
+                              },
+                              "contentType": {
+                                "type": "string",
+                                "description": "Override Content-Type header of this form data entity."
+                              },
+                              "description": {
+                                "$ref": "#/definitions/description"
+                              }
+                            },
+                            "required": ["key"]
+                          },
+                          {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "src": {
+                                "type": ["array", "string", "null"]
+                              },
+                              "disabled": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "When set to true, prevents this form data entity from being sent."
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "file"
+                              },
+                              "contentType": {
+                                "type": "string",
+                                "description": "Override Content-Type header of this form data entity."
+                              },
+                              "description": {
+                                "$ref": "#/definitions/description"
+                              }
+                            },
+                            "required": ["key"]
+                          }
+                        ]
+                      }
+                    },
+                    "file": {
+                      "type": "object",
+                      "properties": {
+                        "src": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "description": "Contains the name of the file to upload. _Not the path_."
+                            },
+                            {
+                              "type": "null",
+                              "description": "A null src indicates that no file has been selected as a part of the request body"
+                            }
+                          ]
+                        },
+                        "content": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "options": {
+                      "type": "object",
+                      "description": "Additional configurations and options set for various body modes."
+                    },
+                    "disabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "When set to true, prevents request body from being sent."
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "response": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/response",
+      "title": "Response",
+      "description": "A response represents an HTTP response.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A unique, user defined identifier that can  be used to refer to this response from requests.",
+          "type": "string"
+        },
+        "originalRequest": {
+          "$ref": "#/definitions/request"
+        },
+        "responseTime": {
+          "title": "ResponseTime",
+          "description": "The time taken by the request to complete. If a number, the unit is milliseconds. If the response is manually created, this can be set to `null`.",
+          "type": ["null", "string", "number"]
+        },
+        "timings": {
+          "title": "Response Timings",
+          "description": "Set of timing information related to request and response in milliseconds",
+          "type": ["object", "null"]
+        },
+        "header": {
+          "title": "Headers",
+          "oneOf": [
+            {
+              "type": "array",
+              "title": "Header",
+              "description": "No HTTP request is complete without its headers, and the same is true for a Postman request. This field is an array containing all the headers.",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/header"
+                  },
+                  {
+                    "title": "Header",
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cookie": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/cookie"
+          }
+        },
+        "body": {
+          "type": ["null", "string"],
+          "description": "The raw text of the response."
+        },
+        "status": {
+          "type": "string",
+          "description": "The response status, e.g: '200 OK'"
+        },
+        "code": {
+          "type": "integer",
+          "description": "The numerical response code, example: 200, 201, 404, etc."
+        }
+      }
+    },
+    "script": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/script",
+      "title": "Script",
+      "type": "object",
+      "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
+      "properties": {
+        "id": {
+          "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the script. E.g: 'text/javascript'",
+          "type": "string"
+        },
+        "exec": {
+          "oneOf": [
+            {
+              "type": "array",
+              "description": "This is an array of strings, where each line represents a single line of code. Having lines separate makes it possible to easily track changes made to scripts.",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "src": {
+          "$ref": "#/definitions/url"
+        },
+        "name": {
+          "type": "string",
+          "description": "Script name"
+        }
+      }
+    },
+    "url": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "If object, contains the complete broken-down URL for this request. If string, contains the literal request URL.",
+      "$id": "#/definitions/url",
+      "title": "Url",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "raw": {
+              "type": "string",
+              "description": "The string representation of the request URL, including the protocol, host, path, hash, query parameter(s) and path variable(s)."
+            },
+            "protocol": {
+              "type": "string",
+              "description": "The protocol associated with the request, E.g: 'http'"
+            },
+            "host": {
+              "title": "Host",
+              "description": "The host for the URL, E.g: api.yourdomain.com. Can be stored as a string or as an array of strings.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The host, split into subdomain strings."
+                }
+              ]
+            },
+            "path": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "description": "The complete path of the current url, broken down into segments. A segment could be a string, or a path variable.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "port": {
+              "type": "string",
+              "description": "The port number present in this URL. An empty value implies 80/443 depending on whether the protocol field contains http/https."
+            },
+            "query": {
+              "type": "array",
+              "description": "An array of QueryParams, which is basically the query string part of the URL, parsed into separate variables",
+              "items": {
+                "type": "object",
+                "title": "QueryParam",
+                "properties": {
+                  "key": {
+                    "type": ["string", "null"]
+                  },
+                  "value": {
+                    "type": ["string", "null"]
+                  },
+                  "disabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, the current query parameter will not be sent with the request."
+                  },
+                  "description": {
+                    "$ref": "#/definitions/description"
+                  }
+                }
+              }
+            },
+            "hash": {
+              "description": "Contains the URL fragment (if any). Usually this is not transmitted over the network, but it could be useful to store this in some cases.",
+              "type": "string"
+            },
+            "variable": {
+              "type": "array",
+              "description": "Postman supports path variables with the syntax `/path/:variableName/to/somewhere`. These variables are stored in this field.",
+              "items": {
+                "$ref": "#/definitions/variable"
+              }
+            }
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "variable-list": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/variable-list",
+      "title": "Variable List",
+      "description": "Collection variables allow you to define a set of variables, that are a *part of the collection*, as opposed to environments, which are separate entities.\n*Note: Collection variables must not contain any sensitive information.*",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/variable"
+      }
+    },
+    "variable": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/variable",
+      "title": "Variable",
+      "description": "Using variables in your Postman requests eliminates the need to duplicate requests, which can save a lot of time. Variables can be defined, and referenced to from any part of a request.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A variable ID is a unique user-defined value that identifies the variable within a collection. In traditional terms, this would be a variable name.",
+          "type": "string"
+        },
+        "key": {
+          "description": "A variable key is a human friendly value that identifies the variable within a collection. In traditional terms, this would be a variable name.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value that a variable holds in this collection. Ultimately, the variables will be replaced by this value, when say running a set of requests from a collection"
+        },
+        "type": {
+          "description": "A variable may have multiple types. This field specifies the type of the variable.",
+          "type": "string",
+          "enum": ["string", "boolean", "any", "number"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Variable name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "system": {
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, indicates that this variable has been set by Postman"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["id"]
+        },
+        {
+          "required": ["key"]
+        },
+        {
+          "required": ["id", "key"]
+        }
+      ]
+    },
+    "version": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/version",
+      "title": "Collection Version",
+      "description": "Postman allows you to version your collections as they grow, and this field holds the version number. While optional, it is recommended that you use this field to its fullest extent!",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "major": {
+              "description": "Increment this number if you make changes to the collection that changes its behaviour. E.g: Removing or adding new test scripts. (partly or completely).",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "minor": {
+              "description": "You should increment this number if you make changes that will not break anything that uses the collection. E.g: removing a folder.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "patch": {
+              "description": "Ideally, minor changes to a collection should result in the increment of this number.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "identifier": {
+              "description": "A human friendly identifier to make sense of the version numbers. E.g: 'beta-3'",
+              "type": "string",
+              "maxLength": 10
+            },
+            "meta": {}
+          },
+          "required": ["major", "minor", "patch"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/packages/postman-types/schemas/v2.1.0.json
+++ b/packages/postman-types/schemas/v2.1.0.json
@@ -1,0 +1,1071 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schema.getpostman.com/json/draft-07/collection/v2.1.0/",
+  "type": "object",
+  "properties": {
+    "info": {
+      "$ref": "#/definitions/info"
+    },
+    "item": {
+      "type": "array",
+      "description": "Items are the basic unit for a Postman collection. You can think of them as corresponding to a single API endpoint. Each Item has one request and may have multiple API responses associated with it.",
+      "items": {
+        "title": "Items",
+        "oneOf": [
+          {
+            "$ref": "#/definitions/item"
+          },
+          {
+            "$ref": "#/definitions/item-group"
+          }
+        ]
+      }
+    },
+    "event": {
+      "$ref": "#/definitions/event-list"
+    },
+    "variable": {
+      "$ref": "#/definitions/variable-list"
+    },
+    "auth": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/definitions/auth"
+        }
+      ]
+    },
+    "protocolProfileBehavior": {
+      "$ref": "#/definitions/protocol-profile-behavior"
+    }
+  },
+  "required": ["info", "item"],
+  "definitions": {
+    "auth-attribute": {
+      "type": "object",
+      "title": "Auth",
+      "$id": "#/definitions/auth-attribute",
+      "description": "Represents an attribute for any authorization method provided by Postman. For example `username` and `password` are set as auth attributes for Basic Authentication method.",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {},
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["key"]
+    },
+    "auth": {
+      "type": "object",
+      "title": "Auth",
+      "$id": "#/definitions/auth",
+      "description": "Represents authentication helpers provided by Postman",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "apikey",
+            "awsv4",
+            "basic",
+            "bearer",
+            "digest",
+            "edgegrid",
+            "hawk",
+            "noauth",
+            "oauth1",
+            "oauth2",
+            "ntlm"
+          ]
+        },
+        "noauth": {},
+        "apikey": {
+          "type": "array",
+          "title": "API Key Authentication",
+          "description": "The attributes for API Key Authentication.",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "awsv4": {
+          "type": "array",
+          "title": "AWS Signature v4",
+          "description": "The attributes for [AWS Auth](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html).",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "basic": {
+          "type": "array",
+          "title": "Basic Authentication",
+          "description": "The attributes for [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "bearer": {
+          "type": "array",
+          "title": "Bearer Token Authentication",
+          "description": "The helper attributes for [Bearer Token Authentication](https://tools.ietf.org/html/rfc6750)",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "digest": {
+          "type": "array",
+          "title": "Digest Authentication",
+          "description": "The attributes for [Digest Authentication](https://en.wikipedia.org/wiki/Digest_access_authentication).",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "edgegrid": {
+          "type": "array",
+          "title": "EdgeGrid Authentication",
+          "description": "The attributes for [Akamai EdgeGrid Authentication](https://developer.akamai.com/legacy/introduction/Client_Auth.html).",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "hawk": {
+          "type": "array",
+          "title": "Hawk Authentication",
+          "description": "The attributes for [Hawk Authentication](https://github.com/hueniverse/hawk)",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "ntlm": {
+          "type": "array",
+          "title": "NTLM Authentication",
+          "description": "The attributes for [NTLM Authentication](https://msdn.microsoft.com/en-us/library/cc237488.aspx)",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "oauth1": {
+          "type": "array",
+          "title": "OAuth1",
+          "description": "The attributes for [OAuth2](https://oauth.net/1/)",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        },
+        "oauth2": {
+          "type": "array",
+          "title": "OAuth2",
+          "description": "Helper attributes for [OAuth2](https://oauth.net/2/)",
+          "items": {
+            "$ref": "#/definitions/auth-attribute"
+          }
+        }
+      },
+      "required": ["type"]
+    },
+    "certificate-list": {
+      "$id": "#/definitions/certificate-list",
+      "title": "Certificate List",
+      "description": "A representation of a list of ssl certificates",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/certificate"
+      }
+    },
+    "certificate": {
+      "$id": "#/definitions/certificate",
+      "title": "Certificate",
+      "description": "A representation of an ssl certificate",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "A name for the certificate for user reference",
+          "type": "string"
+        },
+        "matches": {
+          "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "An Url match pattern string"
+          }
+        },
+        "key": {
+          "description": "An object containing path to file containing private key, on the file system",
+          "type": "object",
+          "properties": {
+            "src": {
+              "description": "The path to file containing key for certificate, on the file system"
+            }
+          }
+        },
+        "cert": {
+          "description": "An object containing path to file certificate, on the file system",
+          "type": "object",
+          "properties": {
+            "src": {
+              "description": "The path to file containing key for certificate, on the file system"
+            }
+          }
+        },
+        "passphrase": {
+          "description": "The passphrase for the certificate",
+          "type": "string"
+        }
+      }
+    },
+    "cookie-list": {
+      "$id": "#/definitions/cookie-list",
+      "title": "Certificate List",
+      "description": "A representation of a list of cookies",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/cookie"
+      }
+    },
+    "cookie": {
+      "type": "object",
+      "title": "Cookie",
+      "$id": "#/definitions/cookie",
+      "description": "A Cookie, that follows the [Google Chrome format](https://developer.chrome.com/extensions/cookies)",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "The domain for which this cookie is valid."
+        },
+        "expires": {
+          "type": ["string", "null"],
+          "description": "When the cookie expires."
+        },
+        "maxAge": {
+          "type": "string"
+        },
+        "hostOnly": {
+          "type": "boolean",
+          "description": "True if the cookie is a host-only cookie. (i.e. a request's URL domain must exactly match the domain of the cookie)."
+        },
+        "httpOnly": {
+          "type": "boolean",
+          "description": "Indicates if this cookie is HTTP Only. (if True, the cookie is inaccessible to client-side scripts)"
+        },
+        "name": {
+          "type": "string",
+          "description": "This is the name of the Cookie."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path associated with the Cookie."
+        },
+        "secure": {
+          "type": "boolean",
+          "description": "Indicates if the 'secure' flag is set on the Cookie, meaning that it is transmitted over secure connections only. (typically HTTPS)"
+        },
+        "session": {
+          "type": "boolean",
+          "description": "True if the cookie is a session cookie."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the Cookie."
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Custom attributes for a cookie go here, such as the [Priority Field](https://code.google.com/p/chromium/issues/detail?id=232693)"
+        }
+      },
+      "required": ["domain", "path"]
+    },
+    "description": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/description",
+      "description": "A Description can be a raw text, or be an object, which holds the description along with its format.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Description",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The content of the description goes here, as a raw string."
+            },
+            "type": {
+              "type": "string",
+              "description": "Holds the mime type of the raw description content. E.g: 'text/markdown' or 'text/html'.\nThe type is used to correctly render the description when generating documentation, or in the Postman app."
+            },
+            "version": {
+              "description": "Description can have versions associated with it, which should be put in this property."
+            }
+          }
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "event-list": {
+      "$id": "#/definitions/event-list",
+      "title": "Event List",
+      "type": "array",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "Postman allows you to configure scripts to run when specific events occur. These scripts are stored here, and can be referenced in the collection by their ID.",
+      "items": {
+        "$ref": "#/definitions/event"
+      }
+    },
+    "event": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/event",
+      "title": "Event",
+      "description": "Defines a script associated with an associated event name",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for the enclosing event."
+        },
+        "listen": {
+          "type": "string",
+          "description": "Can be set to `test` or `prerequest` for test scripts or pre-request scripts respectively."
+        },
+        "script": {
+          "$ref": "#/definitions/script"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Indicates whether the event is disabled. If absent, the event is assumed to be enabled."
+        }
+      },
+      "required": ["listen"]
+    },
+    "header-list": {
+      "$id": "#/definitions/header-list",
+      "title": "Header List",
+      "description": "A representation for a list of headers",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/header"
+      }
+    },
+    "header": {
+      "type": "object",
+      "title": "Header",
+      "$id": "#/definitions/header",
+      "description": "Represents a single HTTP Header",
+      "properties": {
+        "key": {
+          "description": "This holds the LHS of the HTTP Header, e.g ``Content-Type`` or ``X-Custom-Header``",
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value (or the RHS) of the Header is stored in this field."
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true, the current header will not be sent with requests."
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        }
+      },
+      "required": ["key", "value"]
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/info",
+      "title": "Information",
+      "description": "Detailed description of the info block",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name of the collection",
+          "description": "A collection's friendly name is defined by this field. You would want to set this field to a value that would allow you to easily identify this collection among a bunch of other collections, as such outlining its usage or content."
+        },
+        "_postman_id": {
+          "type": "string",
+          "description": "Every collection is identified by the unique value of this field. The value of this field is usually easiest to generate using a UID generator function. If you already have a collection, it is recommended that you maintain the same id since changing the id usually implies that is a different collection than it was originally.\n *Note: This field exists for compatibility reasons with Collection Format V1.*"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "version": {
+          "$ref": "#/definitions/version"
+        },
+        "schema": {
+          "description": "This should ideally hold a link to the Postman schema that is used to validate this collection. E.g: https://schema.getpostman.com/collection/v1",
+          "type": "string"
+        }
+      },
+      "required": ["name", "schema"]
+    },
+    "item-group": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Folder",
+      "$id": "#/definitions/item-group",
+      "description": "One of the primary goals of Postman is to organize the development of APIs. To this end, it is necessary to be able to group requests together. This can be achived using 'Folders'. A folder just is an ordered set of requests.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "A folder's friendly name is defined by this field. You would want to set this field to a value that would allow you to easily identify this folder."
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "variable": {
+          "$ref": "#/definitions/variable-list"
+        },
+        "item": {
+          "description": "Items are entities which contain an actual HTTP request, and sample responses attached to it. Folders may contain many items.",
+          "type": "array",
+          "items": {
+            "title": "Items",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/item"
+              },
+              {
+                "$ref": "#/definitions/item-group"
+              }
+            ]
+          }
+        },
+        "event": {
+          "$ref": "#/definitions/event-list"
+        },
+        "auth": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/auth"
+            }
+          ]
+        },
+        "protocolProfileBehavior": {
+          "$ref": "#/definitions/protocol-profile-behavior"
+        }
+      },
+      "required": ["item"]
+    },
+    "item": {
+      "type": "object",
+      "title": "Item",
+      "$id": "#/definitions/item",
+      "description": "Items are entities which contain an actual HTTP request, and sample responses attached to it.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique ID that is used to identify collections internally"
+        },
+        "name": {
+          "type": "string",
+          "description": "A human readable identifier for the current item."
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "variable": {
+          "$ref": "#/definitions/variable-list"
+        },
+        "event": {
+          "$ref": "#/definitions/event-list"
+        },
+        "request": {
+          "$ref": "#/definitions/request"
+        },
+        "response": {
+          "type": "array",
+          "title": "Responses",
+          "items": {
+            "$ref": "#/definitions/response"
+          }
+        },
+        "protocolProfileBehavior": {
+          "$ref": "#/definitions/protocol-profile-behavior"
+        }
+      },
+      "required": ["request"]
+    },
+    "protocol-profile-behavior": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "title": "Protocol Profile Behavior",
+      "$id": "#/definitions/protocol-profile-behavior",
+      "description": "Set of configurations used to alter the usual behavior of sending the request"
+    },
+    "proxy-config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/proxy-config",
+      "title": "Proxy Config",
+      "description": "Using the Proxy, you can configure your custom proxy into the postman for particular url match",
+      "type": "object",
+      "properties": {
+        "match": {
+          "default": "http+https://*/*",
+          "description": "The Url match for which the proxy config is defined",
+          "type": "string"
+        },
+        "host": {
+          "type": "string",
+          "description": "The proxy server host"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 8080,
+          "description": "The proxy server port"
+        },
+        "tunnel": {
+          "description": "The tunneling details for the proxy config",
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, ignores this proxy configuration entity"
+        }
+      }
+    },
+    "request": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/request",
+      "title": "Request",
+      "description": "A request represents an HTTP request. If a string, the string is assumed to be the request URL and the method is assumed to be 'GET'.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Request",
+          "properties": {
+            "url": {
+              "$ref": "#/definitions/url"
+            },
+            "auth": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/auth"
+                }
+              ]
+            },
+            "proxy": {
+              "$ref": "#/definitions/proxy-config"
+            },
+            "certificate": {
+              "$ref": "#/definitions/certificate"
+            },
+            "method": {
+              "anyOf": [
+                {
+                  "description": "The Standard HTTP method associated with this request.",
+                  "type": "string",
+                  "enum": [
+                    "GET",
+                    "PUT",
+                    "POST",
+                    "PATCH",
+                    "DELETE",
+                    "COPY",
+                    "HEAD",
+                    "OPTIONS",
+                    "LINK",
+                    "UNLINK",
+                    "PURGE",
+                    "LOCK",
+                    "UNLOCK",
+                    "PROPFIND",
+                    "VIEW"
+                  ]
+                },
+                {
+                  "description": "The Custom HTTP method associated with this request.",
+                  "type": "string"
+                }
+              ]
+            },
+            "description": {
+              "$ref": "#/definitions/description"
+            },
+            "header": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/header-list"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "description": "This field contains the data usually contained in the request body.",
+                  "properties": {
+                    "mode": {
+                      "description": "Postman stores the type of data associated with this request in this field.",
+                      "enum": ["raw", "urlencoded", "formdata", "file", "graphql"]
+                    },
+                    "raw": {
+                      "type": "string"
+                    },
+                    "graphql": {
+                      "type": "object"
+                    },
+                    "urlencoded": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "UrlEncodedParameter",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "disabled": {
+                            "type": "boolean",
+                            "default": false
+                          },
+                          "description": {
+                            "$ref": "#/definitions/description"
+                          }
+                        },
+                        "required": ["key"]
+                      }
+                    },
+                    "formdata": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "FormParameter",
+                        "anyOf": [
+                          {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "disabled": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "When set to true, prevents this form data entity from being sent."
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "text"
+                              },
+                              "contentType": {
+                                "type": "string",
+                                "description": "Override Content-Type header of this form data entity."
+                              },
+                              "description": {
+                                "$ref": "#/definitions/description"
+                              }
+                            },
+                            "required": ["key"]
+                          },
+                          {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "src": {
+                                "type": ["array", "string", "null"]
+                              },
+                              "disabled": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "When set to true, prevents this form data entity from being sent."
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "file"
+                              },
+                              "contentType": {
+                                "type": "string",
+                                "description": "Override Content-Type header of this form data entity."
+                              },
+                              "description": {
+                                "$ref": "#/definitions/description"
+                              }
+                            },
+                            "required": ["key"]
+                          }
+                        ]
+                      }
+                    },
+                    "file": {
+                      "type": "object",
+                      "properties": {
+                        "src": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "description": "Contains the name of the file to upload. _Not the path_."
+                            },
+                            {
+                              "type": "null",
+                              "description": "A null src indicates that no file has been selected as a part of the request body"
+                            }
+                          ]
+                        },
+                        "content": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "options": {
+                      "type": "object",
+                      "description": "Additional configurations and options set for various body modes."
+                    },
+                    "disabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "When set to true, prevents request body from being sent."
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "response": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/response",
+      "title": "Response",
+      "description": "A response represents an HTTP response.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A unique, user defined identifier that can  be used to refer to this response from requests.",
+          "type": "string"
+        },
+        "originalRequest": {
+          "$ref": "#/definitions/request"
+        },
+        "responseTime": {
+          "title": "ResponseTime",
+          "type": ["null", "string", "number"],
+          "description": "The time taken by the request to complete. If a number, the unit is milliseconds. If the response is manually created, this can be set to `null`."
+        },
+        "timings": {
+          "title": "Response Timings",
+          "description": "Set of timing information related to request and response in milliseconds",
+          "type": ["object", "null"]
+        },
+        "header": {
+          "title": "Headers",
+          "oneOf": [
+            {
+              "type": "array",
+              "title": "Header",
+              "description": "No HTTP request is complete without its headers, and the same is true for a Postman request. This field is an array containing all the headers.",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/header"
+                  },
+                  {
+                    "title": "Header",
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            {
+              "type": ["string", "null"]
+            }
+          ]
+        },
+        "cookie": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/cookie"
+          }
+        },
+        "body": {
+          "type": ["null", "string"],
+          "description": "The raw text of the response."
+        },
+        "status": {
+          "type": "string",
+          "description": "The response status, e.g: '200 OK'"
+        },
+        "code": {
+          "type": "integer",
+          "description": "The numerical response code, example: 200, 201, 404, etc."
+        }
+      }
+    },
+    "script": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/script",
+      "title": "Script",
+      "type": "object",
+      "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
+      "properties": {
+        "id": {
+          "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the script. E.g: 'text/javascript'",
+          "type": "string"
+        },
+        "exec": {
+          "oneOf": [
+            {
+              "type": "array",
+              "description": "This is an array of strings, where each line represents a single line of code. Having lines separate makes it possible to easily track changes made to scripts.",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "src": {
+          "$ref": "#/definitions/url"
+        },
+        "name": {
+          "type": "string",
+          "description": "Script name"
+        }
+      }
+    },
+    "url": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "If object, contains the complete broken-down URL for this request. If string, contains the literal request URL.",
+      "$id": "#/definitions/url",
+      "title": "Url",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "raw": {
+              "type": "string",
+              "description": "The string representation of the request URL, including the protocol, host, path, hash, query parameter(s) and path variable(s)."
+            },
+            "protocol": {
+              "type": "string",
+              "description": "The protocol associated with the request, E.g: 'http'"
+            },
+            "host": {
+              "title": "Host",
+              "description": "The host for the URL, E.g: api.yourdomain.com. Can be stored as a string or as an array of strings.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The host, split into subdomain strings."
+                }
+              ]
+            },
+            "path": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "description": "The complete path of the current url, broken down into segments. A segment could be a string, or a path variable.",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "port": {
+              "type": "string",
+              "description": "The port number present in this URL. An empty value implies 80/443 depending on whether the protocol field contains http/https."
+            },
+            "query": {
+              "type": "array",
+              "description": "An array of QueryParams, which is basically the query string part of the URL, parsed into separate variables",
+              "items": {
+                "type": "object",
+                "title": "QueryParam",
+                "properties": {
+                  "key": {
+                    "type": ["string", "null"]
+                  },
+                  "value": {
+                    "type": ["string", "null"]
+                  },
+                  "disabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, the current query parameter will not be sent with the request."
+                  },
+                  "description": {
+                    "$ref": "#/definitions/description"
+                  }
+                }
+              }
+            },
+            "hash": {
+              "description": "Contains the URL fragment (if any). Usually this is not transmitted over the network, but it could be useful to store this in some cases.",
+              "type": "string"
+            },
+            "variable": {
+              "type": "array",
+              "description": "Postman supports path variables with the syntax `/path/:variableName/to/somewhere`. These variables are stored in this field.",
+              "items": {
+                "$ref": "#/definitions/variable"
+              }
+            }
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "variable-list": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/variable-list",
+      "title": "Variable List",
+      "description": "Collection variables allow you to define a set of variables, that are a *part of the collection*, as opposed to environments, which are separate entities.\n*Note: Collection variables must not contain any sensitive information.*",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/variable"
+      }
+    },
+    "variable": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/variable",
+      "title": "Variable",
+      "description": "Using variables in your Postman requests eliminates the need to duplicate requests, which can save a lot of time. Variables can be defined, and referenced to from any part of a request.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A variable ID is a unique user-defined value that identifies the variable within a collection. In traditional terms, this would be a variable name.",
+          "type": "string"
+        },
+        "key": {
+          "description": "A variable key is a human friendly value that identifies the variable within a collection. In traditional terms, this would be a variable name.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value that a variable holds in this collection. Ultimately, the variables will be replaced by this value, when say running a set of requests from a collection"
+        },
+        "type": {
+          "description": "A variable may have multiple types. This field specifies the type of the variable.",
+          "type": "string",
+          "enum": ["string", "boolean", "any", "number"]
+        },
+        "name": {
+          "type": "string",
+          "description": "Variable name"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "system": {
+          "type": "boolean",
+          "default": false,
+          "description": "When set to true, indicates that this variable has been set by Postman"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["id"]
+        },
+        {
+          "required": ["key"]
+        },
+        {
+          "required": ["id", "key"]
+        }
+      ]
+    },
+    "version": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "#/definitions/version",
+      "title": "Collection Version",
+      "description": "Postman allows you to version your collections as they grow, and this field holds the version number. While optional, it is recommended that you use this field to its fullest extent!",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "major": {
+              "description": "Increment this number if you make changes to the collection that changes its behaviour. E.g: Removing or adding new test scripts. (partly or completely).",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "minor": {
+              "description": "You should increment this number if you make changes that will not break anything that uses the collection. E.g: removing a folder.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "patch": {
+              "description": "Ideally, minor changes to a collection should result in the increment of this number.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "identifier": {
+              "description": "A human friendly identifier to make sense of the version numbers. E.g: 'beta-3'",
+              "type": "string",
+              "maxLength": 10
+            },
+            "meta": {}
+          },
+          "required": ["major", "minor", "patch"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+}

--- a/packages/postman-types/src/index.ts
+++ b/packages/postman-types/src/index.ts
@@ -1,0 +1,280 @@
+export namespace Postman {}
+
+export namespace PostmanV2 {
+  export interface Collection {
+    auth?: AuthObject | null;
+    event?: EventListObject;
+    info: InfoObject;
+    item: (ItemGroupObject | ItemObject)[];
+    protocolProfileBehavior?: ProtocolProfileBehaviorObject;
+    variable?: VariableListObject;
+  }
+
+  export interface AuthObject {
+    apikey?: object;
+    awsv4?: object;
+    basic?: object;
+    bearer?: object;
+    digest?: object;
+    edgegrid?: object;
+    hawk?: object;
+    noauth?: never;
+    ntlm?: object;
+    oauth1?: object;
+    oauth2?: object;
+    type:
+      | 'apikey'
+      | 'awsv4'
+      | 'basic'
+      | 'bearer'
+      | 'digest'
+      | 'edgegrid'
+      | 'hawk'
+      | 'noauth'
+      | 'ntlm'
+      | 'oauth1'
+      | 'oauth2';
+  }
+
+  export type CertificateListObject = CertificateObject[];
+
+  export interface CertificateObject {
+    cert?: {
+      src: string;
+    };
+    key?: {
+      src: string;
+    };
+    matches: string[];
+    name?: string;
+    passphrase?: string;
+  }
+
+  export type CookieListObject = CookieObject[];
+
+  export interface CookieObject {
+    domain: string;
+    expires?: string | null;
+    extensions?: any[];
+    hostOnly?: boolean;
+    httpOnly?: boolean;
+    maxAge?: string;
+    name?: string;
+    path: string;
+    secure?: boolean;
+    session?: boolean;
+    value?: string;
+  }
+
+  export type DescriptionObject =
+    | string
+    | {
+        content?: string;
+        type?: string;
+        version?: string;
+      }
+    | null;
+
+  export type EventListObject = EventObject[];
+
+  export interface EventObject {
+    disabled?: boolean;
+    id?: string;
+    listen: string;
+    script?: ScriptObject;
+  }
+
+  export type HeaderListObject = HeaderObject[];
+
+  export interface HeaderObject {
+    description?: DescriptionObject;
+    disabled?: boolean;
+    key: string;
+    value: string;
+  }
+
+  export interface InfoObject {
+    _postman_id?: string;
+    description?: DescriptionObject;
+    name: string;
+    schema: string;
+    version?: VersionObject;
+  }
+
+  export interface ItemGroupObject {
+    auth?: AuthObject | null;
+    description?: DescriptionObject;
+    event?: EventListObject;
+    item?: (ItemGroupObject | ItemObject)[];
+    name: string;
+    protocolProfileBehavior: ProtocolProfileBehaviorObject;
+    variable?: VariableListObject;
+  }
+
+  export interface ItemObject {
+    description?: DescriptionObject;
+    event?: EventListObject;
+    id?: string;
+    name?: string;
+    protocolProfileBehavior?: ProtocolProfileBehaviorObject;
+    request: RequestObject;
+    response?: ResponseObject[];
+    variable?: VariableListObject;
+  }
+
+  export interface ProtocolProfileBehaviorObject {}
+
+  export interface ProxyConfigObject {
+    disabled?: boolean;
+    host?: string;
+    match?: string;
+    port?: number;
+    tunnel?: boolean;
+  }
+
+  export type RequestObject =
+    | string
+    | {
+        auth: AuthObject | null;
+        body: {
+          disabled: boolean;
+          file: {
+            content?: string;
+            src?: string | null;
+          };
+          formdata: FormParameter[];
+          graphql?: object;
+          mode?: 'file' | 'formdata' | 'graphql' | 'raw' | 'urlencoded';
+          options: object;
+          raw?: 'string';
+          urlencoded: {
+            description?: DescriptionObject;
+            disabled?: boolean;
+            key: string;
+            value?: string;
+          }[];
+        } | null;
+        certificate: CertificateObject;
+        description: DescriptionObject;
+        header: HeaderListObject | string;
+        method:
+          | string
+          | 'COPY'
+          | 'DELETE'
+          | 'GET'
+          | 'HEAD'
+          | 'LINK'
+          | 'LOCK'
+          | 'OPTIONS'
+          | 'PATCH'
+          | 'POST'
+          | 'PROPFIND'
+          | 'PURGE'
+          | 'PUT'
+          | 'UNLINK'
+          | 'UNLOCK'
+          | 'VIEW';
+        proxy: ProxyConfigObject;
+        url: UrlObject;
+      };
+
+  export interface ResponseObject {
+    body?: 'null' | 'string';
+    code?: number;
+    cookie?: CookieObject[];
+    header?: (HeaderObject | string)[] | string | null;
+    id?: string;
+    originalRequest?: RequestObject;
+    responseTime?: number | string | null;
+    status?: string;
+    timings?: object | null;
+  }
+
+  export interface ScriptObject {
+    exec?: string[] | string;
+    id?: string;
+    name?: string;
+    src?: UrlObject;
+    type?: string;
+  }
+
+  export type UrlObject =
+    | string
+    | {
+        hash: string;
+        host: string[] | string;
+        path: (string | { type: string; value: string })[] | string;
+        port: string;
+        protocol: string;
+        query: {
+          description: DescriptionObject;
+          disabled: boolean;
+          key: string | null;
+          value: string | null;
+        }[];
+        raw: string;
+        variable: VariableObject[];
+      };
+
+  export type VariableListObject = VariableObject[];
+
+  export type VariableObject =
+    | {
+        description?: DescriptionObject;
+        disabled?: boolean;
+        id: string;
+        key: string;
+        name?: string;
+        system?: boolean;
+        type?: any | boolean | number | string;
+        value?: string;
+      }
+    | {
+        description?: DescriptionObject;
+        disabled?: boolean;
+        id: string;
+        key?: string;
+        name?: string;
+        system?: boolean;
+        type?: any | boolean | number | string;
+        value?: string;
+      }
+    | {
+        description?: DescriptionObject;
+        disabled?: boolean;
+        id?: string;
+        key: string;
+        name?: string;
+        system?: boolean;
+        type?: any | boolean | number | string;
+        value?: string;
+      };
+
+  export type VersionObject =
+    | string
+    | {
+        identifier?: string;
+        major: number;
+        meta?: object;
+        minor: number;
+        patch: number;
+      };
+
+  export type FormParameter =
+    | {
+        contentType?: string;
+        description?: DescriptionObject;
+        disabled?: boolean;
+        key: string;
+        src?: 'array' | 'null' | 'string';
+        type?: 'file';
+      }
+    | {
+        contentType?: string;
+        description?: DescriptionObject;
+        disabled?: boolean;
+        key: string;
+        type?: 'text';
+        value?: string;
+      };
+}

--- a/packages/postman-types/src/index.ts
+++ b/packages/postman-types/src/index.ts
@@ -1,4 +1,6 @@
-export namespace Postman {}
+export namespace Postman {
+  export type Collection = PostmanV2_1.Collection | PostmanV2.Collection;
+}
 
 export namespace PostmanV2 {
   export interface Collection {

--- a/packages/postman-types/src/index.ts
+++ b/packages/postman-types/src/index.ts
@@ -18,7 +18,7 @@ export namespace PostmanV2 {
     digest?: object;
     edgegrid?: object;
     hawk?: object;
-    noauth?: never;
+    noauth?: unknown;
     ntlm?: object;
     oauth1?: object;
     oauth2?: object;
@@ -275,6 +275,299 @@ export namespace PostmanV2 {
         disabled?: boolean;
         key: string;
         type?: 'text';
+        value?: string;
+      };
+}
+
+export namespace PostmanV2_1 {
+  export interface Collection {
+    auth?: AuthObject | null;
+    event?: EventListObject;
+    info: InfoObject;
+    item: (ItemGroupObject | ItemObject)[];
+    protocolProfileBehavior?: ProtocolProfileBehaviorObject;
+    variable?: VariableListObject;
+  }
+
+  export interface AuthAttributeObject {
+    key: string;
+    type?: string;
+    value?: object;
+  }
+
+  export interface AuthObject {
+    apikey?: AuthAttributeObject[];
+    awsv4?: AuthAttributeObject[];
+    basic?: AuthAttributeObject[];
+    bearer?: AuthAttributeObject[];
+    digest?: AuthAttributeObject[];
+    edgegrid?: AuthAttributeObject[];
+    hawk?: AuthAttributeObject[];
+    noauth?: unknown;
+    ntlm?: AuthAttributeObject[];
+    oauth1?: AuthAttributeObject[];
+    oauth2?: AuthAttributeObject[];
+    type:
+      | 'apikey'
+      | 'awsv4'
+      | 'basic'
+      | 'bearer'
+      | 'digest'
+      | 'edgegrid'
+      | 'hawk'
+      | 'noauth'
+      | 'ntlm'
+      | 'oauth1'
+      | 'oauth2';
+  }
+
+  export type CertificateListObject = CertificateObject[];
+
+  export interface CertificateObject {
+    cert?: {
+      src?: string;
+    };
+    key?: {
+      src?: string;
+    };
+    matches?: string[];
+    name?: string;
+    passphrase?: string;
+  }
+
+  export type CookieList = CookieObject[];
+
+  export interface CookieObject {
+    domain: string;
+    expires?: string | null;
+    extensions?: unknown[];
+    hostOnly?: boolean;
+    httpOnly?: boolean;
+    maxAge?: string;
+    name?: string;
+    path: string;
+    secure?: boolean;
+    session?: boolean;
+    value?: string;
+  }
+
+  export type DescriptionObject =
+    | string
+    | {
+        content: string;
+        type: string;
+        version: string;
+      }
+    | null;
+
+  export type EventListObject = EventObject[];
+
+  export interface EventObject {
+    disabled?: boolean;
+    id?: string;
+    listen: string;
+    script?: ScriptObject;
+  }
+
+  export type HeaderListObject = HeaderObject[];
+
+  export interface HeaderObject {
+    description?: DescriptionObject;
+    disabled?: boolean;
+    key: string;
+    value: string;
+  }
+
+  export interface InfoObject {
+    _postman_id?: string;
+    description?: DescriptionObject;
+    name: string;
+    schema: string;
+    version?: VersionObject;
+  }
+
+  export interface ItemGroupObject {
+    auth?: AuthObject | null;
+    description?: DescriptionObject;
+    event?: EventListObject;
+    item: (ItemGroupObject | ItemObject)[];
+    name?: string;
+    protocolProfileBehavior?: ProtocolProfileBehaviorObject;
+    variable?: VariableListObject;
+  }
+
+  export interface ItemObject {
+    description?: DescriptionObject;
+    event?: EventListObject;
+    id?: string;
+    name?: string;
+    protocolProfileBehavior?: ProtocolProfileBehaviorObject;
+    request: RequestObject;
+    response?: ResponseObject[];
+    variable?: VariableListObject;
+  }
+
+  export type ProtocolProfileBehaviorObject = object;
+
+  export interface ProxyConfigObject {
+    disabled?: boolean;
+    host?: string;
+    match?: string;
+    port?: number;
+    tunnel?: boolean;
+  }
+
+  export type RequestObject =
+    | string
+    | {
+        auth?: AuthObject | null;
+        body?: {
+          disabled?: boolean;
+          file?: {
+            content: string;
+            src: string | null;
+          };
+          formdata?: FormParameter;
+          graphql?: object;
+          mode?: 'file' | 'formdata' | 'graphql' | 'raw' | 'urlencoded';
+          options?: object;
+          raw?: string;
+          urlencoded?: {
+            description?: DescriptionObject;
+            disabled?: boolean;
+            key: string;
+            value?: string;
+          }[];
+        } | null;
+        certificate?: CertificateObject;
+        description?: DescriptionObject;
+        header?: HeaderListObject | string;
+        method?:
+          | string
+          | 'COPY'
+          | 'DELETE'
+          | 'GET'
+          | 'HEAD'
+          | 'LINK'
+          | 'LOCK'
+          | 'OPTIONS'
+          | 'PATCH'
+          | 'POST'
+          | 'PROPFIND'
+          | 'PURGE'
+          | 'PUT'
+          | 'UNLINK'
+          | 'UNLOCK'
+          | 'VIEW';
+        proxy?: ProxyConfigObject;
+        url?: UrlObject;
+      };
+
+  export interface ResponseObject {
+    body?: 'null' | 'string';
+    code?: number;
+    cookie?: CookieObject[];
+    header?: (HeaderObject | string)[] | string | null;
+    id?: string;
+    originalRequest?: RequestObject;
+    responseTime?: 'null' | 'number' | 'string';
+    status?: string;
+    timings?: 'null' | 'object';
+  }
+
+  export interface ScriptObject {
+    exec?: string[] | string;
+    id?: string;
+    name?: string;
+    src?: UrlObject;
+    type?: string;
+  }
+
+  export type UrlObject =
+    | string
+    | {
+        hash?: string;
+        host?: string[] | string;
+        path?:
+          | (
+              | string
+              | {
+                  type: string;
+                  value: string;
+                }
+            )[]
+          | string;
+        port?: string;
+        protocol?: string;
+        query?: {
+          description?: DescriptionObject;
+          disabled?: boolean;
+          key?: string | null;
+          value?: string | null;
+        }[];
+        raw?: string;
+        variable?: VariableObject[];
+      };
+
+  export type VariableListObject = VariableObject[];
+
+  export type VariableObject =
+    | {
+        description?: DescriptionObject;
+        disabled?: boolean;
+        id: string;
+        key: string;
+        name?: string;
+        system?: boolean;
+        type?: any | boolean | number | string;
+        value?: unknown;
+      }
+    | {
+        description?: DescriptionObject;
+        disabled?: boolean;
+        id: string;
+        key?: string;
+        name?: string;
+        system?: boolean;
+        type?: any | boolean | number | string;
+        value?: unknown;
+      }
+    | {
+        description?: DescriptionObject;
+        disabled?: boolean;
+        id?: string;
+        key?: string;
+        name?: string;
+        system?: boolean;
+        type?: any | boolean | number | string;
+        value?: unknown;
+      };
+
+  export type VersionObject =
+    | string
+    | {
+        identifier?: string;
+        major: number;
+        meta: unknown;
+        minor: number;
+        patch: number;
+      };
+
+  export type FormParameter =
+    | {
+        contentType?: string;
+        description?: DescriptionObject;
+        disabled?: boolean;
+        key: string;
+        src?: 'array' | 'null' | 'string';
+        type?: 'file';
+      }
+    | {
+        contentType?: string;
+        description?: DescriptionObject;
+        disabled?: boolean;
+        key: string;
+        type?: string;
         value?: string;
       };
 }

--- a/packages/postman-types/tsconfig.json
+++ b/packages/postman-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/postman-types/tsup.config.ts
+++ b/packages/postman-types/tsup.config.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'tsup';
+
+import config from '../../tsup.config.js';
+
+export default defineConfig(options => ({
+  ...options,
+  ...config,
+
+  entry: ['src/index.ts'],
+  silent: !options.watch,
+}));


### PR DESCRIPTION
## 🧰 Changes

I'd like some TS types on Postman collections for some new work I'm doing with `oas-normalize` so this creates us a new `postman-types` package that, like [openapi-types](https://npm.im/openapi-types), will do just that.
