### PR TITLE
feat(oas/extensions): oauth configuration options

### DIFF
--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -99,7 +99,7 @@ export const METRICS_ENABLED = 'metrics-enabled';
  *
  * - `scopeSeparator`: scope separator for passing scopes. This value will be URL-encoded.
  * Default value is a space (encoded value `%20`). MUST be a string
- * - `useBasicAuthenticationWithAccessCodeGrant`: When enabled, client password is sent using the HTTP Basic Authentication scheme
+ * - `useBasicAuthenticationWithAuthorizationCodeGrant`: When enabled, client password is sent using the HTTP Basic Authentication scheme
  * (Authorization header with Basic base64encode(client_id + client_secret)). Only activated for the `authorizationCode` grant type.
  * The default is `true`.
  *
@@ -113,7 +113,7 @@ export const METRICS_ENABLED = 'metrics-enabled';
  *  "x-readme": {
  *    "oauth-options": {
  *      "scopeSeparator": ",",
- *      "useBasicAuthenticationWithAccessCodeGrant": false
+ *      "useBasicAuthenticationWithAuthorizationCodeGrant": false
  *    }
  *  }
  * }
@@ -244,7 +244,7 @@ export interface Extensions {
   [METRICS_ENABLED]: boolean;
   [OAUTH_OPTIONS]: {
     scopeSeparator?: string;
-    useBasicAuthenticationWithAccessCodeGrant?: boolean;
+    useBasicAuthenticationWithAuthorizationCodeGrant?: boolean;
   };
   [PARAMETER_ORDERING]: ('body' | 'cookie' | 'form' | 'header' | 'path' | 'query')[];
   [PROXY_ENABLED]: boolean;

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -99,15 +99,12 @@ export const METRICS_ENABLED = 'metrics-enabled';
  *
  * @defaultValue {}
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#oauth-options}
- *
- * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-3.3} Scope separators information from OAuth 2.0 specification
- * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1} Client password information from OAuth 2.0 specification
  * @example
  * {
  *  "x-readme": {
  *    "oauth-options": {
  *      "scopeSeparator": ",",
- *      "useBasicAuthenticationWithAuthorizationCodeGrant": false
+ *      "useInsecureClientAuthentication": true
  *    }
  *  }
  * }
@@ -243,18 +240,23 @@ export interface Extensions {
      * @example ","
      * @example "+"
      * @default " "
+     * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-3.3} Scope separators information from OAuth 2.0 specification
      */
     scopeSeparator?: string;
 
     /**
-     * When enabled, client password is sent using the HTTP Basic Authentication scheme
-     * (Authorization header with Basic base64encode(client_id + client_secret)).
-     * Only activated for the `authorizationCode` grant type.
+     * When enabled, the client credentials (i.e., `client_id` and `client_secret`) are sent in the request body (NOT recommended).
+     * When disabled (the default), client credentials are sent using the HTTP Basic Authentication scheme.
      *
-     * @example false
-     * @default true
+     * This is applicable for all requests to the token endpoint.
+     *
+     * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1}
+     * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-3.2}
+     *
+     * @example true
+     * @default false
      */
-    useBasicAuthenticationWithAuthorizationCodeGrant?: boolean;
+    useInsecureClientAuthentication?: boolean;
   };
   [PARAMETER_ORDERING]: ('body' | 'cookie' | 'form' | 'header' | 'path' | 'query')[];
   [PROXY_ENABLED]: boolean;

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -97,12 +97,6 @@ export const METRICS_ENABLED = 'metrics-enabled';
 /**
  * Configuration options for OAuth flows in the API Explorer.
  *
- * - `scopeSeparator`: scope separator for passing scopes. This value will be URL-encoded.
- * Default value is a space (encoded value `%20`). MUST be a string
- * - `useBasicAuthenticationWithAuthorizationCodeGrant`: When enabled, client password is sent using the HTTP Basic Authentication scheme
- * (Authorization header with Basic base64encode(client_id + client_secret)). Only activated for the `authorizationCode` grant type.
- * The default is `true`.
- *
  * @defaultValue {}
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#oauth-options}
  *
@@ -243,7 +237,23 @@ export interface Extensions {
   [HEADERS]: Record<string, number | string>[];
   [METRICS_ENABLED]: boolean;
   [OAUTH_OPTIONS]: {
+    /**
+     * Scope separator for passing scopes. This value will be URL-encoded.
+     *
+     * @example ","
+     * @example "+"
+     * @default " "
+     */
     scopeSeparator?: string;
+
+    /**
+     * When enabled, client password is sent using the HTTP Basic Authentication scheme
+     * (Authorization header with Basic base64encode(client_id + client_secret)).
+     * Only activated for the `authorizationCode` grant type.
+     *
+     * @example false
+     * @default true
+     */
     useBasicAuthenticationWithAuthorizationCodeGrant?: boolean;
   };
   [PARAMETER_ORDERING]: ('body' | 'cookie' | 'form' | 'header' | 'path' | 'query')[];

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -95,6 +95,32 @@ export const HEADERS = 'headers';
 export const METRICS_ENABLED = 'metrics-enabled';
 
 /**
+ * Configuration options for OAuth flows in the API Explorer.
+ *
+ * - `scopeSeparator`: scope separator for passing scopes. This value will be URL-encoded.
+ * Default value is a space (encoded value `%20`). MUST be a string
+ * - `useBasicAuthenticationWithAccessCodeGrant`: When enabled, client password is sent using the HTTP Basic Authentication scheme
+ * (Authorization header with Basic base64encode(client_id + client_secret)). Only activated for the `authorizationCode` grant type.
+ * The default is `true`.
+ *
+ * @defaultValue {}
+ * @see {@link https://docs.readme.com/main/docs/openapi-extensions#oauth-options}
+ *
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-3.3} Scope separators information from OAuth 2.0 specification
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1} Client password information from OAuth 2.0 specification
+ * @example
+ * {
+ *  "x-readme": {
+ *    "oauth-options": {
+ *      "scopeSeparator": ",",
+ *      "useBasicAuthenticationWithAccessCodeGrant": false
+ *    }
+ *  }
+ * }
+ */
+export const OAUTH_OPTIONS = 'oauth-options';
+
+/**
  * Controls the order of parameters on your API Reference pages.
  *
  * Your custom ordering **must** contain all of our available parameter types:
@@ -211,11 +237,15 @@ export interface Extensions {
      * @example "Custom cURL snippet"
      */
     name?: string;
-  };
+  }[];
   [DISABLE_TAG_SORTING]: boolean;
   [EXPLORER_ENABLED]: boolean;
   [HEADERS]: Record<string, number | string>[];
   [METRICS_ENABLED]: boolean;
+  [OAUTH_OPTIONS]: {
+    scopeSeparator?: string;
+    useBasicAuthenticationWithAccessCodeGrant?: boolean;
+  };
   [PARAMETER_ORDERING]: ('body' | 'cookie' | 'form' | 'header' | 'path' | 'query')[];
   [PROXY_ENABLED]: boolean;
   [SAMPLES_LANGUAGES]: string[];
@@ -228,6 +258,7 @@ export const extensionDefaults: Extensions = {
   [EXPLORER_ENABLED]: true,
   [HEADERS]: undefined,
   [METRICS_ENABLED]: true,
+  [OAUTH_OPTIONS]: {},
   [PARAMETER_ORDERING]: ['path', 'query', 'body', 'cookie', 'form', 'header'],
   [PROXY_ENABLED]: true,
   [SAMPLES_LANGUAGES]: ['shell', 'node', 'ruby', 'php', 'python', 'java', 'csharp'],

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -9,6 +9,7 @@ import { pathToRegexp, match } from 'path-to-regexp';
 import {
   CODE_SAMPLES,
   HEADERS,
+  OAUTH_OPTIONS,
   PARAMETER_ORDERING,
   SAMPLES_LANGUAGES,
   extensionDefaults,
@@ -886,6 +887,10 @@ export default class Oas {
           if (extension === PARAMETER_ORDERING) {
             validateParameterOrdering(data[extension], `x-readme.${extension}`);
           }
+        } else if (extension === OAUTH_OPTIONS) {
+          if (typeof data[extension] !== 'object') {
+            throw new TypeError(`"x-readme.${extension}" must be of type "Object"`);
+          }
         } else if (typeof data[extension] !== 'boolean') {
           throw new TypeError(`"x-readme.${extension}" must be of type "Boolean"`);
         }
@@ -902,6 +907,10 @@ export default class Oas {
 
         if (extension === PARAMETER_ORDERING) {
           validateParameterOrdering(data, `x-${extension}`);
+        }
+      } else if (extension === OAUTH_OPTIONS) {
+        if (typeof data !== 'object') {
+          throw new TypeError(`"x-${extension}" must be of type "Object"`);
         }
       } else if (typeof data !== 'boolean') {
         throw new TypeError(`"x-${extension}" must be of type "Boolean"`);

--- a/packages/oas/src/operation/lib/get-example-groups.ts
+++ b/packages/oas/src/operation/lib/get-example-groups.ts
@@ -13,7 +13,7 @@ export type ExampleGroups = Record<
      * Mutually exclusive of `request`. Note that if this object is present,
      * there may or may not be corresponding responses in the `response` object.
      */
-    customCodeSamples?: (Extensions['code-samples'] & {
+    customCodeSamples?: (Extensions['code-samples'][number] & {
       /**
        * The index in the originally defined `code-samples` array
        */
@@ -110,7 +110,7 @@ function addMatchingResponseExamples(groups: ExampleGroups, operation: Operation
  * Returns a name for the given custom code sample. If there isn't already one defined,
  * we construct a fallback value based on where the sample is in the array.
  */
-function getDefaultName(sample: Extensions['code-samples'], count: Record<string, number>): string {
+function getDefaultName(sample: Extensions['code-samples'][number], count: Record<string, number>): string {
   return sample.name && sample.name.length > 0
     ? sample.name
     : `Default${count[sample.language] > 1 ? ` #${count[sample.language]}` : ''}`;
@@ -132,7 +132,7 @@ export function getExampleGroups(operation: Operation): ExampleGroups {
   const groups: ExampleGroups = {};
 
   // add custom code samples
-  const codeSamples = getExtension('code-samples', operation.api, operation) as Extensions['code-samples'][];
+  const codeSamples = getExtension('code-samples', operation.api, operation) as Extensions['code-samples'];
   codeSamples?.forEach((sample, i) => {
     if (namelessCodeSampleCounts[sample.language]) {
       namelessCodeSampleCounts[sample.language] += 1;

--- a/packages/oas/test/extensions.test.ts
+++ b/packages/oas/test/extensions.test.ts
@@ -187,6 +187,7 @@ describe('#validateExtension', () => {
       ['query', 'header', 'body', 'path', 'cookie', 'formData'],
       'Array',
     ],
+    ['OAUTH_OPTIONS', {}, 'yes', 'Object'],
     ['PROXY_ENABLED', true, 'yes', 'Boolean'],
     ['METRICS_ENABLED', false, 'no', 'Boolean'],
     ['SAMPLES_LANGUAGES', ['swift'], {}, 'Array'],


### PR DESCRIPTION
| 🚥 Partially resolves RM-10641, RM-10720, RM-10730 |
| :------------------- |

## 🧰 Changes

Adds an OAS extension so folks can configure OAuth flows handling. These options are inspired by Swagger UI's configuration options: https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/

In my testing, I've found these ones are necessary for a v1 release of OAuth flows support, but I'm down to add more options further down the line.

Also, a super tiny type-fix with our `CODE_SAMPLES` extension.

## 🧬 QA & Testing

Tests appear to pass, but I would **love** targeted feedback on the following million dollar question: **do you feel good about the naming conventions and defaults**? This will be impossible to change in the future so I'd love to make sure we develop a consensus first!

I opted to stick with the Swagger naming conventions (despite by own personal reservations), with a couple small exceptions:
- The name diverges slightly for `useBasicAuthenticationWithAuthorizationCodeGrant` (known as `useBasicAuthenticationWithAccessCodeGrant` in Swagger UI) — `accessCode` was a Swagger 2.0 convention and it's `authorizationCode` in OpenAPI 3.x, hence the update
- I also diverged from Swagger UI in that the default value for `useBasicAuthenticationWithAuthorizationCodeGrant` is `true`. This is because it's the more secure/recommended approach per the following RFCs[^1][^2]:
  - https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
  - https://datatracker.ietf.org/doc/html/rfc6819#section-5.4.1


[^1]: First discovered through this: https://security.stackexchange.com/a/143560
[^2]: I'm also cool with a name that ensures folks understand the risks, (e.g., `useInsecureAuthorizationCodeGrantDefinition` with a default of `false`, etc.)