### PR TITLE
fix: correctly handle `nullable: false`

### DIFF
--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -432,10 +432,12 @@ export function toJSONSchema(data: RMOAS.SchemaObject | boolean, opts: toJSONSch
     // `nullable` isn't a thing in JSON Schema but it was in OpenAPI 3.0 so we should retain and
     // translate it into something that's compatible with JSON Schema.
     if ('nullable' in schema) {
-      if (Array.isArray(schema.type)) {
-        schema.type.push('null');
-      } else if (schema.type !== null && schema.type !== 'null') {
-        schema.type = [schema.type, 'null'];
+      if (schema.nullable) {
+        if (Array.isArray(schema.type)) {
+          schema.type.push('null');
+        } else if (schema.type !== null && schema.type !== 'null') {
+          schema.type = [schema.type, 'null'];
+        }
       }
 
       delete schema.nullable;

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -222,6 +222,23 @@ describe('`type` support', () => {
         });
       });
 
+      it('should correctly handle `nullable: false`', () => {
+        expect(
+          toJSONSchema({
+            type: 'object',
+            properties: {
+              buster: {
+                type: 'string',
+                nullable: false,
+              },
+            },
+          }),
+        ).toStrictEqual({
+          type: 'object',
+          properties: { buster: { type: 'string' } },
+        });
+      });
+
       it('should not duplicate `null` into a schema type', () => {
         expect(toJSONSchema({ type: ['string', 'null'], nullable: true })).toStrictEqual({
           type: ['string', 'null'],


### PR DESCRIPTION
| 🚥 Resolves RM-11473 |
| :------------------- |

## 🧰 Changes
Currently, if a schema has `nullable: false`, (idk why since it defaults to false? maybe some tooling explicitly defines it as such) we aren't properly handling it as we're only checking for the existence of a `nullable` property. 

I added a condition to only add the `null` type if `nullable: true`. If it's `false`, we don't want to do anything with it, but we still want to delete it so it doesn't show up in the schema. Added a test too. 


## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
