### PR TITLE
fix(oas/json schema): add default resolver for unknown keywords

### DIFF
--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -322,19 +322,11 @@ export function toJSONSchema(data: RMOAS.SchemaObject | boolean, opts: toJSONSch
               return arr;
             },
 
-            // JSON Schema ony supports examples with the `examples` property, since we're
-            // ingesting OpenAPI definitions we need to add a custom resolver for its `example`
-            // property.
-            example: (obj: unknown[]) => obj[0],
-
-            // JSON Schema has no support for `format` on anything other than `string`, but since
-            // OpenAPI has it on `integer` and `number` we need to add a custom resolver here so we
-            // can still merge schemas that may have those.
-            format: (obj: string[]) => obj[0],
-
-            // Since JSON Schema obviously doesn't know about our vendor extension we need to tell
-            // the library to essentially ignore and pass it along.
-            'x-readme-ref-name': (obj: string[]) => obj[0],
+            // for any unknown keywords (e.g., `example`, `format`, `x-readme-ref-name`),
+            // we fallback to using the title resolver (which uses the first value found).
+            // https://github.com/mokkabonna/json-schema-merge-allof/blob/ea2e48ee34415022de5a50c236eb4793a943ad11/src/index.js#L292
+            // https://github.com/mokkabonna/json-schema-merge-allof/blob/ea2e48ee34415022de5a50c236eb4793a943ad11/README.md?plain=1#L147
+            defaultResolver: mergeJSONSchemaAllOf.options.resolvers.title,
           } as unknown,
         }) as RMOAS.SchemaObject;
       } catch (e) {

--- a/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
+++ b/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
@@ -1037,7 +1037,7 @@ exports[`\`description\` support > should support description in an \`allOf\` an
 exports[`polymorphism / inheritance > quirks > should perform default resolution for unrecognized properties 1`] = `
 {
   "additionalProperties": false,
-  "description": "Represents a namespace.",
+  "description": "Represents a namespace (one).",
   "properties": {
     "dataAccessPolicy": {
       "additionalProperties": false,

--- a/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
+++ b/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
@@ -1054,7 +1054,7 @@ exports[`polymorphism / inheritance > quirks > should perform default resolution
       ],
       "type": "object",
       "x-whatever": {
-        "status": "BETA",
+        "somethingelse": "two",
       },
     },
     "groupId": {
@@ -1078,7 +1078,7 @@ exports[`polymorphism / inheritance > quirks > should perform default resolution
   ],
   "type": "object",
   "x-whatever": {
-    "file-path": "schemas/namespace.yaml",
+    "yetanotherthing": "three",
   },
 }
 `;

--- a/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
+++ b/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
@@ -1033,3 +1033,52 @@ exports[`\`description\` support > should support description in an \`allOf\` an
   "type": "object",
 }
 `;
+
+exports[`polymorphism / inheritance > quirks > should perform default resolution for unrecognized properties 1`] = `
+{
+  "additionalProperties": false,
+  "description": "Represents a namespace.",
+  "properties": {
+    "dataAccessPolicy": {
+      "additionalProperties": false,
+      "description": "__Beta__ Overrides the default data access policy.",
+      "properties": {
+        "restrictDataAccess": {
+          "description": "Set a data access policy to override the default setting.",
+          "type": "boolean",
+        },
+      },
+      "required": [
+        "restrictDataAccess",
+        "policyType",
+      ],
+      "type": "object",
+      "x-whatever": {
+        "status": "BETA",
+      },
+    },
+    "groupId": {
+      "description": "The access group the namespace is assigned to.",
+      "minimum": 0,
+      "type": "integer",
+    },
+    "namespace": {
+      "description": "A name for a namespace.",
+      "type": "string",
+    },
+    "retentionInSeconds": {
+      "description": "Retention period of underlying data, represented in seconds.",
+      "type": "integer",
+    },
+  },
+  "required": [
+    "groupId",
+    "namespace",
+    "retentionInSeconds",
+  ],
+  "type": "object",
+  "x-whatever": {
+    "file-path": "schemas/namespace.yaml",
+  },
+}
+`;

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -647,7 +647,7 @@ describe('polymorphism / inheritance', () => {
             required: ['namespace', 'retentionInSeconds'],
             type: 'object',
             'x-whatever': {
-              'file-path': 'schemas/namespace-put.yaml',
+              something: 'one',
             },
           },
           {
@@ -664,7 +664,7 @@ describe('polymorphism / inheritance', () => {
                 required: ['restrictDataAccess', 'policyType'],
                 type: 'object',
                 'x-whatever': {
-                  status: 'BETA',
+                  somethingelse: 'two',
                 },
               },
               groupId: {
@@ -679,7 +679,7 @@ describe('polymorphism / inheritance', () => {
         description: 'Represents a namespace.',
         type: 'object',
         'x-whatever': {
-          'file-path': 'schemas/namespace.yaml',
+          yetanotherthing: 'three',
         },
       } as SchemaObject);
 

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -633,7 +633,7 @@ describe('polymorphism / inheritance', () => {
         additionalProperties: false,
         allOf: [
           {
-            description: 'Represents a namespace.',
+            description: 'Represents a namespace (one).',
             properties: {
               namespace: {
                 description: 'A name for a namespace.',
@@ -676,7 +676,7 @@ describe('polymorphism / inheritance', () => {
             required: ['groupId'],
           },
         ],
-        description: 'Represents a namespace.',
+        description: 'Represents a namespace (two).',
         type: 'object',
         'x-whatever': {
           yetanotherthing: 'three',

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -628,6 +628,65 @@ describe('polymorphism / inheritance', () => {
       });
     });
 
+    it('should perform default resolution for unrecognized properties', () => {
+      const schema: SchemaObject = toJSONSchema({
+        additionalProperties: false,
+        allOf: [
+          {
+            description: 'Represents a namespace.',
+            properties: {
+              namespace: {
+                description: 'A name for a namespace.',
+                type: 'string',
+              },
+              retentionInSeconds: {
+                description: 'Retention period of underlying data, represented in seconds.',
+                type: 'integer',
+              },
+            },
+            required: ['namespace', 'retentionInSeconds'],
+            type: 'object',
+            'x-whatever': {
+              'file-path': 'schemas/namespace-put.yaml',
+            },
+          },
+          {
+            properties: {
+              dataAccessPolicy: {
+                additionalProperties: false,
+                description: '__Beta__ Overrides the default data access policy.',
+                properties: {
+                  restrictDataAccess: {
+                    description: 'Set a data access policy to override the default setting.',
+                    type: 'boolean',
+                  },
+                },
+                required: ['restrictDataAccess', 'policyType'],
+                type: 'object',
+                'x-whatever': {
+                  status: 'BETA',
+                },
+              },
+              groupId: {
+                description: 'The access group the namespace is assigned to.',
+                minimum: 0,
+                type: 'integer',
+              },
+            },
+            required: ['groupId'],
+          },
+        ],
+        description: 'Represents a namespace.',
+        type: 'object',
+        'x-whatever': {
+          'file-path': 'schemas/namespace.yaml',
+        },
+      } as SchemaObject);
+
+      expect(schema.properties).toBeDefined();
+      expect(schema).toMatchSnapshot();
+    });
+
     describe('adding missing `type` properties', () => {
       it("should not add a `type` to a shapeless-description that's part of an `allOf`", () => {
         const schema: SchemaObject = {


### PR DESCRIPTION
| 🚥 Resolves RM-10218 |
| :------------------- |

## 🧰 Changes

For folks that use custom keywords in their polymorphic objects, we now specify a resolution strategy (i.e., simply select the first value) as opposed to totally ignoring the object.

## 🧬 QA & Testing

Do tests pass?
