### PR TITLE
fix(oas): don't add defaults to enum param descriptions

### DIFF
--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -791,23 +791,16 @@ export function toJSONSchema(data: RMOAS.SchemaObject | boolean, opts: toJSONSch
       // Defaults for `object` and types have been dereferenced into their children schemas already
       // above so we don't need to preserve this default anymore.
       delete schema.default;
+    } else if (
+      ('allowEmptyValue' in schema && schema.allowEmptyValue && schema.default === '') ||
+      schema.default !== ''
+    ) {
+      // If we have `allowEmptyValue` present, and the default is actually an empty string, let it
+      // through as it's allowed.
     } else {
-      // If it's an enum and not the response schema, add the default to the description.
-      // If there's an existing description, trim trailing new lines so it doesn't look ugly.
-      if ('enum' in schema && !addEnumsToDescriptions) {
-        schema.description = schema.description
-          ? `${schema.description.replace(/\n$/, '')}\n\nDefault: \`${schema.default}\``
-          : `Default: ${schema.default}`;
-      }
-
-      if (('allowEmptyValue' in schema && schema.allowEmptyValue && schema.default === '') || schema.default !== '') {
-        // If we have `allowEmptyValue` present, and the default is actually an empty string, let it
-        // through as it's allowed.
-      } else {
-        // If the default is empty and we don't want to allowEmptyValue, we need to remove the
-        // default.
-        delete schema.default;
-      }
+      // If the default is empty and we don't want to allowEmptyValue, we need to remove the
+      // default.
+      delete schema.default;
     }
   } else if (prevDefaultSchemas.length) {
     const foundDefault = searchForValueByPropAndPointer('default', currentLocation, prevDefaultSchemas);

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -908,13 +908,13 @@ describe('`description` support', () => {
           type: 'string',
           enum: ['CP', 'NON_CP'],
           default: 'NON_CP',
-          description: 'Enumed property with a default: `NON_CP`\n\nDefault: `NON_CP`',
+          description: 'Enumed property with a default: `NON_CP`\n',
         },
         optional_enum_default: {
           type: 'string',
           enum: ['CP', 'NON_CP'],
           default: 'CP',
-          description: 'Enumed property with a default: `NON_CP`\n\nDefault: `CP`',
+          description: 'Enumed property with a default: `NON_CP`\n',
         },
         enum_no_default: {
           type: 'string',

--- a/packages/oas/test/operation/lib/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/packages/oas/test/operation/lib/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -137,7 +137,6 @@ https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paramet
           "items": {
             "default": "available",
             "deprecated": true,
-            "description": "Default: available",
             "enum": [
               "available",
               "pending",


### PR DESCRIPTION
| 🚥 Resolves CX-947 |
| :------------------- |

## 🧰 Changes

With our new "Defaults to" copy that we're surfacing for request parameters, we now have duplicated info for parameters that are both enums and contain a default value ([bin site preview is here](https://bin.readme.com/s/669ea01aef9101006ed22937)):

![CleanShot 2024-07-22 at 13 16 33@2x](https://github.com/user-attachments/assets/36056d9a-abbe-4283-a15a-a577b8d521d7)


This PR removes that description-updating logic from our `openapi-to-json-schema` handling.

## 🧬 QA & Testing

Is this the right spot to make this change? This logic is only for request parameters right?
