### PR TITLE
feat(oas): check for `x-default` for bearer auth

### DIFF
--- a/packages/oas/src/lib/get-auth.ts
+++ b/packages/oas/src/lib/get-auth.ts
@@ -19,7 +19,7 @@ function getKey(user: RMOAS.User, scheme: RMOAS.KeyedSecuritySchemeObject): auth
       }
 
       if (scheme.scheme === 'bearer') {
-        return user[scheme._key] || user.apiKey || null;
+        return user[scheme._key] || user.apiKey || scheme['x-default'] || null;
       }
       return null;
 

--- a/packages/oas/test/lib/get-auth.test.ts
+++ b/packages/oas/test/lib/get-auth.test.ts
@@ -102,6 +102,12 @@ describe('#getByScheme', () => {
     expect(getByScheme(topLevelUser, { type: 'http', scheme: 'bearer', _key: 'authscheme' })).toBe('123456');
   });
 
+  it('should return default property for bearer', () => {
+    expect(getByScheme({}, { type: 'http', scheme: 'bearer', _key: 'authscheme', 'x-default': 'default' })).toBe(
+      'default',
+    );
+  });
+
   it('should return user/pass properties for basic auth', () => {
     expect(getByScheme(topLevelUser, { type: 'http', scheme: 'basic', _key: 'authscheme' })).toStrictEqual({
       user: 'user',


### PR DESCRIPTION
<!--

| 🚥 Resolves ISSUE_ID |
| :------------------- |

-->

## 🧰 Changes

Adds bearer auth support for [our `x-default` extension](https://docs.readme.com/main/docs/openapi-extensions#authentication-defaults).

Slack thread for context: https://readmeio.slack.com/archives/C04EF46CU/p1719422826977949
