### PR TITLE
chore: prevent tests from being run in subpackages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3394,7 +3394,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5896,7 +5895,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -5906,7 +5904,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7540,8 +7537,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -10228,8 +10224,7 @@
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -16333,7 +16328,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -20127,10 +20122,8 @@
         "@types/json-schema-merge-allof": "^0.6.5",
         "@types/memoizee": "^0.4.11",
         "@types/node": "^20.12.13",
-        "@vitest/coverage-v8": "^1.4.0",
         "tsup": "^8.0.2",
-        "typescript": "^5.4.4",
-        "vitest": "^1.4.0"
+        "typescript": "^5.4.4"
       },
       "engines": {
         "node": ">=18"
@@ -20150,12 +20143,10 @@
         "@readme/oas-examples": "^5.12.0",
         "@types/js-yaml": "^4.0.9",
         "@types/swagger2openapi": "^7.0.4",
-        "@vitest/coverage-v8": "^1.4.0",
         "eslint": "^8.57.0",
         "nock": "^14.0.0-beta.12",
         "tsup": "^8.0.2",
-        "typescript": "^5.1.6",
-        "vitest": "^1.4.0"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">=18"
@@ -20175,13 +20166,11 @@
         "@readme/oas-examples": "^5.12.0",
         "@types/har-format": "^1.2.15",
         "@types/qs": "^6.9.14",
-        "@vitest/coverage-v8": "^1.4.0",
         "eslint": "^8.57.0",
         "jest-expect-har": "^7.1.0",
         "tsup": "^8.0.2",
         "type-fest": "^4.18.3",
-        "typescript": "^5.2.2",
-        "vitest": "^1.4.0"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18"
@@ -20211,14 +20200,12 @@
         "@readme/oas-examples": "^5.12.0",
         "@types/har-format": "^1.2.14",
         "@types/node": "^20.8.7",
-        "@vitest/coverage-v8": "^1.4.0",
         "har-examples": "^3.1.1",
         "httpsnippet-client-api": "^7.0.0-beta.4",
         "oas": "file:../oas",
         "tsup": "^8.0.2",
         "type-fest": "^4.18.3",
-        "typescript": "^5.2.2",
-        "vitest": "^1.4.0"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19445,6 +19445,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
       "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "1.6.0",
         "@vitest/runner": "1.6.0",
@@ -20123,7 +20124,8 @@
         "@types/memoizee": "^0.4.11",
         "@types/node": "^20.12.13",
         "tsup": "^8.0.2",
-        "typescript": "^5.4.4"
+        "typescript": "^5.4.4",
+        "vitest": "^1.6.0"
       },
       "engines": {
         "node": ">=18"
@@ -20146,7 +20148,8 @@
         "eslint": "^8.57.0",
         "nock": "^14.0.0-beta.12",
         "tsup": "^8.0.2",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "vitest": "^1.6.0"
       },
       "engines": {
         "node": ">=18"
@@ -20170,7 +20173,8 @@
         "jest-expect-har": "^7.1.0",
         "tsup": "^8.0.2",
         "type-fest": "^4.18.3",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "vitest": "^1.6.0"
       },
       "engines": {
         "node": ">=18"
@@ -20205,7 +20209,8 @@
         "oas": "file:../oas",
         "tsup": "^8.0.2",
         "type-fest": "^4.18.3",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "vitest": "^1.6.0"
       },
       "engines": {
         "node": ">=18"

--- a/packages/oas-normalize/package.json
+++ b/packages/oas-normalize/package.json
@@ -59,7 +59,7 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "test": "vitest run --coverage"
+    "test": "echo 'Please run tests from the root!' && exit 1"
   },
   "license": "MIT",
   "dependencies": {
@@ -73,12 +73,10 @@
     "@readme/oas-examples": "^5.12.0",
     "@types/js-yaml": "^4.0.9",
     "@types/swagger2openapi": "^7.0.4",
-    "@vitest/coverage-v8": "^1.4.0",
     "eslint": "^8.57.0",
     "nock": "^14.0.0-beta.12",
     "tsup": "^8.0.2",
-    "typescript": "^5.1.6",
-    "vitest": "^1.4.0"
+    "typescript": "^5.1.6"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas-normalize/package.json
+++ b/packages/oas-normalize/package.json
@@ -76,7 +76,8 @@
     "eslint": "^8.57.0",
     "nock": "^14.0.0-beta.12",
     "tsup": "^8.0.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "vitest": "^1.6.0"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -62,7 +62,8 @@
     "jest-expect-har": "^7.1.0",
     "tsup": "^8.0.2",
     "type-fest": "^4.18.3",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^1.6.0"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -46,7 +46,7 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "test": "vitest run --coverage"
+    "test": "echo 'Please run tests from the root!' && exit 1"
   },
   "dependencies": {
     "@readme/data-urls": "^3.0.0",
@@ -58,13 +58,11 @@
     "@readme/oas-examples": "^5.12.0",
     "@types/har-format": "^1.2.15",
     "@types/qs": "^6.9.14",
-    "@vitest/coverage-v8": "^1.4.0",
     "eslint": "^8.57.0",
     "jest-expect-har": "^7.1.0",
     "tsup": "^8.0.2",
     "type-fest": "^4.18.3",
-    "typescript": "^5.2.2",
-    "vitest": "^1.4.0"
+    "typescript": "^5.2.2"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas-to-har/test/index.test.ts
+++ b/packages/oas-to-har/test/index.test.ts
@@ -1,4 +1,5 @@
 import type { Operation } from 'oas/operation';
+import type { OASDocument } from 'oas/types';
 
 import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 import toBeAValidHAR from 'jest-expect-har';
@@ -133,7 +134,7 @@ describe('oas-to-har', () => {
       let operation;
 
       beforeEach(function () {
-        variablesOas = new Oas(serverVariables);
+        variablesOas = new Oas(serverVariables as OASDocument);
         operation = variablesOas.operation('/', 'post');
       });
 

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -62,7 +62,8 @@
     "oas": "file:../oas",
     "tsup": "^8.0.2",
     "type-fest": "^4.18.3",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^1.6.0"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -47,7 +47,7 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "test": "vitest run --coverage"
+    "test": "echo 'Please run tests from the root!' && exit 1"
   },
   "dependencies": {
     "@readme/httpsnippet": "^10.1.0",
@@ -57,14 +57,12 @@
     "@readme/oas-examples": "^5.12.0",
     "@types/har-format": "^1.2.14",
     "@types/node": "^20.8.7",
-    "@vitest/coverage-v8": "^1.4.0",
     "har-examples": "^3.1.1",
     "httpsnippet-client-api": "^7.0.0-beta.4",
     "oas": "file:../oas",
     "tsup": "^8.0.2",
     "type-fest": "^4.18.3",
-    "typescript": "^5.2.2",
-    "vitest": "^1.4.0"
+    "typescript": "^5.2.2"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -84,7 +84,7 @@
     "lint:types": "tsc --noEmit",
     "prebuild": "rm -rf dist/",
     "prepack": "npm run build",
-    "test": "vitest run --coverage",
+    "test": "echo 'Please run tests from the root!' && exit 1",
     "watch": "tsc --watch"
   },
   "dependencies": {
@@ -105,10 +105,8 @@
     "@types/json-schema-merge-allof": "^0.6.5",
     "@types/memoizee": "^0.4.11",
     "@types/node": "^20.12.13",
-    "@vitest/coverage-v8": "^1.4.0",
     "tsup": "^8.0.2",
-    "typescript": "^5.4.4",
-    "vitest": "^1.4.0"
+    "typescript": "^5.4.4"
   },
   "prettier": "@readme/eslint-config/prettier"
 }

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -106,7 +106,8 @@
     "@types/memoizee": "^0.4.11",
     "@types/node": "^20.12.13",
     "tsup": "^8.0.2",
-    "typescript": "^5.4.4"
+    "typescript": "^5.4.4",
+    "vitest": "^1.6.0"
   },
   "prettier": "@readme/eslint-config/prettier"
 }


### PR DESCRIPTION
## 🧰 Changes

This repo is a bit weird in that we need to build the dists before running our test suite, so running tests from the subpackages might result in confusing errors. This PR makes it so we have a bit of a nicer error in case of that.
