### PR TITLE
feat: add Operation.isWebhook()

### DIFF
--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -163,7 +163,7 @@ const operation = petstore.operation('/pet', 'post');
 | `.isJson()` | Determine if this operation requires its payload to be delivered as JSON. |
 | `.isMultipart()` | Determine if this operation requires its data to be sent as a multipart payload. |
 | `.isXml()` | Determine if this operation requires its data to be sent as XML. |
-| `.isWebhook()` | Determine if this operation is an instance of the `Webhook` class . |
+| `.isWebhook()` | Determine if this operation is an instance of the `Webhook` class. |
 | `.getExampleGroups()` | Returns an object with groups of all example definitions (body/header/query/path/response/etc.). The examples are grouped by their key when defined via the `examples` map. |
 | `.getHeaders()` | Retrieve all headers that can either be sent for or returned from this operation. This includes header-based authentication schemes, common header parameters, and request body and response content types. |
 | `.getSummary()` | Retrieve the `summary` that's set on this operation. This supports common summaries that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |

--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -163,6 +163,7 @@ const operation = petstore.operation('/pet', 'post');
 | `.isJson()` | Determine if this operation requires its payload to be delivered as JSON. |
 | `.isMultipart()` | Determine if this operation requires its data to be sent as a multipart payload. |
 | `.isXml()` | Determine if this operation requires its data to be sent as XML. |
+| `.isWebhook()` | Determine if this operation is an instance of the `Webhook` class . |
 | `.getExampleGroups()` | Returns an object with groups of all example definitions (body/header/query/path/response/etc.). The examples are grouped by their key when defined via the `examples` map. |
 | `.getHeaders()` | Retrieve all headers that can either be sent for or returned from this operation. This includes header-based authentication schemes, common header parameters, and request body and response content types. |
 | `.getSummary()` | Retrieve the `summary` that's set on this operation. This supports common summaries that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -154,7 +154,8 @@ export class Operation {
   }
 
   /**
-   * Checks if the current operation is a webhook or not
+   * Checks if the current operation is a webhook or not.
+   *
    */
   isWebhook(): boolean {
     return this instanceof Webhook;

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -153,7 +153,9 @@ export class Operation {
     return matchesMimeType.xml(this.getContentType());
   }
 
-  // Checks if the current operation is a webhook or not 
+  /**
+   * Checks if the current operation is a webhook or not
+   */
   isWebhook(): boolean {
     return this instanceof Webhook;
   }

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -153,6 +153,11 @@ export class Operation {
     return matchesMimeType.xml(this.getContentType());
   }
 
+  // Checks if the current operation is a webhook or not 
+  isWebhook(): boolean {
+    return this instanceof Webhook;
+  }
+
   /**
    * Returns an array of all security requirements associated wtih this operation. If none are
    * defined at the operation level, the securities for the entire API definition are returned

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -5,7 +5,7 @@ import openapiParser from '@readme/openapi-parser';
 import { beforeAll, describe, it, expect } from 'vitest';
 
 import Oas from '../../src/index.js';
-import { Operation, Callback } from '../../src/operation/index.js';
+import { Operation, Callback, Webhook } from '../../src/operation/index.js';
 import { createOasForPaths } from '../__fixtures__/create-oas.js';
 
 let petstore: Oas;
@@ -351,6 +351,26 @@ describe('#isXml()', () => {
 
     expect(op.getContentType()).toBe('application/xml');
     expect(op.isXml()).toBe(true);
+  });
+});
+
+describe('#isWebhook()', () => {
+  it('should return `false` for Operation class', () => {
+    const operation = new Operation(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' })
+
+    expect(operation.isWebhook()).toBe(false);
+  });
+
+  it('should return `false` for Callback class', () => {
+    const operation = new Callback(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' }, 'test', {})
+
+    expect(operation.isWebhook()).toBe(false);
+  });
+
+  it('should return `true` for Webhook class', () => {
+    const operation = new Webhook(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' })
+
+    expect(operation.isWebhook()).toBe(true);
   });
 });
 

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -356,19 +356,19 @@ describe('#isXml()', () => {
 
 describe('#isWebhook()', () => {
   it('should return `false` for Operation class', () => {
-    const operation = new Operation(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' })
+    const operation = new Operation(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' });
 
     expect(operation.isWebhook()).toBe(false);
   });
 
   it('should return `false` for Callback class', () => {
-    const operation = new Callback(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' }, 'test', {})
+    const operation = new Callback(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' }, 'test', {});
 
     expect(operation.isWebhook()).toBe(false);
   });
 
   it('should return `true` for Webhook class', () => {
-    const operation = new Webhook(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' })
+    const operation = new Webhook(petstoreSpec as any, '/test', 'get', { summary: 'operation summary' });
 
     expect(operation.isWebhook()).toBe(true);
   });


### PR DESCRIPTION
| 🚥 Resolves N/A |
| :------------------- |

## 🧰 Changes
I personally find myself checking if the current Operation is a Webhook or not. I looked at the `Operation` class and didn't see anything like this. Thought it'd be useful so we don't have to keep type checking in the main repo. 

I put the check on the Operation class since a Webhook will always be an Operation class but an Operation class might not be a Webhook or Callback class. 

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
