### PR TITLE
feat(oas): type improvements for `oas.splitUrl()`

### DIFF
--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -356,7 +356,38 @@ export default class Oas {
     return defaults;
   }
 
-  splitUrl(selected = 0) {
+  splitUrl(selected = 0): (
+    | {
+        /**
+         * A unique key, where the `value` is concatenated to its index
+         */
+        key: string;
+        type: 'text';
+        value: string;
+      }
+    | {
+        /**
+         * An optional description for the server variable.
+         *
+         * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-4}
+         */
+        description: string;
+
+        /**
+         * An enumeration of string values to be used if the substitution options are from a limited set.
+         *
+         * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-4}
+         */
+        enum: string[];
+
+        /**
+         * A unique key, where the `value` is concatenated to its index
+         */
+        key: string;
+        type: 'variable';
+        value: string;
+      }
+  )[] {
     const url = normalizedUrl(this.api, selected);
     const variables = this.variables(selected);
 

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -371,14 +371,14 @@ export default class Oas {
          *
          * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-4}
          */
-        description: string;
+        description?: string;
 
         /**
          * An enumeration of string values to be used if the substitution options are from a limited set.
          *
          * @see {@link https://spec.openapis.org/oas/v3.1.0#fixed-fields-4}
          */
-        enum: string[];
+        enum?: string[];
 
         /**
          * A unique key, where the `value` is concatenated to its index

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -401,30 +401,28 @@ describe('Oas', () => {
     });
 
     it('should return with description', () => {
-      expect(
-        new Oas({
-          openapi: '3.0.0',
-          info: { title: 'testing', version: '1.0.0' },
-          servers: [
-            {
-              url: 'https://example.com/{path}',
-              variables: { path: { default: 'buster', description: 'path description' } },
-            },
-          ],
-          paths: {},
-        }).splitUrl()[1].description,
-      ).toBe('path description');
+      const split = new Oas({
+        openapi: '3.0.0',
+        info: { title: 'testing', version: '1.0.0' },
+        servers: [
+          {
+            url: 'https://example.com/{path}',
+            variables: { path: { default: 'buster', description: 'path description' } },
+          },
+        ],
+        paths: {},
+      }).splitUrl()[1];
+      expect(split.type === 'variable' && split.description).toBe('path description');
     });
 
     it('should return with enum values', () => {
-      expect(
-        new Oas({
-          openapi: '3.0.0',
-          info: { title: 'testing', version: '1.0.0' },
-          servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'v1', enum: ['v1', 'v2'] } } }],
-          paths: {},
-        }).splitUrl()[1].enum,
-      ).toStrictEqual(['v1', 'v2']);
+      const split = new Oas({
+        openapi: '3.0.0',
+        info: { title: 'testing', version: '1.0.0' },
+        servers: [{ url: 'https://example.com/{path}', variables: { path: { default: 'v1', enum: ['v1', 'v2'] } } }],
+        paths: {},
+      }).splitUrl()[1];
+      expect(split.type === 'variable' && split.enum).toStrictEqual(['v1', 'v2']);
     });
   });
 

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -323,13 +323,68 @@ describe('Oas', () => {
         Oas.init({
           servers: [{ url: 'https://example.com/{a}/{b}/c' }],
         }).splitUrl(),
-      ).toHaveLength(5);
+      ).toStrictEqual([
+        {
+          key: 'https://example.com/-0',
+          type: 'text',
+          value: 'https://example.com/',
+        },
+        {
+          description: undefined,
+          enum: undefined,
+          key: 'a-1',
+          type: 'variable',
+          value: 'a',
+        },
+        {
+          key: '/-2',
+          type: 'text',
+          value: '/',
+        },
+        {
+          description: undefined,
+          enum: undefined,
+          key: 'b-3',
+          type: 'variable',
+          value: 'b',
+        },
+        {
+          key: '/c-4',
+          type: 'text',
+          value: '/c',
+        },
+      ]);
 
       expect(
         Oas.init({
           servers: [{ url: 'https://example.com/v1/flight/{FlightID}/sitezonetargeting/{SiteZoneTargetingID}' }],
         }).splitUrl(),
-      ).toHaveLength(4);
+      ).toStrictEqual([
+        {
+          key: 'https://example.com/v1/flight/-0',
+          type: 'text',
+          value: 'https://example.com/v1/flight/',
+        },
+        {
+          description: undefined,
+          enum: undefined,
+          key: 'FlightID-1',
+          type: 'variable',
+          value: 'FlightID',
+        },
+        {
+          key: '/sitezonetargeting/-2',
+          type: 'text',
+          value: '/sitezonetargeting/',
+        },
+        {
+          description: undefined,
+          enum: undefined,
+          key: 'SiteZoneTargetingID-3',
+          type: 'variable',
+          value: 'SiteZoneTargetingID',
+        },
+      ]);
     });
 
     it('should create unique keys for duplicate values', () => {


### PR DESCRIPTION
## 🧰 Changes

Explicitly defines our types for `oas.splitUrl()`.

Before (inferred return types):

![CleanShot 2024-09-03 at 19 13 20@2x](https://github.com/user-attachments/assets/248fd28a-78d8-4ac6-a34b-dfb09757d010)


After (explicitly defined return types):

![CleanShot 2024-09-03 at 19 13 05@2x](https://github.com/user-attachments/assets/f0ba5269-60c8-4f58-89ef-b126a6982658)

Also, strengthens a few test assertions.
