### PR TITLE
fix: add empty `value` check in getRequestBodyExamples()

### DIFF
--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -708,7 +708,7 @@ export class Operation {
    *
    */
   getRequestBodyExamples(): RequestBodyExamples {
-    const isRequestExampleValueDefined = typeof this.requestBodyExamples?.[0]?.examples?.[0].value !== 'undefined'
+    const isRequestExampleValueDefined = typeof this.requestBodyExamples?.[0]?.examples?.[0].value !== 'undefined';
 
     if (this.requestBodyExamples && isRequestExampleValueDefined) {
       return this.requestBodyExamples;

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -708,7 +708,9 @@ export class Operation {
    *
    */
   getRequestBodyExamples(): RequestBodyExamples {
-    if (this.requestBodyExamples) {
+    const nonEmptyRequestExample = this.requestBodyExamples?.[0]?.examples?.[0].value
+
+    if (this.requestBodyExamples && nonEmptyRequestExample) {
       return this.requestBodyExamples;
     }
 

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -708,9 +708,9 @@ export class Operation {
    *
    */
   getRequestBodyExamples(): RequestBodyExamples {
-    const nonEmptyRequestExample = this.requestBodyExamples?.[0]?.examples?.[0].value;
+    const isRequestExampleValueDefined = typeof this.requestBodyExamples?.[0]?.examples?.[0].value !== 'undefined'
 
-    if (this.requestBodyExamples && nonEmptyRequestExample) {
+    if (this.requestBodyExamples && isRequestExampleValueDefined) {
       return this.requestBodyExamples;
     }
 

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -708,7 +708,7 @@ export class Operation {
    *
    */
   getRequestBodyExamples(): RequestBodyExamples {
-    const nonEmptyRequestExample = this.requestBodyExamples?.[0]?.examples?.[0].value
+    const nonEmptyRequestExample = this.requestBodyExamples?.[0]?.examples?.[0].value;
 
     if (this.requestBodyExamples && nonEmptyRequestExample) {
       return this.requestBodyExamples;

--- a/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
@@ -24,13 +24,15 @@ test('should return early if there is no request body', () => {
 });
 
 test('webhooks', () => {
-  const webhookOperation = webhooksOas.operation('newPet', 'post', {isWebhook: true});
+  const webhookOperation = webhooksOas.operation('newPet', 'post', { isWebhook: true });
   webhookOperation.requestBodyExamples = [
     {
       mediaType: 'application/json',
-      examples: [{
-        value: undefined
-      }],
+      examples: [
+        {
+          value: undefined,
+        },
+      ],
     },
   ];
 
@@ -42,11 +44,11 @@ test('webhooks', () => {
           value: {
             id: 0,
             name: 'string',
-            tag: 'string'
-          }
-        }
-      ]
-    }
+            tag: 'string',
+          },
+        },
+      ],
+    },
   ]);
 });
 

--- a/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
@@ -22,7 +22,7 @@ test('should return early if there is no request body', () => {
   expect(operation.getRequestBodyExamples()).toStrictEqual([]);
 });
 
-test('should generate a request example for an operation with an undefined example value', async () => {
+test('should re-intialize the request examples after the oas is dereferenced', async () => {
   const webhookOperation = webhooksOas.operation('newPet', 'post', { isWebhook: true });
 
   expect(webhookOperation.getRequestBodyExamples()).toStrictEqual([

--- a/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
@@ -15,7 +15,6 @@ beforeAll(async () => {
   await petstore.dereference();
 
   webhooksOas = await import('@readme/oas-examples/3.1/json/webhooks.json').then(r => r.default).then(Oas.init);
-  await webhooksOas.dereference();
 });
 
 test('should return early if there is no request body', () => {
@@ -23,19 +22,21 @@ test('should return early if there is no request body', () => {
   expect(operation.getRequestBodyExamples()).toStrictEqual([]);
 });
 
-test('webhooks', () => {
+test('should generate a request example for an operation with an undefined example value', async () => {
   const webhookOperation = webhooksOas.operation('newPet', 'post', { isWebhook: true });
-  webhookOperation.requestBodyExamples = [
+
+  expect(webhookOperation.getRequestBodyExamples()).toStrictEqual([
     {
       mediaType: 'application/json',
       examples: [
         {
-          value: undefined,
+          value: undefined
         },
       ],
     },
-  ];
+  ]);
 
+  await webhooksOas.dereference();
   expect(webhookOperation.getRequestBodyExamples()).toStrictEqual([
     {
       mediaType: 'application/json',

--- a/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
@@ -30,7 +30,7 @@ test('should generate a request example for an operation with an undefined examp
       mediaType: 'application/json',
       examples: [
         {
-          value: undefined
+          value: undefined,
         },
       ],
     },

--- a/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-requestbody-examples.test.ts
@@ -5,6 +5,7 @@ import cleanStringify from '../../__fixtures__/json-stringify-clean.js';
 
 let operationExamples: Oas;
 let petstore: Oas;
+let webhooksOas: Oas;
 
 beforeAll(async () => {
   operationExamples = await import('../../__datasets__/operation-examples.json').then(r => r.default).then(Oas.init);
@@ -12,11 +13,41 @@ beforeAll(async () => {
 
   petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default).then(Oas.init);
   await petstore.dereference();
+
+  webhooksOas = await import('@readme/oas-examples/3.1/json/webhooks.json').then(r => r.default).then(Oas.init);
+  await webhooksOas.dereference();
 });
 
 test('should return early if there is no request body', () => {
   const operation = operationExamples.operation('/nothing', 'get');
   expect(operation.getRequestBodyExamples()).toStrictEqual([]);
+});
+
+test('webhooks', () => {
+  const webhookOperation = webhooksOas.operation('newPet', 'post', {isWebhook: true});
+  webhookOperation.requestBodyExamples = [
+    {
+      mediaType: 'application/json',
+      examples: [{
+        value: undefined
+      }],
+    },
+  ];
+
+  expect(webhookOperation.getRequestBodyExamples()).toStrictEqual([
+    {
+      mediaType: 'application/json',
+      examples: [
+        {
+          value: {
+            id: 0,
+            name: 'string',
+            tag: 'string'
+          }
+        }
+      ]
+    }
+  ]);
 });
 
 test('should support */* media types', () => {


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes
There is a weird case in our main repo where we initialize `Webhooks` with an empty `requestBodyExamples` with the following structure:
```
requestBodyExamples: [
  {
    mediaType: 'application/json',
    examples: [{
      value: undefined
    }],
  },
];
```

This causes `Operation.getRequestBodyExamples()` to return with an empty request example even though we should be creating an example for them. This adds an extra check so that we avoid returning the empty example and proceed to the subsequent `getRequestBodyExamples()` call that generates an example for the user.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
