### PR TITLE
feat: add `disable-tag-sorting` extension

### DIFF
--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -168,6 +168,22 @@ export const SAMPLES_LANGUAGES = 'samples-languages';
  */
 export const SIMPLE_MODE = 'simple-mode';
 
+/**
+ * If `true`, tags are generated from the file top-down. If `false`, we sort the tags
+ * based off the `tags` array in the OAS file.
+ *
+ * @defaultValue false
+ * @see {@link https://docs.readme.com/main/docs/openapi-extensions#disable-tag-sorting}
+ * @example
+ * {
+ *  "x-readme": {
+ *    "disable-tag-sorting": true
+ *  }
+ * }
+ */
+export const DISABLE_TAG_SORTING = 'disable-tag-sorting';
+
+
 export interface Extensions {
   [CODE_SAMPLES]: {
     /**
@@ -197,6 +213,7 @@ export interface Extensions {
      */
     name?: string;
   };
+  [DISABLE_TAG_SORTING]: boolean;
   [EXPLORER_ENABLED]: boolean;
   [HEADERS]: Record<string, number | string>[];
   [METRICS_ENABLED]: boolean;
@@ -215,6 +232,7 @@ export const extensionDefaults: Extensions = {
   [PROXY_ENABLED]: true,
   [SAMPLES_LANGUAGES]: ['shell', 'node', 'ruby', 'php', 'python', 'java', 'csharp'],
   [SIMPLE_MODE]: true,
+  [DISABLE_TAG_SORTING]: false,
 };
 
 /**

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -183,7 +183,6 @@ export const SIMPLE_MODE = 'simple-mode';
  */
 export const DISABLE_TAG_SORTING = 'disable-tag-sorting';
 
-
 export interface Extensions {
   [CODE_SAMPLES]: {
     /**

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -224,6 +224,7 @@ export interface Extensions {
 
 export const extensionDefaults: Extensions = {
   [CODE_SAMPLES]: undefined,
+  [DISABLE_TAG_SORTING]: false,
   [EXPLORER_ENABLED]: true,
   [HEADERS]: undefined,
   [METRICS_ENABLED]: true,
@@ -231,7 +232,6 @@ export const extensionDefaults: Extensions = {
   [PROXY_ENABLED]: true,
   [SAMPLES_LANGUAGES]: ['shell', 'node', 'ruby', 'php', 'python', 'java', 'csharp'],
   [SIMPLE_MODE]: true,
-  [DISABLE_TAG_SORTING]: false,
 };
 
 /**

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -748,6 +748,8 @@ export default class Oas {
         return tag.name;
       }) || [];
 
+    const disableTagSorting = getExtension('disable-tag-sorting', this.api)
+
     Object.entries(this.getPaths()).forEach(([path, operations]) => {
       Object.values(operations).forEach(operation => {
         const tags = operation.getTags();
@@ -784,6 +786,10 @@ export default class Oas {
     // Distinguish between which tags exist in the `tags` array and which tags
     // exist only at the endpoint level. For tags that exist only at the
     // endpoint level, we'll just tack that on to the end of the sorted tags.
+    if (disableTagSorting) {
+      return Array.from(allTags)
+    }
+
     Array.from(allTags).forEach(tag => {
       if (oasTags.includes(tag)) {
         tagsArray.push(tag);

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -748,7 +748,7 @@ export default class Oas {
         return tag.name;
       }) || [];
 
-    const disableTagSorting = getExtension('disable-tag-sorting', this.api)
+    const disableTagSorting = getExtension('disable-tag-sorting', this.api);
 
     Object.entries(this.getPaths()).forEach(([path, operations]) => {
       Object.values(operations).forEach(operation => {
@@ -787,7 +787,7 @@ export default class Oas {
     // exist only at the endpoint level. For tags that exist only at the
     // endpoint level, we'll just tack that on to the end of the sorted tags.
     if (disableTagSorting) {
-      return Array.from(allTags)
+      return Array.from(allTags);
     }
 
     Array.from(allTags).forEach(tag => {

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1665,6 +1665,11 @@ describe('#getTags()', () => {
     expect(orderedTags.getTags()).toStrictEqual(['user', 'store', 'pet', 'endpoint']);
   });
 
+  it('should acknowledge `disable-tag-sorting` extension', () => {
+    orderedTags.api['x-readme'] = { 'disable-tag-sorting': true }
+    expect(orderedTags.getTags()).toStrictEqual(['pet', 'endpoint', 'store', 'user']);
+  });
+
   describe('setIfMissing option', () => {
     it('should return no tags if none are present', () => {
       expect(serverVariables.getTags()).toHaveLength(0);

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1666,7 +1666,7 @@ describe('#getTags()', () => {
   });
 
   it('should acknowledge `disable-tag-sorting` extension', () => {
-    orderedTags.api['x-readme'] = { 'disable-tag-sorting': true }
+    orderedTags.api['x-readme'] = { 'disable-tag-sorting': true };
     expect(orderedTags.getTags()).toStrictEqual(['pet', 'endpoint', 'store', 'user']);
   });
 


### PR DESCRIPTION
| 🚥 Resolves [Slack thread](https://readmeio.slack.com/archives/C06DBJRSHJP/p1717788236438779) |
| :------------------- |

## 🧰 Changes
Adds an extension to disable sorting the tag generation by the `tags` array in the OAS file. Instead, it will use the method we used before, which is top-down. 

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
