### PR TITLE
feat: creation of a new `.getOperationById()` method

### DIFF
--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -76,13 +76,13 @@ Because this library has full TypeScript types and docblocks this README is not 
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#dereference()` | Dereference the current OpenAPI definition. Note that this will ignore circular references. |
-| `#getCircularReferences()` | Retrieve an array of any circular `$ref` pointer that may exist wthin the OpenAPI definition. Note that this requires `#dereference()` to be called first. |
-| `#getDefinition()` | Retrieve the OpenAPI definition that was fed into the `Oas` constructor. |
-| `#getTags()` | Retrieve an array of all tags that exist within the API definition and are set on operations. |
-| `#getPaths()` | Retrieve every operation that exists within the API definition. This returns an array of instances of the `Operation` class. |
-| `#getVersion()` | Retrieve the OpenAPI version that this API definition is targeted for. |
-| `#getWebhooks()` | Retrieve every webhook operation that exists within the API definition. This returns an array of instances of the `Webhook` class. |
+| `.dereference()` | Dereference the current OpenAPI definition. Note that this will ignore circular references. |
+| `.getCircularReferences()` | Retrieve an array of any circular `$ref` pointer that may exist wthin the OpenAPI definition. Note that this requires `.dereference()` to be called first. |
+| `.getDefinition()` | Retrieve the OpenAPI definition that was fed into the `Oas` constructor. |
+| `.getTags()` | Retrieve an array of all tags that exist within the API definition and are set on operations. |
+| `.getPaths()` | Retrieve every operation that exists within the API definition. This returns an array of instances of the `Operation` class. |
+| `.getVersion()` | Retrieve the OpenAPI version that this API definition is targeted for. |
+| `.getWebhooks()` | Retrieve every webhook operation that exists within the API definition. This returns an array of instances of the `Webhook` class. |
 | `#init()` | An alternative for `new Oas()` that you can use if the typing on the `Oas` constructor gives you trouble. Typing OpenAPI definitions is hard! |
 <!-- prettier-ignore-end -->
 
@@ -91,10 +91,11 @@ Because this library has full TypeScript types and docblocks this README is not 
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#findOperation()` | Discover an operation with the current OpenAPI definition that matches a given URL and HTTP method. |
-| `#findOperationWithoutMethod()` | Like `oas.findOperation()` but without supplying an HTTP method. |
-| `#getOperation()` | Same as `oas.findOperation()` but this returns an instance of the `Operation` class. |
-| `#operation()` | Retrieve an instance of the `Operation` or `Webhook` classes for a given path and HTTP method. |
+| `.findOperation()` | Discover an operation with the current OpenAPI definition that matches a given URL and HTTP method. |
+| `.findOperationWithoutMethod()` | Like `.findOperation()` but without supplying an HTTP method. |
+| `.getOperation()` | Same as `.findOperation()` but this returns an instance of the `Operation` class. |
+| `.getOperationById()` | Retrieve an operation in an OpenAPI definition by an `operationId`. |
+| `.operation()` | Retrieve an instance of the `Operation` or `Webhook` classes for a given path and HTTP method. |
 <!-- prettier-ignore-end -->
 
 #### Servers
@@ -102,12 +103,12 @@ Because this library has full TypeScript types and docblocks this README is not 
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#defaultVariables()` | Retrieve the default server variables for a specific server URL, while also potentially factoring in user data. You can specify user variable data to the `Oas` constructor. Check out [Using Variables in Documentation](https://docs.readme.com/docs/user-data-options#using-variables-in-documentation) for some background on how we use this. |
-| `#replaceUrl()` | Replace a given templated server URL with supplied server variable data. |
-| `#splitUrl()` | Chunk out a specific server URL into its individual parts. |
-| `#splitVariables` | Chunk out a given URL and if it matches a server URL in the OpenAPI file, extract the matched server variables that are present in the URL. |
-| `#url()` | Retrieve a fully composed server URL. You can optionally select which of the defined server URLs to use as well as specify server variable information. |
-| `#variables()` | Retrieve all server variables that a specific server URL in the definition has. |
+| `.defaultVariables()` | Retrieve the default server variables for a specific server URL, while also potentially factoring in user data. You can specify user variable data to the `Oas` constructor. Check out [Using Variables in Documentation](https://docs.readme.com/docs/user-data-options#using-variables-in-documentation) for some background on how we use this. |
+| `.replaceUrl()` | Replace a given templated server URL with supplied server variable data. |
+| `.splitUrl()` | Chunk out a specific server URL into its individual parts. |
+| `.splitVariables` | Chunk out a given URL and if it matches a server URL in the OpenAPI file, extract the matched server variables that are present in the URL. |
+| `.url()` | Retrieve a fully composed server URL. You can optionally select which of the defined server URLs to use as well as specify server variable information. |
+| `.variables()` | Retrieve all server variables that a specific server URL in the definition has. |
 <!-- prettier-ignore-end -->
 
 #### Specification Extensions
@@ -118,10 +119,10 @@ Because this library has full TypeScript types and docblocks this README is not 
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getExtension()` | Retrieve a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) if it exists at the root of the API definition.  |
-| `#hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) exists on the root of the API definition. |
-| `#validateExtension()` | Determine if a given [ReadMe custom OpenAPI extension](https://docs.readme.com/docs/openapi-extensions) is valid or not. |
-| `#validateExtensions()` | Validate all of our [ReadMe custom OpenAPI extension](https://docs.readme.com/docs/openapi-extensions), throwing exceptions when necessary. |
+| `.getExtension()` | Retrieve a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) if it exists at the root of the API definition.  |
+| `.hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) exists on the root of the API definition. |
+| `.validateExtension()` | Determine if a given [ReadMe custom OpenAPI extension](https://docs.readme.com/docs/openapi-extensions) is valid or not. |
+| `.validateExtensions()` | Validate all of our [ReadMe custom OpenAPI extension](https://docs.readme.com/docs/openapi-extensions), throwing exceptions when necessary. |
 <!-- prettier-ignore-end -->
 
 Information about ReadMe's supported OpenAPI extensions at https://docs.readme.com/docs/openapi-extensions.
@@ -131,14 +132,14 @@ Information about ReadMe's supported OpenAPI extensions at https://docs.readme.c
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getAuth()` | Retrieve the appropriate API keys for the current OpenAPI definition from an object of user data. Check out [Using Variables in Documentation](https://docs.readme.com/docs/user-data-options#using-variables-in-documentation) for some background on how we use this. |
+| `.getAuth()` | Retrieve the appropriate API keys for the current OpenAPI definition from an object of user data. Check out [Using Variables in Documentation](https://docs.readme.com/docs/user-data-options#using-variables-in-documentation) for some background on how we use this. |
 <!-- prettier-ignore-end -->
 
 ---
 
 ### Operations
 
-For your convenience, the entrypoint into the `Operation` class should generally always be through `Oas.operation()`. For example:
+For your convenience, the entrypoint into the `Operation` class should generally always be through `.operation()`. For example:
 
 ```js
 import Oas from 'oas';
@@ -153,19 +154,19 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getContentType()` | Retrieve the primary request body content type. If multiple are present, prefer whichever is JSON-compliant. |
-| `#getDescription()` | Retrieve the `description` that's set on this operation. This supports common descriptions that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |
-| `#getOperationId()` | Retrieve the `operationId` that's present on the operation, and if one is not present one will be created based off the method + path and returned instead. |
-| `#hasOperationId()` | Determine if the operation has an `operationId` present. |
-| `#isDeprecated()` | Determine if this operation is marked as deprecated. |
-| `#isFormUrlEncoded()` | Determine if this operation requires its payload to be delivered as `application/x-www-form-urlencoded`. |
-| `#isJson()` | Determine if this operation requires its payload to be delivered as JSON. |
-| `#isMultipart()` | Determine if this operation requires its data to be sent as a multipart payload. |
-| `#isXml()` | Determine if this operation requires its data to be sent as XML. |
-| `#getExampleGroups()` | Returns an object with groups of all example definitions (body/header/query/path/response/etc.). The examples are grouped by their key when defined via the `examples` map. |
-| `#getHeaders()` | Retrieve all headers that can either be sent for or returned from this operation. This includes header-based authentication schemes, common header parameters, and request body and response content types. |
-| `#getSummary()` | Retrieve the `summary` that's set on this operation. This supports common summaries that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |
-| `#getTags()` | Retrieve all tags, and [their metadata](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#tagObject), that exist on this operation. |
+| `.getContentType()` | Retrieve the primary request body content type. If multiple are present, prefer whichever is JSON-compliant. |
+| `.getDescription()` | Retrieve the `description` that's set on this operation. This supports common descriptions that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |
+| `.getOperationId()` | Retrieve the `operationId` that's present on the operation, and if one is not present one will be created based off the method + path and returned instead. |
+| `.hasOperationId()` | Determine if the operation has an `operationId` present. |
+| `.isDeprecated()` | Determine if this operation is marked as deprecated. |
+| `.isFormUrlEncoded()` | Determine if this operation requires its payload to be delivered as `application/x-www-form-urlencoded`. |
+| `.isJson()` | Determine if this operation requires its payload to be delivered as JSON. |
+| `.isMultipart()` | Determine if this operation requires its data to be sent as a multipart payload. |
+| `.isXml()` | Determine if this operation requires its data to be sent as XML. |
+| `.getExampleGroups()` | Returns an object with groups of all example definitions (body/header/query/path/response/etc.). The examples are grouped by their key when defined via the `examples` map. |
+| `.getHeaders()` | Retrieve all headers that can either be sent for or returned from this operation. This includes header-based authentication schemes, common header parameters, and request body and response content types. |
+| `.getSummary()` | Retrieve the `summary` that's set on this operation. This supports common summaries that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |
+| `.getTags()` | Retrieve all tags, and [their metadata](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#tagObject), that exist on this operation. |
 <!-- prettier-ignore-end -->
 
 #### Callbacks
@@ -173,10 +174,10 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getCallback()` | Retrieve a specific callback on this operation. This will return an instance of the `Callback` class. |
-| `#getCallbackExamples()` | Retrieve an array of all calback examples that this operation has defined. |
-| `#getCallbacks()` | Retrieve all callbacks that this operation has. Similar to `Oas.getPaths()` returning an array of `Operation` instances this will return an array of `Callback` instances. |
-| `#hasCallbacks()` | Determine if this operation has any callbacks defined. |
+| `.getCallback()` | Retrieve a specific callback on this operation. This will return an instance of the `Callback` class. |
+| `.getCallbackExamples()` | Retrieve an array of all calback examples that this operation has defined. |
+| `.getCallbacks()` | Retrieve all callbacks that this operation has. Similar to `.getPaths()` returning an array of `Operation` instances this will return an array of `Callback` instances. |
+| `.hasCallbacks()` | Determine if this operation has any callbacks defined. |
 <!-- prettier-ignore-end -->
 
 #### Parameters
@@ -187,10 +188,10 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getParameters()` | Retrieve all parameters that may be used with on this operation. |
-| `#getParametersAsJSONSchema()` | Retrieve and convert the operations parameters into an array of JSON Schema schemas for each available type of parameter available on the operation: `path`, `query`, `body`, `cookie`, `formData`, and `header`. |
-| `#hasParameters()` | Determine if the operation has any parameters to send. |
-| `#hasRequiredParameters()` | Determine if any of the parameters on this operation are required. |
+| `.getParameters()` | Retrieve all parameters that may be used with on this operation. |
+| `.getParametersAsJSONSchema()` | Retrieve and convert the operations parameters into an array of JSON Schema schemas for each available type of parameter available on the operation: `path`, `query`, `body`, `cookie`, `formData`, and `header`. |
+| `.hasParameters()` | Determine if the operation has any parameters to send. |
+| `.hasRequiredParameters()` | Determine if any of the parameters on this operation are required. |
 <!-- prettier-ignore-end -->
 
 #### Request Body
@@ -198,10 +199,10 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getRequestBody()` | Retrieve the raw request body object for a given content type. If none is specified it will return either the first that's JSON-like, or the first defined. |
-| `#getRequestBodyExamples()` | Retrieve an array of all request body examples that this operation has defined. |
-| `#getRequestBodyMediaTypes()` | Retrieve a list of all the media/content types that the operation can accept a request body payload for. |
-| `#hasRequestBody()` | Determine if this operation has a request body defined. |
+| `.getRequestBody()` | Retrieve the raw request body object for a given content type. If none is specified it will return either the first that's JSON-like, or the first defined. |
+| `.getRequestBodyExamples()` | Retrieve an array of all request body examples that this operation has defined. |
+| `.getRequestBodyMediaTypes()` | Retrieve a list of all the media/content types that the operation can accept a request body payload for. |
+| `.hasRequestBody()` | Determine if this operation has a request body defined. |
 <!-- prettier-ignore-end -->
 
 #### Responses
@@ -209,11 +210,11 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getResponseAsJSONSchema()` | Retrive and convert a response on this operation into JSON Schema. |
-| `#getResponseByStatusCode()` | Retrieve the raw response object for a given status code. |
-| `#getResponseExamples()` | Retrieve an array of all response examples that this operation has defined. |
-| `#getResponseStatusCodes()` | Retrieve all status codes that this operation may respond with. |
-| `#hasRequiredRequestBody()` | Determine if this operation has a required request body. |
+| `.getResponseAsJSONSchema()` | Retrive and convert a response on this operation into JSON Schema. |
+| `.getResponseByStatusCode()` | Retrieve the raw response object for a given status code. |
+| `.getResponseExamples()` | Retrieve an array of all response examples that this operation has defined. |
+| `.getResponseStatusCodes()` | Retrieve all status codes that this operation may respond with. |
+| `.hasRequiredRequestBody()` | Determine if this operation has a required request body. |
 <!-- prettier-ignore-end -->
 
 #### Security
@@ -221,9 +222,9 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getSecurity()` | Return all security requirements that are applicable for either this operation, or if the operation has none specific to it, then for the entire API. |
-| `#getSecurityWithTypes()` | Return a collection of all security schemes applicable to this operation (using `#getSecurity()`), grouped by how the security should be handled (either AND or OR auth requirements). |
-| `#prepareSecurity` | Return an object of every security scheme that _can_ be used on this operation, indexed by the type of security scheme it is (eg. `Basic`, `OAuth2`, `APIKey`, etc.). |
+| `.getSecurity()` | Return all security requirements that are applicable for either this operation, or if the operation has none specific to it, then for the entire API. |
+| `.getSecurityWithTypes()` | Return a collection of all security schemes applicable to this operation (using `.getSecurity()`), grouped by how the security should be handled (either AND or OR auth requirements). |
+| `.prepareSecurity` | Return an object of every security scheme that _can_ be used on this operation, indexed by the type of security scheme it is (eg. `Basic`, `OAuth2`, `APIKey`, etc.). |
 <!-- prettier-ignore-end -->
 
 #### Specification Extensions
@@ -231,7 +232,7 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) exists on this operation. |
+| `.hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) exists on this operation. |
 <!-- prettier-ignore-end -->
 
 Information about ReadMe's supported OpenAPI extensions at https://docs.readme.com/docs/openapi-extensions.
@@ -245,7 +246,7 @@ The `Callback` class inherits `Operation` so every API available on instances of
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `#getIdentifier()` | Retrieve the primary identifier of this callback. |
+| `.getIdentifier()` | Retrieve the primary identifier of this callback. |
 <!-- prettier-ignore-end -->
 
 ### Webhooks

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -660,7 +660,7 @@ export default class Oas {
    * If an operation does not have an `operationId` one will be generated in place, using the
    * default behavior of `Operation.getOperationId()`, and then asserted against your query.
    *
-   * Note that because `operationId`s are unique that uniqueness does include casing so your the ID
+   * Note that because `operationId`s are unique that uniqueness does include casing so the ID
    * you are looking for will be asserted as an exact match.
    *
    * @see {Operation.getOperationId()}

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -655,6 +655,48 @@ export default class Oas {
   }
 
   /**
+   * Retrieve an operation in an OAS by an `operationId`.
+   *
+   * If an operation does not have an `operationId` one will be generated in place, using the
+   * default behavior of `Operation.getOperationId()`, and then asserted against your query.
+   *
+   * Note that because `operationId`s are unique that uniqueness does include casing so your the ID
+   * you are looking for will be asserted as an exact match.
+   *
+   * @see {Operation.getOperationId()}
+   * @param id The `operationId` to look up.
+   */
+  getOperationById(id: string) {
+    let found: Operation | Webhook;
+
+    Object.entries(this.getPaths()).forEach(([, operations]) => {
+      if (found) return;
+      Object.values(operations).forEach(operation => {
+        if (found) return;
+        if (operation.getOperationId() === id) {
+          found = operation;
+        }
+      });
+    });
+
+    if (found) {
+      return found;
+    }
+
+    Object.entries(this.getWebhooks()).forEach(([, webhooks]) => {
+      if (found) return;
+      Object.values(webhooks).forEach(webhook => {
+        if (found) return;
+        if (webhook.getOperationId() === id) {
+          found = webhook;
+        }
+      });
+    });
+
+    return found;
+  }
+
+  /**
    * With an object of user information, retrieve the appropriate API auth keys from the current
    * OAS definition.
    *

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -669,14 +669,9 @@ export default class Oas {
   getOperationById(id: string) {
     let found: Operation | Webhook;
 
-    Object.entries(this.getPaths()).forEach(([, operations]) => {
+    Object.values(this.getPaths()).forEach(operations => {
       if (found) return;
-      Object.values(operations).forEach(operation => {
-        if (found) return;
-        if (operation.getOperationId() === id) {
-          found = operation;
-        }
-      });
+      found = Object.values(operations).find(operation => operation.getOperationId() === id);
     });
 
     if (found) {
@@ -685,12 +680,7 @@ export default class Oas {
 
     Object.entries(this.getWebhooks()).forEach(([, webhooks]) => {
       if (found) return;
-      Object.values(webhooks).forEach(webhook => {
-        if (found) return;
-        if (webhook.getOperationId() === id) {
-          found = webhook;
-        }
-      });
+      found = Object.values(webhooks).find(webhook => webhook.getOperationId() === id);
     });
 
     return found;

--- a/packages/oas/test/__datasets__/circular-path.json
+++ b/packages/oas/test/__datasets__/circular-path.json
@@ -1,0 +1,166 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "circular example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything"
+    }
+  ],
+  "paths": {
+    "/anything": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "dateTime": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "offsetAfter": {
+                      "$ref": "#/components/schemas/offset"
+                    },
+                    "offsetBefore": {
+                      "$ref": "#/paths/~1anything/post/requestBody/content/application~1json/schema/properties/circular"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "circular": {
+                    "$ref": "#/components/schemas/offset"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "description": "This operation is different because it has a circular ref array as a parameter and in its response, but not its request body.",
+        "parameters": [
+          {
+            "name": "content",
+            "in": "header",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SalesLine"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SalesLine"
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SalesLine"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "dateTime": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "offset": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rules": {
+            "$ref": "#/components/schemas/rules"
+          }
+        }
+      },
+      "offsetTransition": {
+        "type": "object",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "offsetAfter": {
+            "$ref": "#/components/schemas/offset"
+          },
+          "offsetBefore": {
+            "$ref": "#/components/schemas/offset"
+          }
+        }
+      },
+      "rules": {
+        "type": "object",
+        "properties": {
+          "transitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/offsetTransition"
+            }
+          }
+        }
+      },
+      "SalesLine": {
+        "type": "object",
+        "properties": {
+          "stock": {
+            "$ref": "#/components/schemas/ProductStock"
+          }
+        }
+      },
+      "ProductStock": {
+        "properties": {
+          "test_param": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SalesLine"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`#dereference() > should add metadata to components pre-dereferencing to preserve their lineage > stored as \`title\` if the \`preserveRefAsJSONSchemaTitle\` option is supplied 1`] = `
+exports[`Oas > .dereference() > should add metadata to components pre-dereferencing to preserve their lineage > stored as \`title\` if the \`preserveRefAsJSONSchemaTitle\` option is supplied 1`] = `
 {
   "/pet": {
     "post": {
@@ -2073,7 +2073,7 @@ exports[`#dereference() > should add metadata to components pre-dereferencing to
 }
 `;
 
-exports[`#dereference() > should add metadata to components pre-dereferencing to preserve their lineage > stored as \`x-readme-ref-name 1`] = `
+exports[`Oas > .dereference() > should add metadata to components pre-dereferencing to preserve their lineage > stored as \`x-readme-ref-name 1`] = `
 {
   "/multischema/of-everything": {
     "post": {
@@ -3444,7 +3444,7 @@ exports[`#dereference() > should add metadata to components pre-dereferencing to
 }
 `;
 
-exports[`#operation() > should return a default when no operation 1`] = `
+exports[`Oas > .operation() > should return a default when no operation 1`] = `
 Operation {
   "api": {},
   "callbackExamples": undefined,

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1,1245 +1,1177 @@
 import type * as RMOAS from '../src/types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
-import { beforeAll, describe, test, it, expect, vi } from 'vitest';
+import { beforeAll, describe, it, expect, vi } from 'vitest';
 
 import Oas from '../src/index.js';
 import { Operation, Webhook } from '../src/operation/index.js';
 
-let petstore: Oas;
-let webhooks: Oas;
+import { createOasForPaths } from './__fixtures__/create-oas.js';
+
+let multipleSecurities: Oas;
+let orderedTags: Oas;
 let pathMatchingQuirks: Oas;
 let pathVariableQuirks: Oas;
+let petstore: Oas;
 let serverVariables: Oas;
-let orderedTags: Oas;
+let webhooks: Oas;
 
-beforeAll(async () => {
-  petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default).then(Oas.init);
-  webhooks = await import('@readme/oas-examples/3.1/json/webhooks.json').then(r => r.default).then(Oas.init);
-  pathMatchingQuirks = await import('./__datasets__/path-matching-quirks.json').then(r => r.default).then(Oas.init);
-  pathVariableQuirks = await import('./__datasets__/path-variable-quirks.json').then(r => r.default).then(Oas.init);
-  serverVariables = await import('./__datasets__/server-variables.json').then(r => r.default).then(Oas.init);
-  orderedTags = await import('./__datasets__/ordered-tags.json').then(r => r.default).then(Oas.init);
-});
-
-test('should be able to access properties on the class instance', () => {
-  expect(petstore.api.info.version).toBe('1.0.0');
-});
-
-test('should be able to accept an `RMOAS.OASDocument` in the constructor', () => {
-  expect(new Oas(petstoreSpec as RMOAS.OASDocument).getVersion()).toBe('3.0.0');
-});
-
-test('should be able to accept a string in the constructor', () => {
-  expect(new Oas(JSON.stringify(petstoreSpec)).getVersion()).toBe('3.0.0');
-});
-
-describe('#init()', () => {
-  it('should return an instance of Oas with a user', () => {
-    const user = { username: 'buster' };
-    const oas = Oas.init(petstoreSpec, user);
-
-    expect(oas).toBeInstanceOf(Oas);
-    expect(oas.api).toStrictEqual(petstoreSpec);
-    expect(oas.user).toStrictEqual(user);
-  });
-});
-
-describe('#getVersion()', () => {
-  it('should be able to identify an OpenAPI definition', () => {
-    expect(petstore.getVersion()).toBe('3.0.0');
-    expect(webhooks.getVersion()).toBe('3.1.0');
+describe('Oas', () => {
+  beforeAll(async () => {
+    multipleSecurities = await import('./__datasets__/multiple-securities.json').then(r => r.default).then(Oas.init);
+    orderedTags = await import('./__datasets__/ordered-tags.json').then(r => r.default).then(Oas.init);
+    pathMatchingQuirks = await import('./__datasets__/path-matching-quirks.json').then(r => r.default).then(Oas.init);
+    pathVariableQuirks = await import('./__datasets__/path-variable-quirks.json').then(r => r.default).then(Oas.init);
+    petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default).then(Oas.init);
+    serverVariables = await import('./__datasets__/server-variables.json').then(r => r.default).then(Oas.init);
+    webhooks = await import('@readme/oas-examples/3.1/json/webhooks.json').then(r => r.default).then(Oas.init);
   });
 
-  it('should throw an error if unable to identify', () => {
-    expect(() => {
-      return Oas.init({}).getVersion();
-    }).toThrow('Unable to recognize what specification version this API definition conforms to.');
-  });
-});
-
-describe('#url([selected])', () => {
-  it('should trim surrounding whitespace from the url', () => {
-    expect(Oas.init({ servers: [{ url: '  http://example.com/' }] }).url()).toBe('http://example.com');
+  it('should be able to access properties on the class instance', () => {
+    expect(petstore.api.info.version).toBe('1.0.0');
   });
 
-  it('should remove end slash from the server URL', () => {
-    expect(Oas.init({ servers: [{ url: 'http://example.com/' }] }).url()).toBe('http://example.com');
+  it('should be able to accept an `RMOAS.OASDocument` in the constructor', () => {
+    expect(new Oas(petstoreSpec as RMOAS.OASDocument).getVersion()).toBe('3.0.0');
   });
 
-  it('should default missing servers array to example.com', () => {
-    expect(Oas.init({}).url()).toBe('https://example.com');
+  it('should be able to accept a string in the constructor', () => {
+    expect(new Oas(JSON.stringify(petstoreSpec)).getVersion()).toBe('3.0.0');
   });
 
-  it('should default empty servers array to example.com', () => {
-    expect(Oas.init({ servers: [] }).url()).toBe('https://example.com');
+  describe('#init()', () => {
+    it('should return an instance of Oas with a user', () => {
+      const user = { username: 'buster' };
+      const oas = Oas.init(petstoreSpec, user);
+
+      expect(oas).toBeInstanceOf(Oas);
+      expect(oas.api).toStrictEqual(petstoreSpec);
+      expect(oas.user).toStrictEqual(user);
+    });
   });
 
-  it('should default empty server object to example.com', () => {
-    expect(Oas.init({ servers: [{}] }).url()).toBe('https://example.com');
-  });
-
-  it('should add https:// if url starts with //', () => {
-    expect(Oas.init({ servers: [{ url: '//example.com' }] }).url()).toBe('https://example.com');
-  });
-
-  it('should add https:// if url does not start with a protocol', () => {
-    expect(Oas.init({ servers: [{ url: 'example.com' }] }).url()).toBe('https://example.com');
-  });
-
-  it('should accept an index for servers selection', () => {
-    expect(Oas.init({ servers: [{ url: 'example.com' }, { url: 'https://api.example.com' }] }).url(1)).toBe(
-      'https://api.example.com',
-    );
-  });
-
-  it('should default to first if selected is not valid', () => {
-    expect(Oas.init({ servers: [{ url: 'https://example.com' }] }).url(10)).toBe('https://example.com');
-  });
-
-  it('should make example.com the origin if none is present', () => {
-    expect(Oas.init({ servers: [{ url: '/api/v3' }] }).url()).toBe('https://example.com/api/v3');
-  });
-
-  describe('server variables', () => {
-    const oas = new Oas({
-      openapi: '3.0.0',
-      info: {
-        title: 'testing',
-        version: '1.0.0',
-      },
-      servers: [
-        {
-          url: 'https://{name}.example.com:{port}/{basePath}',
-          variables: {
-            name: {
-              default: 'demo',
-            },
-            port: {
-              default: '443',
-            },
-            basePath: {
-              default: 'v2',
-            },
-          },
-        },
-      ],
-      paths: {},
+  describe('.getVersion()', () => {
+    it('should be able to identify an OpenAPI definition', () => {
+      expect(petstore.getVersion()).toBe('3.0.0');
+      expect(webhooks.getVersion()).toBe('3.1.0');
     });
 
-    it('should use default variables if no variables are supplied', () => {
-      expect(oas.url(0)).toBe('https://demo.example.com:443/v2');
+    it('should throw an error if unable to identify', () => {
+      expect(() => {
+        return Oas.init({}).getVersion();
+      }).toThrow('Unable to recognize what specification version this API definition conforms to.');
+    });
+  });
+
+  describe('.url([selected])', () => {
+    it('should trim surrounding whitespace from the url', () => {
+      expect(Oas.init({ servers: [{ url: '  http://example.com/' }] }).url()).toBe('http://example.com');
     });
 
-    it('should prefill in variables if supplied', () => {
-      expect(oas.url(0, { basePath: 'v3', name: 'subdomain', port: '8080' })).toBe(
-        'https://subdomain.example.com:8080/v3',
+    it('should remove end slash from the server URL', () => {
+      expect(Oas.init({ servers: [{ url: 'http://example.com/' }] }).url()).toBe('http://example.com');
+    });
+
+    it('should default missing servers array to example.com', () => {
+      expect(Oas.init({}).url()).toBe('https://example.com');
+    });
+
+    it('should default empty servers array to example.com', () => {
+      expect(Oas.init({ servers: [] }).url()).toBe('https://example.com');
+    });
+
+    it('should default empty server object to example.com', () => {
+      expect(Oas.init({ servers: [{}] }).url()).toBe('https://example.com');
+    });
+
+    it('should add https:// if url starts with //', () => {
+      expect(Oas.init({ servers: [{ url: '//example.com' }] }).url()).toBe('https://example.com');
+    });
+
+    it('should add https:// if url does not start with a protocol', () => {
+      expect(Oas.init({ servers: [{ url: 'example.com' }] }).url()).toBe('https://example.com');
+    });
+
+    it('should accept an index for servers selection', () => {
+      expect(Oas.init({ servers: [{ url: 'example.com' }, { url: 'https://api.example.com' }] }).url(1)).toBe(
+        'https://api.example.com',
       );
     });
 
-    it('should use defaults', () => {
-      expect(
-        new Oas({
-          openapi: '3.0.0',
-          info: {
-            title: 'testing',
-            version: '1.0.0',
-          },
-          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
-          paths: {},
-        }).url(),
-      ).toBe('https://example.com/path');
+    it('should default to first if selected is not valid', () => {
+      expect(Oas.init({ servers: [{ url: 'https://example.com' }] }).url(10)).toBe('https://example.com');
     });
 
-    it('should use user variables over defaults', () => {
-      expect(
-        new Oas(
+    it('should make example.com the origin if none is present', () => {
+      expect(Oas.init({ servers: [{ url: '/api/v3' }] }).url()).toBe('https://example.com/api/v3');
+    });
+
+    describe('server variables', () => {
+      const oas = new Oas({
+        openapi: '3.0.0',
+        info: {
+          title: 'testing',
+          version: '1.0.0',
+        },
+        servers: [
           {
+            url: 'https://{name}.example.com:{port}/{basePath}',
+            variables: {
+              name: {
+                default: 'demo',
+              },
+              port: {
+                default: '443',
+              },
+              basePath: {
+                default: 'v2',
+              },
+            },
+          },
+        ],
+        paths: {},
+      });
+
+      it('should use default variables if no variables are supplied', () => {
+        expect(oas.url(0)).toBe('https://demo.example.com:443/v2');
+      });
+
+      it('should prefill in variables if supplied', () => {
+        expect(oas.url(0, { basePath: 'v3', name: 'subdomain', port: '8080' })).toBe(
+          'https://subdomain.example.com:8080/v3',
+        );
+      });
+
+      it('should use defaults', () => {
+        expect(
+          new Oas({
             openapi: '3.0.0',
             info: {
               title: 'testing',
               version: '1.0.0',
             },
-            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+            servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'path' } } }],
             paths: {},
-          },
-          { username: 'domh' },
-        ).url(),
-      ).toBe('https://domh.example.com');
-    });
+          }).url(),
+        ).toBe('https://example.com/path');
+      });
 
-    it('should use user variables over defaults even if user payload has keys array', () => {
-      expect(
-        new Oas(
-          {
+      it('should use user variables over defaults', () => {
+        expect(
+          new Oas(
+            {
+              openapi: '3.0.0',
+              info: {
+                title: 'testing',
+                version: '1.0.0',
+              },
+              servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+              paths: {},
+            },
+            { username: 'domh' },
+          ).url(),
+        ).toBe('https://domh.example.com');
+      });
+
+      it('should use user variables over defaults even if user payload has keys array', () => {
+        expect(
+          new Oas(
+            {
+              openapi: '3.0.0',
+              info: {
+                title: 'testing',
+                version: '1.0.0',
+              },
+              servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+              paths: {},
+            },
+            {
+              username: 'domh',
+              keys: [
+                { apiKey: '123456', name: 'app-1' },
+                { apiKey: '7890', name: 'app-2' },
+              ],
+            },
+          ).url(),
+        ).toBe('https://domh.example.com');
+      });
+
+      it('should use supplied variables over user variables', () => {
+        expect(
+          new Oas(
+            {
+              openapi: '3.0.0',
+              info: {
+                title: 'testing',
+                version: '1.0.0',
+              },
+              servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+              paths: {},
+            },
+            { username: 'domh' },
+          ).url(0, { username: 'owlbert' }),
+        ).toBe('https://owlbert.example.com');
+      });
+
+      it('should fetch user variables from keys array', () => {
+        expect(
+          new Oas(
+            {
+              openapi: '3.0.0',
+              info: {
+                title: 'testing',
+                version: '1.0.0',
+              },
+              servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
+              paths: {},
+            },
+            { keys: [{ name: 1, username: 'domh' }] },
+          ).url(),
+        ).toBe('https://domh.example.com');
+      });
+
+      it('should look for variables in selected server', () => {
+        expect(
+          new Oas({
             openapi: '3.0.0',
             info: {
               title: 'testing',
               version: '1.0.0',
             },
-            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
-            paths: {},
-          },
-          {
-            username: 'domh',
-            keys: [
-              { apiKey: '123456', name: 'app-1' },
-              { apiKey: '7890', name: 'app-2' },
+            servers: [
+              { url: 'https://{username1}.example.com', variables: { username1: { default: 'demo1' } } },
+              { url: 'https://{username2}.example.com', variables: { username2: { default: 'demo2' } } },
             ],
-          },
-        ).url(),
-      ).toBe('https://domh.example.com');
-    });
-
-    it('should use supplied variables over user variables', () => {
-      expect(
-        new Oas(
-          {
-            openapi: '3.0.0',
-            info: {
-              title: 'testing',
-              version: '1.0.0',
-            },
-            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
             paths: {},
-          },
-          { username: 'domh' },
-        ).url(0, { username: 'owlbert' }),
-      ).toBe('https://owlbert.example.com');
+          }).url(1),
+        ).toBe('https://demo2.example.com');
+      });
+
+      // Test encodeURI
+      it('should pass through if no default set', () => {
+        expect(Oas.init({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe('https://example.com/{path}');
+      });
+    });
+  });
+
+  describe('.replaceUrl()', () => {
+    const url = 'https://{name}.example.com:{port}/{basePath}';
+
+    it('should pull data from user variables', () => {
+      const oas = Oas.init({}, { name: 'mysubdomain', port: '8000', basePath: 'v5' });
+      expect(oas.replaceUrl(url)).toBe('https://mysubdomain.example.com:8000/v5');
     });
 
-    it('should fetch user variables from keys array', () => {
+    it('should use template names as variables if no variables are supplied', () => {
+      expect(Oas.init({}).replaceUrl(url)).toBe(url);
+    });
+
+    it('should allow variables to come in as an object of defaults from `oas.defaultVariables`', () => {
       expect(
-        new Oas(
-          {
-            openapi: '3.0.0',
-            info: {
-              title: 'testing',
-              version: '1.0.0',
-            },
-            servers: [{ url: 'https://{username}.example.com', variables: { username: { default: 'demo' } } }],
-            paths: {},
+        Oas.init({}).replaceUrl(url, {
+          name: {
+            default: 'demo',
           },
-          { keys: [{ name: 1, username: 'domh' }] },
-        ).url(),
-      ).toBe('https://domh.example.com');
+          port: {
+            default: '443',
+          },
+          basePath: {
+            default: 'v2',
+          },
+        }),
+      ).toBe('https://demo.example.com:443/v2');
     });
 
-    it('should look for variables in selected server', () => {
+    it('should allow variable key-value pairs to be supplied', () => {
+      expect(
+        Oas.init({}).replaceUrl(url, {
+          name: 'subdomain',
+          port: '8080',
+          basePath: 'v3',
+        }),
+      ).toBe('https://subdomain.example.com:8080/v3');
+    });
+
+    it('should not fail if the variable objects are in weird shapes', () => {
+      expect(
+        Oas.init({}).replaceUrl(url, {
+          name: {
+            // This would normally have something like `default: 'demo'` but we're testing a weird
+            // case here.
+          },
+          port: '443',
+          basePath: [{ default: 'v2' }],
+        }),
+      ).toBe('https://{name}.example.com:443/{basePath}');
+    });
+  });
+
+  describe('.splitUrl()', () => {
+    it('should split url into chunks', () => {
+      expect(
+        Oas.init({
+          servers: [{ url: 'https://example.com/{path}' }],
+        }).splitUrl(),
+      ).toStrictEqual([
+        { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
+        { key: 'path-1', type: 'variable', value: 'path', description: undefined, enum: undefined },
+      ]);
+    });
+
+    it('should work for multiple path params', () => {
+      expect(
+        Oas.init({
+          servers: [{ url: 'https://example.com/{a}/{b}/c' }],
+        }).splitUrl(),
+      ).toHaveLength(5);
+
+      expect(
+        Oas.init({
+          servers: [{ url: 'https://example.com/v1/flight/{FlightID}/sitezonetargeting/{SiteZoneTargetingID}' }],
+        }).splitUrl(),
+      ).toHaveLength(4);
+    });
+
+    it('should create unique keys for duplicate values', () => {
+      expect(
+        Oas.init({
+          servers: [{ url: 'https://example.com/{test}/{test}' }],
+        }).splitUrl(),
+      ).toStrictEqual([
+        { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
+        { key: 'test-1', type: 'variable', value: 'test', description: undefined, enum: undefined },
+        { key: '/-2', type: 'text', value: '/' },
+        { key: 'test-3', type: 'variable', value: 'test', description: undefined, enum: undefined },
+      ]);
+    });
+
+    it('should return with description', () => {
       expect(
         new Oas({
           openapi: '3.0.0',
-          info: {
-            title: 'testing',
-            version: '1.0.0',
-          },
+          info: { title: 'testing', version: '1.0.0' },
           servers: [
-            { url: 'https://{username1}.example.com', variables: { username1: { default: 'demo1' } } },
-            { url: 'https://{username2}.example.com', variables: { username2: { default: 'demo2' } } },
+            {
+              url: 'https://example.com/{path}',
+              variables: { path: { default: 'buster', description: 'path description' } },
+            },
           ],
           paths: {},
-        }).url(1),
-      ).toBe('https://demo2.example.com');
+        }).splitUrl()[1].description,
+      ).toBe('path description');
     });
 
-    // Test encodeURI
-    it('should pass through if no default set', () => {
-      expect(Oas.init({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe('https://example.com/{path}');
+    it('should return with enum values', () => {
+      expect(
+        new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'v1', enum: ['v1', 'v2'] } } }],
+          paths: {},
+        }).splitUrl()[1].enum,
+      ).toStrictEqual(['v1', 'v2']);
     });
   });
-});
 
-describe('#replaceUrl()', () => {
-  const url = 'https://{name}.example.com:{port}/{basePath}';
+  describe('.splitVariables()', () => {
+    it('should return false if no match was found', () => {
+      expect(Oas.init({}).splitVariables('https://local.dev')).toBe(false);
+    });
 
-  it('should pull data from user variables', () => {
-    const oas = Oas.init({}, { name: 'mysubdomain', port: '8000', basePath: 'v5' });
-    expect(oas.replaceUrl(url)).toBe('https://mysubdomain.example.com:8000/v5');
-  });
-
-  it('should use template names as variables if no variables are supplied', () => {
-    expect(Oas.init({}).replaceUrl(url)).toBe(url);
-  });
-
-  it('should allow variables to come in as an object of defaults from `oas.defaultVariables`', () => {
-    expect(
-      Oas.init({}).replaceUrl(url, {
-        name: {
-          default: 'demo',
-        },
-        port: {
-          default: '443',
-        },
-        basePath: {
-          default: 'v2',
-        },
-      }),
-    ).toBe('https://demo.example.com:443/v2');
-  });
-
-  it('should allow variable key-value pairs to be supplied', () => {
-    expect(
-      Oas.init({}).replaceUrl(url, {
-        name: 'subdomain',
-        port: '8080',
-        basePath: 'v3',
-      }),
-    ).toBe('https://subdomain.example.com:8080/v3');
-  });
-
-  it('should not fail if the variable objects are in weird shapes', () => {
-    expect(
-      Oas.init({}).replaceUrl(url, {
-        name: {
-          // This would normally have something like `default: 'demo'` but we're testing a weird
-          // case here.
-        },
-        port: '443',
-        basePath: [{ default: 'v2' }],
-      }),
-    ).toBe('https://{name}.example.com:443/{basePath}');
-  });
-});
-
-describe('#splitUrl()', () => {
-  it('should split url into chunks', () => {
-    expect(
-      Oas.init({
-        servers: [{ url: 'https://example.com/{path}' }],
-      }).splitUrl(),
-    ).toStrictEqual([
-      { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
-      { key: 'path-1', type: 'variable', value: 'path', description: undefined, enum: undefined },
-    ]);
-  });
-
-  it('should work for multiple path params', () => {
-    expect(
-      Oas.init({
-        servers: [{ url: 'https://example.com/{a}/{b}/c' }],
-      }).splitUrl(),
-    ).toHaveLength(5);
-
-    expect(
-      Oas.init({
-        servers: [{ url: 'https://example.com/v1/flight/{FlightID}/sitezonetargeting/{SiteZoneTargetingID}' }],
-      }).splitUrl(),
-    ).toHaveLength(4);
-  });
-
-  it('should create unique keys for duplicate values', () => {
-    expect(
-      Oas.init({
-        servers: [{ url: 'https://example.com/{test}/{test}' }],
-      }).splitUrl(),
-    ).toStrictEqual([
-      { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
-      { key: 'test-1', type: 'variable', value: 'test', description: undefined, enum: undefined },
-      { key: '/-2', type: 'text', value: '/' },
-      { key: 'test-3', type: 'variable', value: 'test', description: undefined, enum: undefined },
-    ]);
-  });
-
-  it('should return with description', () => {
-    expect(
-      new Oas({
-        openapi: '3.0.0',
-        info: { title: 'testing', version: '1.0.0' },
-        servers: [
-          {
-            url: 'https://example.com/{path}',
-            variables: { path: { default: 'buster', description: 'path description' } },
-          },
-        ],
-        paths: {},
-      }).splitUrl()[1].description,
-    ).toBe('path description');
-  });
-
-  it('should return with enum values', () => {
-    expect(
-      new Oas({
-        openapi: '3.0.0',
-        info: { title: 'testing', version: '1.0.0' },
-        servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'v1', enum: ['v1', 'v2'] } } }],
-        paths: {},
-      }).splitUrl()[1].enum,
-    ).toStrictEqual(['v1', 'v2']);
-  });
-});
-
-describe('#splitVariables()', () => {
-  it('should return false if no match was found', () => {
-    expect(Oas.init({}).splitVariables('https://local.dev')).toBe(false);
-  });
-
-  it('should not return any variables for a server url that has none', () => {
-    expect(Oas.init({ servers: [{ url: 'https://example.com' }] }).splitVariables('https://example.com')).toStrictEqual(
-      {
+    it('should not return any variables for a server url that has none', () => {
+      expect(
+        Oas.init({ servers: [{ url: 'https://example.com' }] }).splitVariables('https://example.com'),
+      ).toStrictEqual({
         selected: 0,
         variables: {},
-      },
-    );
-  });
-
-  it('should find and return variables', () => {
-    const oas = new Oas({
-      openapi: '3.0.0',
-      info: { title: 'testing', version: '1.0.0' },
-      servers: [
-        {
-          url: 'http://{name}.local/{basePath}',
-          variables: {
-            name: { default: 'demo' },
-            basePath: { default: 'v2' },
-          },
-        },
-        {
-          url: 'https://{name}.example.com:{port}/{basePath}',
-          variables: {
-            name: { default: 'demo' },
-            port: { default: '443' },
-            basePath: { default: 'v2' },
-          },
-        },
-      ],
-      paths: {},
+      });
     });
 
-    const url = 'https://buster.example.com:3000/pet';
-    const split = oas.splitVariables(url);
-
-    expect(split).toStrictEqual({
-      selected: 1,
-      variables: {
-        name: 'buster',
-        port: '3000',
-        basePath: 'pet',
-      },
-    });
-
-    // @ts-expect-error This is an annoying exclusion but `split` is a known object at this point.
-    expect(oas.url(split.selected, split.variables)).toBe(url);
-  });
-
-  // Surprisingly this is valid by the spec. :cowboy-sweat:
-  it('should handle if a variable is duped in the server url', () => {
-    const oas = new Oas({
-      openapi: '3.0.0',
-      info: { title: 'testing', version: '1.0.0' },
-      servers: [
-        {
-          url: 'http://{region}.api.example.com/region/{region}/{lang}',
-          variables: {
-            region: { default: 'us' },
-            lang: { default: 'en-US' },
-          },
-        },
-      ],
-      paths: {},
-    });
-
-    expect(oas.splitVariables('http://eu.api.example.com/region/eu/fr-CH')).toStrictEqual({
-      selected: 0,
-      variables: {
-        region: 'eu',
-        lang: 'fr-CH',
-      },
-    });
-  });
-});
-
-describe('#variables([selected])', () => {
-  it('should return with list of variables', () => {
-    const variables = { path: { default: 'buster', description: 'path description' } };
-    expect(
-      new Oas({
-        openapi: '3.0.0',
-        info: { title: 'testing', version: '1.0.0' },
-        servers: [{ url: 'https://example.com/{path}', variables }],
-        paths: {},
-      }).variables(),
-    ).toStrictEqual(variables);
-  });
-
-  it('should return with empty object if out of bounds', () => {
-    expect(
-      new Oas({
+    it('should find and return variables', () => {
+      const oas = new Oas({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0.0' },
         servers: [
           {
-            url: 'https://example.com/{path}',
-            variables: { path: { default: 'buster', description: 'path description' } },
-          },
-        ],
-        paths: {},
-      }).variables(10),
-    ).toStrictEqual({});
-  });
-});
-
-describe('#defaultVariables([selected])', () => {
-  it('should return with list of variables', () => {
-    expect(
-      new Oas({
-        openapi: '3.0.0',
-        info: { title: 'testing', version: '1.0.0' },
-        servers: [
-          {
-            url: 'https://example.com/{path}',
+            url: 'http://{name}.local/{basePath}',
             variables: {
-              path: { default: '', description: 'path description' },
-              port: { default: '8000' },
+              name: { default: 'demo' },
+              basePath: { default: 'v2' },
+            },
+          },
+          {
+            url: 'https://{name}.example.com:{port}/{basePath}',
+            variables: {
+              name: { default: 'demo' },
+              port: { default: '443' },
+              basePath: { default: 'v2' },
             },
           },
         ],
         paths: {},
-      }).defaultVariables(),
-    ).toStrictEqual({ path: '', port: '8000' });
+      });
+
+      const url = 'https://buster.example.com:3000/pet';
+      const split = oas.splitVariables(url);
+
+      expect(split).toStrictEqual({
+        selected: 1,
+        variables: {
+          name: 'buster',
+          port: '3000',
+          basePath: 'pet',
+        },
+      });
+
+      // @ts-expect-error This is an annoying exclusion but `split` is a known object at this point.
+      expect(oas.url(split.selected, split.variables)).toBe(url);
+    });
+
+    // Surprisingly this is valid by the spec. :cowboy-sweat:
+    it('should handle if a variable is duped in the server url', () => {
+      const oas = new Oas({
+        openapi: '3.0.0',
+        info: { title: 'testing', version: '1.0.0' },
+        servers: [
+          {
+            url: 'http://{region}.api.example.com/region/{region}/{lang}',
+            variables: {
+              region: { default: 'us' },
+              lang: { default: 'en-US' },
+            },
+          },
+        ],
+        paths: {},
+      });
+
+      expect(oas.splitVariables('http://eu.api.example.com/region/eu/fr-CH')).toStrictEqual({
+        selected: 0,
+        variables: {
+          region: 'eu',
+          lang: 'fr-CH',
+        },
+      });
+    });
   });
 
-  it('should embellish with user variables', () => {
-    expect(
-      new Oas(
-        {
+  describe('.variables([selected])', () => {
+    it('should return with list of variables', () => {
+      const variables = { path: { default: 'buster', description: 'path description' } };
+      expect(
+        new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [{ url: 'https://example.com/{path}', variables }],
+          paths: {},
+        }).variables(),
+      ).toStrictEqual(variables);
+    });
+
+    it('should return with empty object if out of bounds', () => {
+      expect(
+        new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [
+            {
+              url: 'https://example.com/{path}',
+              variables: { path: { default: 'buster', description: 'path description' } },
+            },
+          ],
+          paths: {},
+        }).variables(10),
+      ).toStrictEqual({});
+    });
+  });
+
+  describe('.defaultVariables([selected])', () => {
+    it('should return with list of variables', () => {
+      expect(
+        new Oas({
           openapi: '3.0.0',
           info: { title: 'testing', version: '1.0.0' },
           servers: [
             {
               url: 'https://example.com/{path}',
               variables: {
-                path: { default: 'default-path', description: 'path description' },
+                path: { default: '', description: 'path description' },
                 port: { default: '8000' },
               },
             },
           ],
           paths: {},
-        },
-        {
-          path: 'user-path',
-        },
-      ).defaultVariables(),
-    ).toStrictEqual({ path: 'user-path', port: '8000' });
+        }).defaultVariables(),
+      ).toStrictEqual({ path: '', port: '8000' });
+    });
+
+    it('should embellish with user variables', () => {
+      expect(
+        new Oas(
+          {
+            openapi: '3.0.0',
+            info: { title: 'testing', version: '1.0.0' },
+            servers: [
+              {
+                url: 'https://example.com/{path}',
+                variables: {
+                  path: { default: 'default-path', description: 'path description' },
+                  port: { default: '8000' },
+                },
+              },
+            ],
+            paths: {},
+          },
+          {
+            path: 'user-path',
+          },
+        ).defaultVariables(),
+      ).toStrictEqual({ path: 'user-path', port: '8000' });
+    });
+
+    it('should return with empty object if out of bounds', () => {
+      expect(
+        new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [
+            {
+              url: 'https://example.com/{path}',
+              variables: { path: { default: 'buster', description: 'path description' } },
+            },
+          ],
+          paths: {},
+        }).variables(10),
+      ).toStrictEqual({});
+    });
   });
 
-  it('should return with empty object if out of bounds', () => {
-    expect(
-      new Oas({
+  describe('.operation()', () => {
+    it('should return an Operation object', () => {
+      const operation = petstore.operation('/pet', 'post');
+
+      expect(operation).toBeInstanceOf(Operation);
+      expect(operation.path).toBe('/pet');
+      expect(operation.method).toBe('post');
+      expect(operation.schema).toStrictEqual({
+        tags: ['pet'],
+        summary: 'Add a new pet to the store',
+        description: '',
+        operationId: 'addPet',
+        responses: expect.any(Object),
+        security: expect.any(Array),
+        requestBody: expect.any(Object),
+      });
+    });
+
+    it('should return a Webhook object for a webhook', () => {
+      const operation = webhooks.operation('newPet', 'post', { isWebhook: true });
+
+      expect(operation).toBeInstanceOf(Webhook);
+      expect(operation.path).toBe('newPet');
+      expect(operation.method).toBe('post');
+      expect(operation.schema).toStrictEqual({
+        requestBody: expect.any(Object),
+        responses: {
+          200: expect.any(Object),
+        },
+        tags: expect.any(Array),
+      });
+    });
+
+    it('should return a default when no operation', () => {
+      expect(Oas.init({}).operation('/unknown', 'get')).toMatchSnapshot();
+    });
+
+    it('should return an operation object with security if it has security', () => {
+      const operation = petstore.operation('/pet', 'put');
+      expect(operation.getSecurity()).toStrictEqual([{ petstore_auth: ['write:pets', 'read:pets'] }]);
+    });
+
+    it("should still return an operation object if the operation isn't found", () => {
+      const operation = petstore.operation('/pet', 'patch');
+      expect(operation).toMatchObject({
+        schema: { parameters: [] },
+        api: petstore.api,
+        path: '/pet',
+        method: 'patch',
+        contentType: undefined,
+        requestBodyExamples: undefined,
+        responseExamples: undefined,
+        callbackExamples: undefined,
+      });
+    });
+
+    it('should still return an operation object if the supplied API definition was `undefined`', () => {
+      const operation = Oas.init(undefined).operation('/pet', 'patch');
+      expect(operation).toMatchObject({
+        schema: { parameters: [] },
+        api: undefined,
+        path: '/pet',
+        method: 'patch',
+        contentType: undefined,
+        requestBodyExamples: undefined,
+        responseExamples: undefined,
+        callbackExamples: undefined,
+      });
+    });
+  });
+
+  describe('.findOperation()', () => {
+    it('should return undefined if no server found', () => {
+      const uri = 'http://localhost:3000/pet/1';
+      const method = 'delete';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return undefined if origin is correct but unable to extract path', () => {
+      const uri = 'http://petstore.swagger.io/';
+      const method = 'get';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return undefined if no path matches found', () => {
+      const uri = 'http://petstore.swagger.io/v2/search';
+      const method = 'get';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return undefined if no matching methods in path', () => {
+      const uri = 'http://petstore.swagger.io/v2/pet/1';
+      const method = 'patch';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return a result if found', () => {
+      const uri = 'http://petstore.swagger.io/v2/pet/1';
+      const method = 'delete';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'http://petstore.swagger.io/v2',
+          path: '/pet/:petId',
+          slugs: {
+            ':petId': '1',
+          },
+          method: 'DELETE',
+        },
+      });
+    });
+
+    it('should return normally if path is formatted poorly', () => {
+      const uri = 'http://petstore.swagger.io/v2/pet/1/';
+      const method = 'delete';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'http://petstore.swagger.io/v2',
+          path: '/pet/:petId',
+          slugs: {
+            ':petId': '1',
+          },
+          method: 'DELETE',
+        },
+      });
+    });
+
+    it('should return object if query string is included', () => {
+      const uri = 'http://petstore.swagger.io/v2/pet/findByStatus?test=2';
+      const method = 'get';
+
+      const res = petstore.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'http://petstore.swagger.io/v2',
+          path: '/pet/findByStatus',
+          slugs: {},
+          method: 'GET',
+        },
+      });
+    });
+
+    it('should support schemeless servers', () => {
+      const schemeless = JSON.parse(JSON.stringify(petstoreSpec));
+      schemeless.servers = [{ url: '//petstore.swagger.io/v2' }];
+
+      const oas = new Oas(schemeless);
+      const uri = 'http://petstore.swagger.io/v2/pet/findByStatus?test=2';
+      const method = 'get';
+
+      const res = oas.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: '//petstore.swagger.io/v2',
+          path: '/pet/findByStatus',
+          slugs: {},
+          method: 'GET',
+        },
+      });
+    });
+
+    it('should return result if server has a trailing slash', () => {
+      const oas = new Oas({
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0.0' },
         servers: [
           {
-            url: 'https://example.com/{path}',
-            variables: { path: { default: 'buster', description: 'path description' } },
+            url: 'https://example.com/',
           },
         ],
-        paths: {},
-      }).variables(10),
-    ).toStrictEqual({});
-  });
-});
-
-describe('#operation()', () => {
-  it('should return an Operation object', () => {
-    const operation = petstore.operation('/pet', 'post');
-
-    expect(operation).toBeInstanceOf(Operation);
-    expect(operation.path).toBe('/pet');
-    expect(operation.method).toBe('post');
-    expect(operation.schema).toStrictEqual({
-      tags: ['pet'],
-      summary: 'Add a new pet to the store',
-      description: '',
-      operationId: 'addPet',
-      responses: expect.any(Object),
-      security: expect.any(Array),
-      requestBody: expect.any(Object),
-    });
-  });
-
-  it('should return a Webhook object for a webhook', () => {
-    const operation = webhooks.operation('newPet', 'post', { isWebhook: true });
-
-    expect(operation).toBeInstanceOf(Webhook);
-    expect(operation.path).toBe('newPet');
-    expect(operation.method).toBe('post');
-    expect(operation.schema).toStrictEqual({
-      requestBody: expect.any(Object),
-      responses: {
-        200: expect.any(Object),
-      },
-      tags: expect.any(Array),
-    });
-  });
-
-  it('should return a default when no operation', () => {
-    expect(Oas.init({}).operation('/unknown', 'get')).toMatchSnapshot();
-  });
-
-  it('should return an operation object with security if it has security', () => {
-    const operation = petstore.operation('/pet', 'put');
-    expect(operation.getSecurity()).toStrictEqual([{ petstore_auth: ['write:pets', 'read:pets'] }]);
-  });
-
-  it("should still return an operation object if the operation isn't found", () => {
-    const operation = petstore.operation('/pet', 'patch');
-    expect(operation).toMatchObject({
-      schema: { parameters: [] },
-      api: petstore.api,
-      path: '/pet',
-      method: 'patch',
-      contentType: undefined,
-      requestBodyExamples: undefined,
-      responseExamples: undefined,
-      callbackExamples: undefined,
-    });
-  });
-
-  it('should still return an operation object if the supplied API definition was `undefined`', () => {
-    const operation = Oas.init(undefined).operation('/pet', 'patch');
-    expect(operation).toMatchObject({
-      schema: { parameters: [] },
-      api: undefined,
-      path: '/pet',
-      method: 'patch',
-      contentType: undefined,
-      requestBodyExamples: undefined,
-      responseExamples: undefined,
-      callbackExamples: undefined,
-    });
-  });
-});
-
-describe('#findOperation()', () => {
-  it('should return undefined if no server found', () => {
-    const uri = 'http://localhost:3000/pet/1';
-    const method = 'delete';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return undefined if origin is correct but unable to extract path', () => {
-    const uri = 'http://petstore.swagger.io/';
-    const method = 'get';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return undefined if no path matches found', () => {
-    const uri = 'http://petstore.swagger.io/v2/search';
-    const method = 'get';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return undefined if no matching methods in path', () => {
-    const uri = 'http://petstore.swagger.io/v2/pet/1';
-    const method = 'patch';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return a result if found', () => {
-    const uri = 'http://petstore.swagger.io/v2/pet/1';
-    const method = 'delete';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toMatchObject({
-      url: {
-        origin: 'http://petstore.swagger.io/v2',
-        path: '/pet/:petId',
-        slugs: {
-          ':petId': '1',
-        },
-        method: 'DELETE',
-      },
-    });
-  });
-
-  it('should return normally if path is formatted poorly', () => {
-    const uri = 'http://petstore.swagger.io/v2/pet/1/';
-    const method = 'delete';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toMatchObject({
-      url: {
-        origin: 'http://petstore.swagger.io/v2',
-        path: '/pet/:petId',
-        slugs: {
-          ':petId': '1',
-        },
-        method: 'DELETE',
-      },
-    });
-  });
-
-  it('should return object if query string is included', () => {
-    const uri = 'http://petstore.swagger.io/v2/pet/findByStatus?test=2';
-    const method = 'get';
-
-    const res = petstore.findOperation(uri, method);
-    expect(res).toMatchObject({
-      url: {
-        origin: 'http://petstore.swagger.io/v2',
-        path: '/pet/findByStatus',
-        slugs: {},
-        method: 'GET',
-      },
-    });
-  });
-
-  it('should support schemeless servers', () => {
-    const schemeless = JSON.parse(JSON.stringify(petstoreSpec));
-    schemeless.servers = [{ url: '//petstore.swagger.io/v2' }];
-
-    const oas = new Oas(schemeless);
-    const uri = 'http://petstore.swagger.io/v2/pet/findByStatus?test=2';
-    const method = 'get';
-
-    const res = oas.findOperation(uri, method);
-    expect(res).toMatchObject({
-      url: {
-        origin: '//petstore.swagger.io/v2',
-        path: '/pet/findByStatus',
-        slugs: {},
-        method: 'GET',
-      },
-    });
-  });
-
-  it('should return result if server has a trailing slash', () => {
-    const oas = new Oas({
-      openapi: '3.0.0',
-      info: { title: 'testing', version: '1.0.0' },
-      servers: [
-        {
-          url: 'https://example.com/',
-        },
-      ],
-      paths: {
-        '/pets/:id': {
-          get: {
-            responses: {
-              200: {
-                description: 'OK',
+        paths: {
+          '/pets/:id': {
+            get: {
+              responses: {
+                200: {
+                  description: 'OK',
+                },
               },
             },
           },
         },
-      },
+      });
+
+      const uri = 'https://example.com/pets/:id';
+      const method = 'get';
+
+      const res = oas.findOperation(uri, method);
+      expect(res.url).toStrictEqual({
+        origin: 'https://example.com',
+        path: '/pets/:id',
+        nonNormalizedPath: '/pets/:id',
+        slugs: { ':id': ':id' },
+        method: 'GET',
+      });
     });
 
-    const uri = 'https://example.com/pets/:id';
-    const method = 'get';
-
-    const res = oas.findOperation(uri, method);
-    expect(res.url).toStrictEqual({
-      origin: 'https://example.com',
-      path: '/pets/:id',
-      nonNormalizedPath: '/pets/:id',
-      slugs: { ':id': ':id' },
-      method: 'GET',
-    });
-  });
-
-  it('should return result if path is slash', () => {
-    const oas = new Oas({
-      openapi: '3.0.0',
-      info: { title: 'testing', version: '1.0.0' },
-      servers: [
-        {
-          url: 'https://example.com',
-        },
-      ],
-      paths: {
-        '/': {
-          get: {
-            responses: {
-              200: {
-                description: 'OK',
+    it('should return result if path is slash', () => {
+      const oas = new Oas({
+        openapi: '3.0.0',
+        info: { title: 'testing', version: '1.0.0' },
+        servers: [
+          {
+            url: 'https://example.com',
+          },
+        ],
+        paths: {
+          '/': {
+            get: {
+              responses: {
+                200: {
+                  description: 'OK',
+                },
               },
             },
           },
         },
-      },
-    });
+      });
 
-    const uri = 'https://example.com';
-    const method = 'get';
+      const uri = 'https://example.com';
+      const method = 'get';
 
-    const res = oas.findOperation(uri, method);
-    expect(res.url).toStrictEqual({
-      origin: 'https://example.com',
-      path: '/',
-      nonNormalizedPath: '/',
-      slugs: {},
-      method: 'GET',
-    });
+      const res = oas.findOperation(uri, method);
+      expect(res.url).toStrictEqual({
+        origin: 'https://example.com',
+        path: '/',
+        nonNormalizedPath: '/',
+        slugs: {},
+        method: 'GET',
+      });
 
-    expect(res.operation).toStrictEqual({
-      responses: {
-        200: {
-          description: 'OK',
+      expect(res.operation).toStrictEqual({
+        responses: {
+          200: {
+            description: 'OK',
+          },
         },
-      },
+      });
     });
-  });
 
-  it('should return result if in server variable defaults', () => {
-    const uri = 'https://demo.example.com:443/v2/post';
-    const method = 'post';
+    it('should return result if in server variable defaults', () => {
+      const uri = 'https://demo.example.com:443/v2/post';
+      const method = 'post';
 
-    const res = serverVariables.findOperation(uri, method);
-    expect(res).toMatchObject({
-      url: {
+      const res = serverVariables.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'https://demo.example.com:443/v2',
+          path: '/post',
+          nonNormalizedPath: '/post',
+          slugs: {},
+          method: 'POST',
+        },
+        operation: expect.objectContaining({
+          summary: 'Should fetch variables from defaults and user values',
+        }),
+      });
+    });
+
+    it('should render any target server variable defaults', async () => {
+      const oas = await import('./__datasets__/petstore-server-vars.json').then(r => r.default).then(Oas.init);
+      const uri = 'http://petstore.swagger.io/v2/pet';
+      const method = 'post';
+
+      const res = oas.findOperation(uri, method);
+      expect(res).toMatchObject({
+        url: {
+          origin: 'http://petstore.swagger.io/v2',
+          path: '/pet',
+          nonNormalizedPath: '/pet',
+          slugs: {},
+          method: 'POST',
+        },
+        operation: {
+          summary: 'Add a new pet to the store',
+          description: '',
+          responses: {},
+        },
+      });
+    });
+
+    it('should not overwrite the servers in the core OAS while looking for matches', () => {
+      const uri = 'https://demo.example.com:443/v2/post';
+      const method = 'post';
+
+      expect(serverVariables.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
+
+      const res = serverVariables.findOperation(uri, method);
+      expect(res.url).toMatchObject({
         origin: 'https://demo.example.com:443/v2',
         path: '/post',
         nonNormalizedPath: '/post',
         slugs: {},
         method: 'POST',
-      },
-      operation: expect.objectContaining({
-        summary: 'Should fetch variables from defaults and user values',
-      }),
-    });
-  });
-
-  it('should render any target server variable defaults', async () => {
-    const oas = await import('./__datasets__/petstore-server-vars.json').then(r => r.default).then(Oas.init);
-    const uri = 'http://petstore.swagger.io/v2/pet';
-    const method = 'post';
-
-    const res = oas.findOperation(uri, method);
-    expect(res).toMatchObject({
-      url: {
-        origin: 'http://petstore.swagger.io/v2',
-        path: '/pet',
-        nonNormalizedPath: '/pet',
-        slugs: {},
-        method: 'POST',
-      },
-      operation: {
-        summary: 'Add a new pet to the store',
-        description: '',
-        responses: {},
-      },
-    });
-  });
-
-  it('should not overwrite the servers in the core OAS while looking for matches', () => {
-    const uri = 'https://demo.example.com:443/v2/post';
-    const method = 'post';
-
-    expect(serverVariables.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
-
-    const res = serverVariables.findOperation(uri, method);
-    expect(res.url).toMatchObject({
-      origin: 'https://demo.example.com:443/v2',
-      path: '/post',
-      nonNormalizedPath: '/post',
-      slugs: {},
-      method: 'POST',
-    });
-
-    expect(serverVariables.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
-  });
-
-  it('should be able to match against servers with a variable hostname that includes subdomains and a port', () => {
-    const uri = 'http://online.example.global:3001/api/public/v1/tables/c445a575-ee58-4aa7/rows/5ba96283-29c2-47f7';
-    const method = 'put';
-
-    const res = serverVariables.findOperation(uri, method);
-    expect(res.url).toStrictEqual({
-      origin: '{protocol}://{hostname}/api/public/v1',
-      path: '/tables/:tableId/rows/:rowId',
-      nonNormalizedPath: '/tables/{tableId}/rows/{rowId}',
-      slugs: {
-        ':rowId': '5ba96283-29c2-47f7',
-        ':tableId': 'c445a575-ee58-4aa7',
-      },
-      method: 'PUT',
-    });
-  });
-
-  describe('quirks', () => {
-    it('should return result if the operation path has malformed path parameters', () => {
-      const uri = 'https://api.example.com/v2/games/destiny-2/dlc/witch-queen';
-      const method = 'get';
-      const res = pathMatchingQuirks.findOperation(uri, method);
-
-      expect(res.url).toStrictEqual({
-        origin: 'https://api.example.com/v2',
-        path: '/games/:game/dlc/:dlcrelease',
-        nonNormalizedPath: '/games/{game}/dlc/{dlcrelease}}',
-        slugs: { ':game': 'destiny-2', ':dlcrelease': 'witch-queen' },
-        method: 'GET',
       });
+
+      expect(serverVariables.api.servers[0].url).toBe('https://{name}.example.com:{port}/{basePath}');
     });
 
-    it('should support a path parameter that has a hypen in it', () => {
-      const uri = 'https://api.example.com/v2/games/destiny-2/platforms/ps5/dlc/witch-queen';
-      const method = 'get';
-      const res = pathMatchingQuirks.findOperation(uri, method);
+    it('should be able to match against servers with a variable hostname that includes subdomains and a port', () => {
+      const uri = 'http://online.example.global:3001/api/public/v1/tables/c445a575-ee58-4aa7/rows/5ba96283-29c2-47f7';
+      const method = 'put';
 
+      const res = serverVariables.findOperation(uri, method);
       expect(res.url).toStrictEqual({
-        origin: 'https://api.example.com/v2',
-        path: '/games/:game/platforms/:platform/dlc/:dlcrelease',
-        nonNormalizedPath: '/games/{game}/platforms/{platform}/dlc/{dlc-release}',
+        origin: '{protocol}://{hostname}/api/public/v1',
+        path: '/tables/:tableId/rows/:rowId',
+        nonNormalizedPath: '/tables/{tableId}/rows/{rowId}',
         slugs: {
-          ':game': 'destiny-2',
-          ':platform': 'ps5',
-          ':dlcrelease': 'witch-queen',
+          ':rowId': '5ba96283-29c2-47f7',
+          ':tableId': 'c445a575-ee58-4aa7',
         },
-        method: 'GET',
+        method: 'PUT',
       });
     });
 
-    it('should return a match if a defined server has camelcasing, but the uri is all lower', () => {
-      const oas = new Oas({
-        openapi: '3.0.0',
-        info: { title: 'testing', version: '1.0.0' },
-        servers: [{ url: 'https://api.EXAMPLE.com/' }],
-        paths: {
-          '/anything': {
-            get: {
-              responses: { 200: { description: 'OK' } },
+    describe('quirks', () => {
+      it('should return result if the operation path has malformed path parameters', () => {
+        const uri = 'https://api.example.com/v2/games/destiny-2/dlc/witch-queen';
+        const method = 'get';
+        const res = pathMatchingQuirks.findOperation(uri, method);
+
+        expect(res.url).toStrictEqual({
+          origin: 'https://api.example.com/v2',
+          path: '/games/:game/dlc/:dlcrelease',
+          nonNormalizedPath: '/games/{game}/dlc/{dlcrelease}}',
+          slugs: { ':game': 'destiny-2', ':dlcrelease': 'witch-queen' },
+          method: 'GET',
+        });
+      });
+
+      it('should support a path parameter that has a hypen in it', () => {
+        const uri = 'https://api.example.com/v2/games/destiny-2/platforms/ps5/dlc/witch-queen';
+        const method = 'get';
+        const res = pathMatchingQuirks.findOperation(uri, method);
+
+        expect(res.url).toStrictEqual({
+          origin: 'https://api.example.com/v2',
+          path: '/games/:game/platforms/:platform/dlc/:dlcrelease',
+          nonNormalizedPath: '/games/{game}/platforms/{platform}/dlc/{dlc-release}',
+          slugs: {
+            ':game': 'destiny-2',
+            ':platform': 'ps5',
+            ':dlcrelease': 'witch-queen',
+          },
+          method: 'GET',
+        });
+      });
+
+      it('should return a match if a defined server has camelcasing, but the uri is all lower', () => {
+        const oas = new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [{ url: 'https://api.EXAMPLE.com/' }],
+          paths: {
+            '/anything': {
+              get: {
+                responses: { 200: { description: 'OK' } },
+              },
             },
           },
-        },
+        });
+
+        const uri = 'https://api.example.com/anything';
+        const method = 'get';
+
+        const res = oas.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
+          origin: 'https://api.EXAMPLE.com',
+          path: '/anything',
+          nonNormalizedPath: '/anything',
+          slugs: {},
+          method: 'GET',
+        });
       });
 
-      const uri = 'https://api.example.com/anything';
-      const method = 'get';
-
-      const res = oas.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://api.EXAMPLE.com',
-        path: '/anything',
-        nonNormalizedPath: '/anything',
-        slugs: {},
-        method: 'GET',
-      });
-    });
-
-    it("should return a match if the uri has variable casing but the defined server doesn't", () => {
-      const oas = new Oas({
-        openapi: '3.0.0',
-        info: { title: 'testing', version: '1.0.0' },
-        servers: [{ url: 'https://api.example.com/' }],
-        paths: {
-          '/anything': {
-            get: {
-              responses: { 200: { description: 'OK' } },
+      it("should return a match if the uri has variable casing but the defined server doesn't", () => {
+        const oas = new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [{ url: 'https://api.example.com/' }],
+          paths: {
+            '/anything': {
+              get: {
+                responses: { 200: { description: 'OK' } },
+              },
             },
           },
-        },
-      });
+        });
 
-      const uri = 'https://api.EXAMPLE.com/anything';
-      const method = 'get';
+        const uri = 'https://api.EXAMPLE.com/anything';
+        const method = 'get';
 
-      const res = oas.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://api.example.com',
-        path: '/anything',
-        nonNormalizedPath: '/anything',
-        slugs: {},
-        method: 'GET',
-      });
-    });
-
-    it('should return result if path contains non-variabled colons', () => {
-      const uri = 'https://api.example.com/people/GWID:3';
-      const method = 'post';
-
-      const res = pathVariableQuirks.findOperation(uri, method);
-      expect(res).toMatchObject({
-        url: {
+        const res = oas.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
           origin: 'https://api.example.com',
-          path: '/people/:personIdType::personId',
-          nonNormalizedPath: '/people/{personIdType}:{personId}',
-          slugs: { ':personIdType': 'GWID', ':personId': '3' },
+          path: '/anything',
+          nonNormalizedPath: '/anything',
+          slugs: {},
+          method: 'GET',
+        });
+      });
+
+      it('should return result if path contains non-variabled colons', () => {
+        const uri = 'https://api.example.com/people/GWID:3';
+        const method = 'post';
+
+        const res = pathVariableQuirks.findOperation(uri, method);
+        expect(res).toMatchObject({
+          url: {
+            origin: 'https://api.example.com',
+            path: '/people/:personIdType::personId',
+            nonNormalizedPath: '/people/{personIdType}:{personId}',
+            slugs: { ':personIdType': 'GWID', ':personId': '3' },
+            method: 'POST',
+          },
+          operation: {
+            parameters: [
+              {
+                name: 'personIdType',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+              {
+                name: 'personId',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+          },
+        });
+      });
+
+      it('should not error if an unrelated OAS path has a query param in it', () => {
+        const uri = 'https://api.example.com/v2/listings';
+        const method = 'post';
+
+        const res = pathMatchingQuirks.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
+          origin: 'https://api.example.com/v2',
+          path: '/listings',
+          nonNormalizedPath: '/listings',
+          slugs: {},
           method: 'POST',
-        },
-        operation: {
-          parameters: [
-            {
-              name: 'personIdType',
-              in: 'path',
-              required: true,
-              schema: { type: 'string' },
-            },
-            {
-              name: 'personId',
-              in: 'path',
-              required: true,
-              schema: { type: 'string' },
-            },
-          ],
-        },
+        });
       });
-    });
 
-    it('should not error if an unrelated OAS path has a query param in it', () => {
-      const uri = 'https://api.example.com/v2/listings';
-      const method = 'post';
+      it('should match a path that has a query param in its OAS path definition', () => {
+        const uri = 'https://api.example.com/v2/rating_stats';
+        const method = 'get';
 
-      const res = pathMatchingQuirks.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://api.example.com/v2',
-        path: '/listings',
-        nonNormalizedPath: '/listings',
-        slugs: {},
-        method: 'POST',
+        const res = pathMatchingQuirks.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
+          origin: 'https://api.example.com/v2',
+          path: '/rating_stats',
+          nonNormalizedPath: '/rating_stats?listing_ids[]=1234567',
+          slugs: {},
+          method: 'GET',
+        });
       });
-    });
 
-    it('should match a path that has a query param in its OAS path definition', () => {
-      const uri = 'https://api.example.com/v2/rating_stats';
-      const method = 'get';
+      it('should match a path that has a hash in its OAS path definition', () => {
+        const uri = 'https://api.example.com/v2/listings#hash';
+        const method = 'get';
 
-      const res = pathMatchingQuirks.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://api.example.com/v2',
-        path: '/rating_stats',
-        nonNormalizedPath: '/rating_stats?listing_ids[]=1234567',
-        slugs: {},
-        method: 'GET',
+        const res = pathMatchingQuirks.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
+          origin: 'https://api.example.com/v2',
+          path: '/listings#hash',
+          nonNormalizedPath: '/listings#hash',
+          slugs: {},
+          method: 'GET',
+        });
       });
-    });
 
-    it('should match a path that has a hash in its OAS path definition', () => {
-      const uri = 'https://api.example.com/v2/listings#hash';
-      const method = 'get';
-
-      const res = pathMatchingQuirks.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://api.example.com/v2',
-        path: '/listings#hash',
-        nonNormalizedPath: '/listings#hash',
-        slugs: {},
-        method: 'GET',
-      });
-    });
-
-    it('should be able to find an operation if `servers` are missing from the API definition', () => {
-      const oas = new Oas({
-        openapi: '3.0.1',
-        info: {
-          title: 'Some Test API',
-          version: '1',
-        },
-        paths: {
-          '/v1/endpoint': {
-            get: {
-              responses: {
-                200: {
-                  description: 'OK',
+      it('should be able to find an operation if `servers` are missing from the API definition', () => {
+        const oas = new Oas({
+          openapi: '3.0.1',
+          info: {
+            title: 'Some Test API',
+            version: '1',
+          },
+          paths: {
+            '/v1/endpoint': {
+              get: {
+                responses: {
+                  200: {
+                    description: 'OK',
+                  },
                 },
               },
             },
           },
-        },
+        });
+
+        const uri = 'https://example.com/v1/endpoint';
+        const method = 'get';
+
+        const res = oas.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
+          origin: 'https://example.com',
+          path: '/v1/endpoint',
+          nonNormalizedPath: '/v1/endpoint',
+          slugs: {},
+          method: 'GET',
+        });
       });
 
-      const uri = 'https://example.com/v1/endpoint';
-      const method = 'get';
-
-      const res = oas.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://example.com',
-        path: '/v1/endpoint',
-        nonNormalizedPath: '/v1/endpoint',
-        slugs: {},
-        method: 'GET',
-      });
-    });
-
-    it('should not error if one of the paths in the API definition has a malformed path parameter', () => {
-      const oas = new Oas({
-        openapi: '3.0.1',
-        info: {
-          title: 'Some Test API',
-          version: '1',
-        },
-        paths: {
-          '/v1/endpoint': {
-            get: {
-              responses: {
-                200: {
-                  description: 'OK',
+      it('should not error if one of the paths in the API definition has a malformed path parameter', () => {
+        const oas = new Oas({
+          openapi: '3.0.1',
+          info: {
+            title: 'Some Test API',
+            version: '1',
+          },
+          paths: {
+            '/v1/endpoint': {
+              get: {
+                responses: {
+                  200: {
+                    description: 'OK',
+                  },
+                },
+              },
+            },
+            '/}/v1/endpoint': {
+              get: {
+                summary:
+                  "The path on this operation is malformed and will throw an error in `path-to-regexp` if we don't handle it.",
+                responses: {
+                  200: {
+                    description: 'OK',
+                  },
                 },
               },
             },
           },
-          '/}/v1/endpoint': {
-            get: {
-              summary:
-                "The path on this operation is malformed and will throw an error in `path-to-regexp` if we don't handle it.",
-              responses: {
-                200: {
-                  description: 'OK',
-                },
-              },
-            },
-          },
-        },
-      });
+        });
 
-      const uri = 'https://example.com/v1/endpoint';
-      const method = 'get';
+        const uri = 'https://example.com/v1/endpoint';
+        const method = 'get';
 
-      // Calling `findOperation` twice in this test so we can make sure that not only does it not
-      // throw an exception but that it still returns the data we want.
-      expect(() => {
-        oas.findOperation(uri, method);
-      }).not.toThrow(new TypeError('Unexpected CLOSE at 1, expected END'));
+        // Calling `findOperation` twice in this test so we can make sure that not only does it not
+        // throw an exception but that it still returns the data we want.
+        expect(() => {
+          oas.findOperation(uri, method);
+        }).not.toThrow(new TypeError('Unexpected CLOSE at 1, expected END'));
 
-      const res = oas.findOperation(uri, method);
-      expect(res.url).toStrictEqual({
-        origin: 'https://example.com',
-        path: '/v1/endpoint',
-        nonNormalizedPath: '/v1/endpoint',
-        slugs: {},
-        method: 'GET',
+        const res = oas.findOperation(uri, method);
+        expect(res.url).toStrictEqual({
+          origin: 'https://example.com',
+          path: '/v1/endpoint',
+          nonNormalizedPath: '/v1/endpoint',
+          slugs: {},
+          method: 'GET',
+        });
       });
     });
   });
-});
 
-// Since this is just a wrapper for findOperation, we don't need to re-test everything that the
-// tests for that does. All we need to know is that if findOperation fails this fails, as well as
-// the reverse.
-describe('#getOperation()', () => {
-  it('should return undefined if #findOperation returns undefined', () => {
-    const uri = 'http://localhost:3000/pet/1';
-    const method = 'delete';
+  // Since this is just a wrapper for findOperation, we don't need to re-test everything that the
+  // tests for that does. All we need to know is that if findOperation fails this fails, as well as
+  // the reverse.
+  describe('.getOperation()', () => {
+    it('should return undefined if #findOperation returns undefined', () => {
+      const uri = 'http://localhost:3000/pet/1';
+      const method = 'delete';
 
-    expect(petstore.getOperation(uri, method)).toBeUndefined();
-  });
-
-  it('should return a result if found', () => {
-    const uri = 'http://petstore.swagger.io/v2/pet/1';
-    const method = 'delete';
-
-    const res = petstore.getOperation(uri, method);
-
-    expect(res).toBeInstanceOf(Operation);
-    expect(res.path).toBe('/pet/{petId}');
-    expect(res.method).toBe('delete');
-  });
-
-  it('should have security present on an operation that has it', () => {
-    const security = [{ petstore_auth: ['write:pets', 'read:pets'] }];
-
-    expect(petstore.api.paths['/pet'].put.security).toStrictEqual(security);
-
-    const res = petstore.getOperation('http://petstore.swagger.io/v2/pet', 'put');
-    expect(res.getSecurity()).toStrictEqual(security);
-  });
-
-  it('should handle paths with uri templates', () => {
-    const operation = petstore.getOperation('http://petstore.swagger.io/v2/store/order/1234', 'get');
-
-    expect(operation.schema.parameters).toHaveLength(1);
-    expect(operation.schema.operationId).toBe('getOrderById');
-    expect(operation.path).toBe('/store/order/{orderId}');
-    expect(operation.method).toBe('get');
-  });
-
-  describe('server variables', () => {
-    const apiDefinition = {
-      openapi: '3.0.0',
-      info: { title: 'testing', version: '1.0.0' },
-      servers: [
-        {
-          url: 'https://{region}.node.example.com/v14',
-          variables: {
-            region: {
-              default: 'us',
-              enum: ['us', 'eu'],
-            },
-          },
-        },
-      ],
-      paths: {
-        '/api/esm': {
-          put: {
-            responses: {
-              200: {
-                description: '200',
-              },
-            },
-          },
-        },
-      },
-    };
-
-    it('should be able to find an operation where the variable matches the url', () => {
-      const source = {
-        url: 'https://eu.node.example.com/v14/api/esm',
-        method: 'put',
-      };
-
-      const method = source.method.toLowerCase() as RMOAS.HttpMethods;
-      const oas = new Oas(apiDefinition, { region: 'eu' });
-      const operation = oas.getOperation(source.url, method);
-
-      expect(operation).toBeDefined();
-      expect(operation.path).toBe('/api/esm');
-      expect(operation.method).toBe('put');
+      expect(petstore.getOperation(uri, method)).toBeUndefined();
     });
 
-    it("should be able to find an operation where the variable **doesn't** match the url", () => {
-      const source = {
-        url: 'https://eu.node.example.com/v14/api/esm',
-        method: 'put' as RMOAS.HttpMethods,
-      };
+    it('should return a result if found', () => {
+      const uri = 'http://petstore.swagger.io/v2/pet/1';
+      const method = 'delete';
 
-      const oas = new Oas(apiDefinition, { region: 'us' });
-      const operation = oas.getOperation(source.url, source.method);
+      const res = petstore.getOperation(uri, method);
 
-      expect(operation).toBeDefined();
-      expect(operation.path).toBe('/api/esm');
-      expect(operation.method).toBe('put');
+      expect(res).toBeInstanceOf(Operation);
+      expect(res.path).toBe('/pet/{petId}');
+      expect(res.method).toBe('delete');
     });
 
-    it('should be able to find an operation if there are no user variables present', () => {
-      const source = {
-        url: 'https://eu.node.example.com/v14/api/esm',
-        method: 'put' as RMOAS.HttpMethods,
-      };
+    it('should have security present on an operation that has it', () => {
+      const security = [{ petstore_auth: ['write:pets', 'read:pets'] }];
 
-      const oas = new Oas(apiDefinition);
-      const operation = oas.getOperation(source.url, source.method);
+      expect(petstore.api.paths['/pet'].put.security).toStrictEqual(security);
 
-      expect(operation).toBeDefined();
-      expect(operation.path).toBe('/api/esm');
-      expect(operation.method).toBe('put');
+      const res = petstore.getOperation('http://petstore.swagger.io/v2/pet', 'put');
+      expect(res.getSecurity()).toStrictEqual(security);
     });
 
-    it('should fail to find a match on a url that doesnt quite match', () => {
-      const source = {
-        url: 'https://eu.buster.example.com/v14/api/esm',
-        method: 'put' as RMOAS.HttpMethods,
-      };
+    it('should handle paths with uri templates', () => {
+      const operation = petstore.getOperation('http://petstore.swagger.io/v2/store/order/1234', 'get');
 
-      const oas = new Oas(apiDefinition, { region: 'us' });
-      const operation = oas.getOperation(source.url, source.method);
-
-      expect(operation).toBeUndefined();
+      expect(operation.schema.parameters).toHaveLength(1);
+      expect(operation.schema.operationId).toBe('getOrderById');
+      expect(operation.path).toBe('/store/order/{orderId}');
+      expect(operation.method).toBe('get');
     });
 
-    it('should be able to find a match on a url with an server OAS that doesnt have fleshed out server variables', () => {
-      const oas = new Oas({
+    describe('server variables', () => {
+      const apiDefinition = {
         openapi: '3.0.0',
         info: { title: 'testing', version: '1.0.0' },
-        servers: [{ url: 'https://{region}.node.example.com/v14' }],
+        servers: [
+          {
+            url: 'https://{region}.node.example.com/v14',
+            variables: {
+              region: {
+                default: 'us',
+                enum: ['us', 'eu'],
+              },
+            },
+          },
+        ],
         paths: {
           '/api/esm': {
             put: {
@@ -1251,452 +1183,620 @@ describe('#getOperation()', () => {
             },
           },
         },
+      };
+
+      it('should be able to find an operation where the variable matches the url', () => {
+        const source = {
+          url: 'https://eu.node.example.com/v14/api/esm',
+          method: 'put',
+        };
+
+        const method = source.method.toLowerCase() as RMOAS.HttpMethods;
+        const oas = new Oas(apiDefinition, { region: 'eu' });
+        const operation = oas.getOperation(source.url, method);
+
+        expect(operation).toBeDefined();
+        expect(operation.path).toBe('/api/esm');
+        expect(operation.method).toBe('put');
       });
 
-      const source = {
-        url: 'https://us.node.example.com/v14/api/esm',
-        method: 'put' as RMOAS.HttpMethods,
+      it("should be able to find an operation where the variable **doesn't** match the url", () => {
+        const source = {
+          url: 'https://eu.node.example.com/v14/api/esm',
+          method: 'put' as RMOAS.HttpMethods,
+        };
+
+        const oas = new Oas(apiDefinition, { region: 'us' });
+        const operation = oas.getOperation(source.url, source.method);
+
+        expect(operation).toBeDefined();
+        expect(operation.path).toBe('/api/esm');
+        expect(operation.method).toBe('put');
+      });
+
+      it('should be able to find an operation if there are no user variables present', () => {
+        const source = {
+          url: 'https://eu.node.example.com/v14/api/esm',
+          method: 'put' as RMOAS.HttpMethods,
+        };
+
+        const oas = new Oas(apiDefinition);
+        const operation = oas.getOperation(source.url, source.method);
+
+        expect(operation).toBeDefined();
+        expect(operation.path).toBe('/api/esm');
+        expect(operation.method).toBe('put');
+      });
+
+      it('should fail to find a match on a url that doesnt quite match', () => {
+        const source = {
+          url: 'https://eu.buster.example.com/v14/api/esm',
+          method: 'put' as RMOAS.HttpMethods,
+        };
+
+        const oas = new Oas(apiDefinition, { region: 'us' });
+        const operation = oas.getOperation(source.url, source.method);
+
+        expect(operation).toBeUndefined();
+      });
+
+      it('should be able to find a match on a url with an server OAS that doesnt have fleshed out server variables', () => {
+        const oas = new Oas({
+          openapi: '3.0.0',
+          info: { title: 'testing', version: '1.0.0' },
+          servers: [{ url: 'https://{region}.node.example.com/v14' }],
+          paths: {
+            '/api/esm': {
+              put: {
+                responses: {
+                  200: {
+                    description: '200',
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const source = {
+          url: 'https://us.node.example.com/v14/api/esm',
+          method: 'put' as RMOAS.HttpMethods,
+        };
+
+        const operation = oas.getOperation(source.url, source.method);
+
+        expect(operation).toBeDefined();
+        expect(operation.path).toBe('/api/esm');
+        expect(operation.method).toBe('put');
+      });
+
+      it('should be able to find a match on a url that contains colons', () => {
+        const source = {
+          url: 'https://api.example.com/people/GWID:3',
+          method: 'post' as RMOAS.HttpMethods,
+        };
+
+        const operation = pathVariableQuirks.getOperation(source.url, source.method);
+
+        expect(operation).toBeDefined();
+        expect(operation.path).toBe('/people/{personIdType}:{personId}');
+        expect(operation.method).toBe('post');
+      });
+    });
+  });
+
+  describe('.getOperationById()', () => {
+    describe('given an operation that does have an operationId', () => {
+      it('should return an operation', () => {
+        const operation = petstore.getOperationById('deletePet');
+        expect(operation.path).toBe('/pet/{petId}');
+        expect(operation.method).toBe('delete');
+      });
+
+      it('should return `undefined` if not found', () => {
+        expect(petstore.getOperationById('deletepet')).toBeUndefined();
+      });
+
+      describe('and the same operationId is duplicated with different casing', () => {
+        it('should return the matching operation', () => {
+          const spec = createOasForPaths({
+            '/anything': {
+              get: {
+                operationId: 'findpetsbystatus',
+                responses: {},
+              },
+              post: {
+                operationId: 'findPetsByStatus',
+                responses: {},
+              },
+            },
+          });
+
+          const operation = spec.getOperationById('findPetsByStatus');
+          expect(operation.path).toBe('/anything');
+          expect(operation.method).toBe('post');
+        });
+      });
+
+      describe('and it contains non-alphanumeric characters', () => {
+        it('should return an operation', () => {
+          const spec = createOasForPaths({
+            '/anything': {
+              get: {
+                operationId: 'find/?*!@#$%^&*()-=.,<>+[]{}\\|pets-by-status',
+                responses: {},
+              },
+              post: {
+                operationId: 'find/?*!@#$%^&*()-=.,<>+[]{}\\|pets-by-statuses',
+                responses: {},
+              },
+            },
+          });
+
+          const operation = spec.getOperationById('find/?*!@#$%^&*()-=.,<>+[]{}\\|pets-by-status');
+          expect(operation.path).toBe('/anything');
+          expect(operation.method).toBe('get');
+        });
+      });
+    });
+
+    describe('given an api definition with webhooks', () => {
+      it('should return an operation', () => {
+        const webhook = webhooks.operation('newPet', 'post', { isWebhook: true });
+        expect(webhook).toBeInstanceOf(Webhook);
+        expect(webhook.getOperationId()).toBe('post_newpet');
+
+        const operation = webhooks.getOperationById('post_newpet');
+        expect(operation.path).toBe('newPet');
+        expect(operation.method).toBe('post');
+      });
+    });
+
+    describe('given an operation that doesnt have an operationId', () => {
+      it('should return an operation', () => {
+        const operation = multipleSecurities.getOperationById('get_multiple-combo-auths-duped');
+        expect(operation.path).toBe('/multiple-combo-auths-duped');
+        expect(operation.method).toBe('get');
+      });
+
+      describe('and the path we are looking for begins with double forward slashes', () => {
+        it('should return an operation', () => {
+          const spec = createOasForPaths({
+            '//candidate/{candidate_id}/': {
+              get: {
+                responses: {},
+              },
+            },
+          });
+
+          const operationId = spec.operation('//candidate/{candidate_id}/', 'get').getOperationId();
+          expect(operationId).toBe('get_candidate-candidate-id');
+
+          const operation = spec.getOperationById(operationId);
+          expect(operation.path).toBe('//candidate/{candidate_id}/');
+          expect(operation.method).toBe('get');
+        });
+      });
+    });
+  });
+
+  describe('.findOperationWithoutMethod()', () => {
+    it('should return undefined if no server found', () => {
+      const uri = 'http://localhost:3000/pet/1';
+
+      const res = petstore.findOperationWithoutMethod(uri);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return undefined if origin is correct but unable to extract path', () => {
+      const uri = 'http://petstore.swagger.io/';
+
+      const res = petstore.findOperationWithoutMethod(uri);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return undefined if no path matches found', () => {
+      const uri = 'http://petstore.swagger.io/v2/search';
+
+      const res = petstore.findOperationWithoutMethod(uri);
+      expect(res).toBeUndefined();
+    });
+
+    it('should return all results for valid path match', () => {
+      const uri = 'http://petstore.swagger.io/v2/pet/1';
+
+      const res = petstore.findOperationWithoutMethod(uri);
+      const petIndexResult = petstore.api.paths['/pet/{petId}'];
+
+      const expected = {
+        match: {
+          index: 0,
+          params: {
+            petId: '1',
+          },
+          path: '/pet/1',
+        },
+        operation: {
+          ...petIndexResult,
+        },
+        url: {
+          nonNormalizedPath: '/pet/{petId}',
+          origin: 'http://petstore.swagger.io/v2',
+          path: '/pet/:petId',
+          slugs: {
+            ':petId': '1',
+          },
+        },
       };
 
-      const operation = oas.getOperation(source.url, source.method);
-
-      expect(operation).toBeDefined();
-      expect(operation.path).toBe('/api/esm');
-      expect(operation.method).toBe('put');
-    });
-
-    it('should be able to find a match on a url that contains colons', () => {
-      const source = {
-        url: 'https://api.example.com/people/GWID:3',
-        method: 'post' as RMOAS.HttpMethods,
-      };
-
-      const operation = pathVariableQuirks.getOperation(source.url, source.method);
-
-      expect(operation).toBeDefined();
-      expect(operation.path).toBe('/people/{personIdType}:{personId}');
-      expect(operation.method).toBe('post');
-    });
-  });
-});
-
-describe('#findOperationWithoutMethod()', () => {
-  it('should return undefined if no server found', () => {
-    const uri = 'http://localhost:3000/pet/1';
-
-    const res = petstore.findOperationWithoutMethod(uri);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return undefined if origin is correct but unable to extract path', () => {
-    const uri = 'http://petstore.swagger.io/';
-
-    const res = petstore.findOperationWithoutMethod(uri);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return undefined if no path matches found', () => {
-    const uri = 'http://petstore.swagger.io/v2/search';
-
-    const res = petstore.findOperationWithoutMethod(uri);
-    expect(res).toBeUndefined();
-  });
-
-  it('should return all results for valid path match', () => {
-    const uri = 'http://petstore.swagger.io/v2/pet/1';
-
-    const res = petstore.findOperationWithoutMethod(uri);
-    const petIndexResult = petstore.api.paths['/pet/{petId}'];
-
-    const expected = {
-      match: {
-        index: 0,
-        params: {
-          petId: '1',
-        },
-        path: '/pet/1',
-      },
-      operation: {
-        ...petIndexResult,
-      },
-      url: {
-        nonNormalizedPath: '/pet/{petId}',
-        origin: 'http://petstore.swagger.io/v2',
-        path: '/pet/:petId',
-        slugs: {
-          ':petId': '1',
-        },
-      },
-    };
-
-    expect(res).toMatchObject(expected);
-  });
-});
-
-describe('#dereference()', () => {
-  it('should not fail on a empty, null or undefined API definitions', async () => {
-    await expect(Oas.init({}).dereference()).resolves.toStrictEqual([]);
-    await expect(Oas.init(undefined).dereference()).resolves.toStrictEqual([]);
-    await expect(Oas.init(null).dereference()).resolves.toStrictEqual([]);
-  });
-
-  it('should dereference the current OAS', async () => {
-    const oas = Oas.init(petstoreSpec);
-
-    expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
-      $ref: '#/components/requestBodies/Pet',
-    });
-
-    await oas.dereference();
-
-    expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
-      content: {
-        'application/json': {
-          schema: oas.api.components.schemas.Pet,
-        },
-        'application/xml': {
-          schema: oas.api.components.schemas.Pet,
-        },
-      },
-      description: 'Pet object that needs to be added to the store',
-      required: true,
+      expect(res).toMatchObject(expected);
     });
   });
 
-  it('should support primitive component schemas', async () => {
-    const oas = await import('./__datasets__/3-1-primitive-components.json').then(r => r.default).then(Oas.init);
-    await oas.dereference();
+  describe('.dereference()', () => {
+    it('should not fail on a empty, null or undefined API definitions', async () => {
+      await expect(Oas.init({}).dereference()).resolves.toStrictEqual([]);
+      await expect(Oas.init(undefined).dereference()).resolves.toStrictEqual([]);
+      await expect(Oas.init(null).dereference()).resolves.toStrictEqual([]);
+    });
 
-    expect(oas.api.components.schemas.primitive).toBe(true);
-  });
+    it('should dereference the current OAS', async () => {
+      const oas = Oas.init(petstoreSpec);
 
-  it('should support `$ref` pointers existing alongside `description` in OpenAPI 3.1 definitions', async () => {
-    const oas = await import('./__datasets__/3-1-dereference-handling.json').then(r => r.default).then(Oas.init);
-    await oas.dereference();
+      expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
+        $ref: '#/components/requestBodies/Pet',
+      });
 
-    expect(oas.api.paths['/'].get.parameters).toStrictEqual([
-      {
-        description: 'This is an overridden description on the number parameter.',
-        in: 'query',
-        name: 'number',
-        required: false,
-        schema: { type: 'integer' },
-      },
-    ]);
+      await oas.dereference();
 
-    expect(oas.api.paths['/'].get.responses).toStrictEqual({
-      '200': {
-        description: 'OK',
+      expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
         content: {
-          '*/*': {
-            schema: {
-              description: 'This is an overridden description on the response.',
-              summary: 'This is an overridden summary on the response.',
-              type: 'object',
-              properties: { foo: { type: 'string' }, bar: { type: 'number' } },
-              'x-readme-ref-name': 'simple-object',
+          'application/json': {
+            schema: oas.api.components.schemas.Pet,
+          },
+          'application/xml': {
+            schema: oas.api.components.schemas.Pet,
+          },
+        },
+        description: 'Pet object that needs to be added to the store',
+        required: true,
+      });
+    });
+
+    it('should support primitive component schemas', async () => {
+      const oas = await import('./__datasets__/3-1-primitive-components.json').then(r => r.default).then(Oas.init);
+      await oas.dereference();
+
+      expect(oas.api.components.schemas.primitive).toBe(true);
+    });
+
+    it('should support `$ref` pointers existing alongside `description` in OpenAPI 3.1 definitions', async () => {
+      const oas = await import('./__datasets__/3-1-dereference-handling.json').then(r => r.default).then(Oas.init);
+      await oas.dereference();
+
+      expect(oas.api.paths['/'].get.parameters).toStrictEqual([
+        {
+          description: 'This is an overridden description on the number parameter.',
+          in: 'query',
+          name: 'number',
+          required: false,
+          schema: { type: 'integer' },
+        },
+      ]);
+
+      expect(oas.api.paths['/'].get.responses).toStrictEqual({
+        '200': {
+          description: 'OK',
+          content: {
+            '*/*': {
+              schema: {
+                description: 'This is an overridden description on the response.',
+                summary: 'This is an overridden summary on the response.',
+                type: 'object',
+                properties: { foo: { type: 'string' }, bar: { type: 'number' } },
+                'x-readme-ref-name': 'simple-object',
+              },
             },
           },
         },
-      },
+      });
     });
-  });
 
-  describe('should add metadata to components pre-dereferencing to preserve their lineage', () => {
-    it('stored as `x-readme-ref-name', async () => {
-      const oas = await import('./__datasets__/complex-nesting.json').then(r => r.default).then(Oas.init);
+    describe('should add metadata to components pre-dereferencing to preserve their lineage', () => {
+      it('stored as `x-readme-ref-name', async () => {
+        const oas = await import('./__datasets__/complex-nesting.json').then(r => r.default).then(Oas.init);
+        await oas.dereference();
+
+        const schema = (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject)
+          .content['application/json'].schema as RMOAS.SchemaObject;
+
+        expect(schema.title).toBeUndefined();
+        expect(schema['x-readme-ref-name']).toBe('MultischemaOfEverything');
+
+        expect(oas.api.paths).toMatchSnapshot();
+      });
+
+      it('stored as `title` if the `preserveRefAsJSONSchemaTitle` option is supplied', async () => {
+        const oas = Oas.init(petstoreSpec);
+        await oas.dereference({ preserveRefAsJSONSchemaTitle: true });
+
+        const schema = (oas.api.paths['/pet'].post.requestBody as RMOAS.RequestBodyObject).content['application/json']
+          .schema as RMOAS.SchemaObject;
+
+        expect(schema.title).toBe('Pet');
+        expect(schema['x-readme-ref-name']).toBe('Pet');
+
+        expect(oas.api.paths).toMatchSnapshot();
+      });
+    });
+
+    it('should retain the user object when dereferencing', async () => {
+      const oas = Oas.init(petstoreSpec, {
+        username: 'buster',
+      });
+
+      expect(oas.user).toStrictEqual({
+        username: 'buster',
+      });
+
       await oas.dereference();
 
-      const schema = (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject).content[
-        'application/json'
-      ].schema as RMOAS.SchemaObject;
+      expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
+        content: expect.any(Object),
+        description: 'Pet object that needs to be added to the store',
+        required: true,
+      });
 
-      expect(schema.title).toBeUndefined();
-      expect(schema['x-readme-ref-name']).toBe('MultischemaOfEverything');
-
-      expect(oas.api.paths).toMatchSnapshot();
+      // User data should remain unchanged
+      expect(oas.user).toStrictEqual({
+        username: 'buster',
+      });
     });
 
-    it('stored as `title` if the `preserveRefAsJSONSchemaTitle` option is supplied', async () => {
-      const oas = Oas.init(petstoreSpec);
-      await oas.dereference({ preserveRefAsJSONSchemaTitle: true });
+    it('should be able to handle a circular schema without erroring', async () => {
+      const oas = await import('./__datasets__/circular.json').then(r => r.default).then(Oas.init);
+      await oas.dereference();
 
-      const schema = (oas.api.paths['/pet'].post.requestBody as RMOAS.RequestBodyObject).content['application/json']
-        .schema as RMOAS.SchemaObject;
-
-      expect(schema.title).toBe('Pet');
-      expect(schema['x-readme-ref-name']).toBe('Pet');
-
-      expect(oas.api.paths).toMatchSnapshot();
-    });
-  });
-
-  it('should retain the user object when dereferencing', async () => {
-    const oas = Oas.init(petstoreSpec, {
-      username: 'buster',
-    });
-
-    expect(oas.user).toStrictEqual({
-      username: 'buster',
-    });
-
-    await oas.dereference();
-
-    expect(oas.api.paths['/pet'].post.requestBody).toStrictEqual({
-      content: expect.any(Object),
-      description: 'Pet object that needs to be added to the store',
-      required: true,
-    });
-
-    // User data should remain unchanged
-    expect(oas.user).toStrictEqual({
-      username: 'buster',
-    });
-  });
-
-  it('should be able to handle a circular schema without erroring', async () => {
-    const oas = await import('./__datasets__/circular.json').then(r => r.default).then(Oas.init);
-    await oas.dereference();
-
-    // $refs should remain in the OAS because they're circular and are ignored.
-    expect(oas.api.paths['/'].get).toStrictEqual({
-      responses: {
-        200: {
-          description: 'OK',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  dateTime: { type: 'string', format: 'date-time' },
-                  offsetAfter: { $ref: '#/components/schemas/offset' },
-                  offsetBefore: { $ref: '#/components/schemas/offset' },
+      // $refs should remain in the OAS because they're circular and are ignored.
+      expect(oas.api.paths['/'].get).toStrictEqual({
+        responses: {
+          200: {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    dateTime: { type: 'string', format: 'date-time' },
+                    offsetAfter: { $ref: '#/components/schemas/offset' },
+                    offsetBefore: { $ref: '#/components/schemas/offset' },
+                  },
                 },
               },
             },
           },
         },
-      },
+      });
     });
-  });
 
-  it('should be able to handle OpenAPI 3.1 `pathItem` reference objects', async () => {
-    const oas = await import('./__datasets__/pathitems-component.json').then(r => r.default).then(Oas.init);
-    await oas.dereference();
+    it('should be able to handle OpenAPI 3.1 `pathItem` reference objects', async () => {
+      const oas = await import('./__datasets__/pathitems-component.json').then(r => r.default).then(Oas.init);
+      await oas.dereference();
 
-    expect(oas.operation('/pet/:id', 'put').schema).toStrictEqual({
-      tags: ['pet'],
-      summary: 'Update a pet',
-      description: 'This operation will update a pet in the database.',
-      responses: {
-        '400': {
-          description: 'Invalid id value',
+      expect(oas.operation('/pet/:id', 'put').schema).toStrictEqual({
+        tags: ['pet'],
+        summary: 'Update a pet',
+        description: 'This operation will update a pet in the database.',
+        responses: {
+          '400': {
+            description: 'Invalid id value',
+          },
         },
-      },
-      security: [
-        {
-          apiKey: [],
-        },
-      ],
+        security: [
+          {
+            apiKey: [],
+          },
+        ],
+      });
     });
-  });
 
-  describe('blocking', () => {
-    class TestOas extends Oas {
-      // Because `dereferencing` is a protected property we need to create a getter with this new
-      // class in order to inspect it.
-      getDereferencing() {
-        return this.dereferencing;
+    describe('blocking', () => {
+      class TestOas extends Oas {
+        // Because `dereferencing` is a protected property we need to create a getter with this new
+        // class in order to inspect it.
+        getDereferencing() {
+          return this.dereferencing;
+        }
       }
-    }
 
-    it('should only dereference once when called multiple times', async () => {
-      const oas = new TestOas(petstoreSpec as RMOAS.OASDocument);
-      const spy = vi.fn();
+      it('should only dereference once when called multiple times', async () => {
+        const oas = new TestOas(petstoreSpec as RMOAS.OASDocument);
+        const spy = vi.fn();
 
-      await Promise.all([oas.dereference({ cb: spy }), oas.dereference({ cb: spy }), oas.dereference({ cb: spy })]);
+        await Promise.all([oas.dereference({ cb: spy }), oas.dereference({ cb: spy }), oas.dereference({ cb: spy })]);
 
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(oas.getDereferencing()).toStrictEqual({ processing: false, complete: true, circularRefs: [] });
-      expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
-        $ref: '#/components/requestBodies/Pet',
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(oas.getDereferencing()).toStrictEqual({ processing: false, complete: true, circularRefs: [] });
+        expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
+          $ref: '#/components/requestBodies/Pet',
+        });
+      });
+
+      it('should only **ever** dereference once', async () => {
+        const oas = new TestOas(petstoreSpec as RMOAS.OASDocument);
+        const spy = vi.fn();
+
+        await oas.dereference({ cb: spy });
+        expect(oas.getDereferencing()).toStrictEqual({ processing: false, complete: true, circularRefs: [] });
+        expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
+          $ref: '#/components/requestBodies/Pet',
+        });
+
+        await oas.dereference({ cb: spy });
+        expect(oas.getDereferencing()).toStrictEqual({ processing: false, complete: true, circularRefs: [] });
+        expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
+          $ref: '#/components/requestBodies/Pet',
+        });
+
+        expect(spy).toHaveBeenCalledTimes(1);
       });
     });
+  });
 
-    it('should only **ever** dereference once', async () => {
-      const oas = new TestOas(petstoreSpec as RMOAS.OASDocument);
-      const spy = vi.fn();
+  describe('.getCircularReferences()', () => {
+    it('should throw an error if dereferencing has not yet happened', () => {
+      const oas = Oas.init({});
 
-      await oas.dereference({ cb: spy });
-      expect(oas.getDereferencing()).toStrictEqual({ processing: false, complete: true, circularRefs: [] });
-      expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
-        $ref: '#/components/requestBodies/Pet',
-      });
-
-      await oas.dereference({ cb: spy });
-      expect(oas.getDereferencing()).toStrictEqual({ processing: false, complete: true, circularRefs: [] });
-      expect(oas.api.paths['/pet'].post.requestBody).not.toStrictEqual({
-        $ref: '#/components/requestBodies/Pet',
-      });
-
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(() => {
+        oas.getCircularReferences();
+      }).toThrow('#dereference() must be called first in order for this method to obtain circular references.');
     });
-  });
-});
 
-describe('#getCircularReferences()', () => {
-  it('should throw an error if dereferencing has not yet happened', () => {
-    const oas = Oas.init({});
+    it('should be able to return circular refs in a circular schema', async () => {
+      const oas = await import('./__datasets__/circular.json').then(r => r.default).then(Oas.init);
+      await oas.dereference();
 
-    expect(() => {
-      oas.getCircularReferences();
-    }).toThrow('#dereference() must be called first in order for this method to obtain circular references.');
-  });
+      expect(oas.getCircularReferences()).toStrictEqual([
+        '#/components/schemas/offsetTransition/properties/offsetAfter',
+        '#/components/schemas/ProductStock/properties/test_param/items',
+      ]);
+    });
 
-  it('should be able to return circular refs in a circular schema', async () => {
-    const oas = await import('./__datasets__/circular.json').then(r => r.default).then(Oas.init);
-    await oas.dereference();
+    it('should not return circular refs in a schema that has none', async () => {
+      const oas = Oas.init(petstoreSpec);
+      await oas.dereference();
 
-    expect(oas.getCircularReferences()).toStrictEqual([
-      '#/components/schemas/offsetTransition/properties/offsetAfter',
-      '#/components/schemas/ProductStock/properties/test_param/items',
-    ]);
-  });
-
-  it('should not return circular refs in a schema that has none', async () => {
-    const oas = Oas.init(petstoreSpec);
-    await oas.dereference();
-
-    expect(oas.getCircularReferences()).toHaveLength(0);
-  });
-});
-
-describe('#getPaths()', () => {
-  it('should all paths if paths are present', () => {
-    const paths = petstore.getPaths();
-
-    expect(Object.keys(paths)).toHaveLength(14);
-    expect(paths['/pet']).toStrictEqual({
-      post: expect.any(Operation),
-      put: expect.any(Operation),
+      expect(oas.getCircularReferences()).toHaveLength(0);
     });
   });
 
-  it('should return an empty object if no paths are present', () => {
-    expect(webhooks.getPaths()).toStrictEqual({});
-  });
+  describe('.getPaths()', () => {
+    it('should all paths if paths are present', () => {
+      const paths = petstore.getPaths();
 
-  it("should return an empty object for the path if only only properties present aren't supported HTTP methods", () => {
-    const oas = Oas.init({
-      openapi: '3.0.0',
-      info: {
-        version: '1.0.0',
-        title: 'Unknown object keys',
-      },
-      servers: [{ url: 'http://httpbin.org' }],
-      paths: {
-        '/post': {
-          'x-deprecated': true,
+      expect(Object.keys(paths)).toHaveLength(14);
+      expect(paths['/pet']).toStrictEqual({
+        post: expect.any(Operation),
+        put: expect.any(Operation),
+      });
+    });
+
+    it('should return an empty object if no paths are present', () => {
+      expect(webhooks.getPaths()).toStrictEqual({});
+    });
+
+    it("should return an empty object for the path if only only properties present aren't supported HTTP methods", () => {
+      const oas = Oas.init({
+        openapi: '3.0.0',
+        info: {
+          version: '1.0.0',
+          title: 'Unknown object keys',
         },
-      },
-    });
+        servers: [{ url: 'http://httpbin.org' }],
+        paths: {
+          '/post': {
+            'x-deprecated': true,
+          },
+        },
+      });
 
-    expect(oas.getPaths()).toStrictEqual({
-      '/post': {},
-    });
-  });
-
-  it('should be able to handle, and ignore, extensions set at the `paths` level', () => {
-    const oas = Oas.init({
-      openapi: '3.0.0',
-      info: {
-        version: '1.0.0',
-        title: '`paths`-level extensions',
-      },
-      servers: [{ url: 'http://httpbin.org' }],
-      paths: {
+      expect(oas.getPaths()).toStrictEqual({
         '/post': {},
-        'x-extension-name': 'buster',
-      },
+      });
     });
 
-    expect(oas.getPaths()).toStrictEqual({
-      '/post': {},
+    it('should be able to handle, and ignore, extensions set at the `paths` level', () => {
+      const oas = Oas.init({
+        openapi: '3.0.0',
+        info: {
+          version: '1.0.0',
+          title: '`paths`-level extensions',
+        },
+        servers: [{ url: 'http://httpbin.org' }],
+        paths: {
+          '/post': {},
+          'x-extension-name': 'buster',
+        },
+      });
+
+      expect(oas.getPaths()).toStrictEqual({
+        '/post': {},
+      });
+    });
+
+    it('should be able to handle OpenAPI 3.1 `pathItem` reference objects without dereferencing', async () => {
+      const oas = await import('./__datasets__/pathitems-component.json').then(r => r.default).then(Oas.init);
+
+      const paths = oas.getPaths();
+
+      expect(Object.keys(paths)).toHaveLength(1);
+      expect(paths['/pet/:id']).toStrictEqual({
+        put: expect.any(Operation),
+        get: expect.any(Operation),
+      });
     });
   });
 
-  it('should be able to handle OpenAPI 3.1 `pathItem` reference objects without dereferencing', async () => {
-    const oas = await import('./__datasets__/pathitems-component.json').then(r => r.default).then(Oas.init);
+  describe('.getWebhooks()', () => {
+    it('should all paths if paths are present', () => {
+      const hooks = webhooks.getWebhooks();
 
-    const paths = oas.getPaths();
-
-    expect(Object.keys(paths)).toHaveLength(1);
-    expect(paths['/pet/:id']).toStrictEqual({
-      put: expect.any(Operation),
-      get: expect.any(Operation),
+      expect(Object.keys(hooks)).toHaveLength(1);
+      expect(hooks).toStrictEqual({
+        newPet: {
+          post: expect.any(Webhook),
+        },
+      });
     });
-  });
-});
 
-describe('#getWebhooks()', () => {
-  it('should all paths if paths are present', () => {
-    const hooks = webhooks.getWebhooks();
-
-    expect(Object.keys(hooks)).toHaveLength(1);
-    expect(hooks).toStrictEqual({
-      newPet: {
-        post: expect.any(Webhook),
-      },
+    it('should return an empty object if no webhooks are present', () => {
+      expect(petstore.getWebhooks()).toStrictEqual({});
     });
   });
 
-  it('should return an empty object if no webhooks are present', () => {
-    expect(petstore.getWebhooks()).toStrictEqual({});
-  });
-});
-
-describe('#getTags()', () => {
-  it('should return all tags that are present in a definition', () => {
-    expect(petstore.getTags()).toStrictEqual(['pet', 'store', 'user']);
-    expect(webhooks.getTags()).toStrictEqual(['Webhooks']);
-  });
-
-  it('should respect `tags` array ordering', () => {
-    expect(orderedTags.getTags()).toStrictEqual(['user', 'store', 'pet', 'endpoint']);
-  });
-
-  it('should acknowledge `disable-tag-sorting` extension', () => {
-    orderedTags.api['x-readme'] = { 'disable-tag-sorting': true };
-    expect(orderedTags.getTags()).toStrictEqual(['pet', 'endpoint', 'store', 'user']);
-  });
-
-  describe('setIfMissing option', () => {
-    it('should return no tags if none are present', () => {
-      expect(serverVariables.getTags()).toHaveLength(0);
+  describe('.getTags()', () => {
+    it('should return all tags that are present in a definition', () => {
+      expect(petstore.getTags()).toStrictEqual(['pet', 'store', 'user']);
+      expect(webhooks.getTags()).toStrictEqual(['Webhooks']);
     });
 
-    it('should ensure that operations without a tag still have a tag set as the path name if `setIfMissing` is true', () => {
-      expect(serverVariables.getTags(true)).toStrictEqual(['/post', '/tables/{tableId}/rows/{rowId}']);
-    });
-  });
-});
-
-describe('#hasExtension()', () => {
-  it('should return true if the extension exists', () => {
-    const oas = Oas.init({
-      ...petstoreSpec,
-      'x-samples-languages': false,
+    it('should respect `tags` array ordering', () => {
+      expect(orderedTags.getTags()).toStrictEqual(['user', 'store', 'pet', 'endpoint']);
     });
 
-    expect(oas.hasExtension('x-samples-languages')).toBe(true);
+    it('should acknowledge `disable-tag-sorting` extension', () => {
+      orderedTags.api['x-readme'] = { 'disable-tag-sorting': true };
+      expect(orderedTags.getTags()).toStrictEqual(['pet', 'endpoint', 'store', 'user']);
+    });
+
+    describe('setIfMissing option', () => {
+      it('should return no tags if none are present', () => {
+        expect(serverVariables.getTags()).toHaveLength(0);
+      });
+
+      it('should ensure that operations without a tag still have a tag set as the path name if `setIfMissing` is true', () => {
+        expect(serverVariables.getTags(true)).toStrictEqual(['/post', '/tables/{tableId}/rows/{rowId}']);
+      });
+    });
   });
 
-  it("should return false if the extension doesn't exist", () => {
-    expect(petstore.hasExtension('x-readme')).toBe(false);
-  });
+  describe('.hasExtension()', () => {
+    it('should return true if the extension exists', () => {
+      const oas = Oas.init({
+        ...petstoreSpec,
+        'x-samples-languages': false,
+      });
 
-  it('should not fail if the Oas instance has no API definition', () => {
-    const oas = Oas.init(undefined);
-    expect(oas.hasExtension('x-readme')).toBe(false);
+      expect(oas.hasExtension('x-samples-languages')).toBe(true);
+    });
+
+    it("should return false if the extension doesn't exist", () => {
+      expect(petstore.hasExtension('x-readme')).toBe(false);
+    });
+
+    it('should not fail if the Oas instance has no API definition', () => {
+      const oas = Oas.init(undefined);
+      expect(oas.hasExtension('x-readme')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## 🧰 Changes

This creates a new `.getOperationById()` method on the main `Oas` instance that allows us to retrieve an `Operation` or `Webhook` instance by either the `operationId` that's set to the schema, or if that's missing then the default generated behavior from `Operation.getOperationId()`.

I plan on using this within our main app to retrieve `path` and `method` for an operation based on the data I have for it: just an `operationId`.

## 🧬 QA & Testing

The tests I wrote have been sort of ported over from the `Operation.getOperationById()` tests but heavily reduced as I don't need to re-test that thing.
