### PR TITLE
feat(oas): adding support for common parameter detection to the analyzer

### DIFF
--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -119,8 +119,8 @@ Because this library has full TypeScript types and docblocks this README is not 
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `.getExtension()` | Retrieve a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) if it exists at the root of the API definition.  |
-| `.hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) exists on the root of the API definition. |
+| `.getExtension()` | Retrieve a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions) if it exists at the root of the API definition.  |
+| `.hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions) exists on the root of the API definition. |
 | `.validateExtension()` | Determine if a given [ReadMe custom OpenAPI extension](https://docs.readme.com/docs/openapi-extensions) is valid or not. |
 | `.validateExtensions()` | Validate all of our [ReadMe custom OpenAPI extension](https://docs.readme.com/docs/openapi-extensions), throwing exceptions when necessary. |
 <!-- prettier-ignore-end -->
@@ -153,7 +153,7 @@ const operation = petstore.operation('/pet', 'post');
 | Method | Description |
 | :--- | :--- |
 | `.getContentType()` | Retrieve the primary request body content type. If multiple are present, prefer whichever is JSON-compliant. |
-| `.getDescription()` | Retrieve the `description` that's set on this operation. This supports common descriptions that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |
+| `.getDescription()` | Retrieve the `description` that's set on this operation. This supports common descriptions that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object). |
 | `.getOperationId()` | Retrieve the `operationId` that's present on the operation, and if one is not present one will be created based off the method + path and returned instead. |
 | `.hasOperationId()` | Determine if the operation has an `operationId` present. |
 | `.isDeprecated()` | Determine if this operation is marked as deprecated. |
@@ -164,8 +164,8 @@ const operation = petstore.operation('/pet', 'post');
 | `.isWebhook()` | Determine if this operation is an instance of the `Webhook` class. |
 | `.getExampleGroups()` | Returns an object with groups of all example definitions (body/header/query/path/response/etc.). The examples are grouped by their key when defined via the `examples` map. |
 | `.getHeaders()` | Retrieve all headers that can either be sent for or returned from this operation. This includes header-based authentication schemes, common header parameters, and request body and response content types. |
-| `.getSummary()` | Retrieve the `summary` that's set on this operation. This supports common summaries that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject). |
-| `.getTags()` | Retrieve all tags, and [their metadata](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#tagObject), that exist on this operation. |
+| `.getSummary()` | Retrieve the `summary` that's set on this operation. This supports common summaries that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object). |
+| `.getTags()` | Retrieve all tags, and [their metadata](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#tag-object), that exist on this operation. |
 <!-- prettier-ignore-end -->
 
 #### Callbacks
@@ -182,7 +182,7 @@ const operation = petstore.operation('/pet', 'post');
 #### Parameters
 
 > [!NOTE]
-> All parameter accessors here support, and will automatically retrieve and handle, common parameters that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject).
+> All parameter accessors here support, and will automatically retrieve and handle, common parameters that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object).
 
 <!-- prettier-ignore-start -->
 | Method | Description |
@@ -231,14 +231,14 @@ const operation = petstore.operation('/pet', 'post');
 <!-- prettier-ignore-start -->
 | Method | Description |
 | :--- | :--- |
-| `.hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions) exists on this operation. |
+| `.hasExtension()` | Determine if a given [specification extension](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions) exists on this operation. |
 <!-- prettier-ignore-end -->
 
 Information about ReadMe's supported OpenAPI extensions at https://docs.readme.com/docs/openapi-extensions.
 
 ### Callbacks
 
-The `Callback` class inherits `Operation` so every API available on instances of `Operation` is available here too. Much like `Operation`, we also support common parameters, summaries, and descriptions that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject) within a `callbacks` definition.
+The `Callback` class inherits `Operation` so every API available on instances of `Operation` is available here too. Much like `Operation`, we also support common parameters, summaries, and descriptions that may be set at the [path item level](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object) within a `callbacks` definition.
 
 #### General
 
@@ -285,6 +285,7 @@ console.log(await analyzer(petstore));
 | `additionalProperties` | Does your API use `additionalProperties`? |
 | `callbacks` | Does your API use [callbacks](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object)? |
 | `circularRefs` | Does your API have any circular `$ref` pointers, and if so where are they located? |
+| `commonParameters` | Does your API utilize [common parameters](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object)? |
 | `discriminators` | Does your API use polymorphic [discriminators](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object)? |
 | `links` | Does your API use [links](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object)? |
 | `style` | Do any parameters in your API require [style](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#user-content-parameterstyle) serialization?

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -14,6 +14,7 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
   const additionalProperties = OPENAPI_QUERIES.additionalProperties(definition);
   const callbacks = OPENAPI_QUERIES.callbacks(definition);
   const circularRefs = await OPENAPI_QUERIES.circularRefs(definition);
+  const commonParameters = OPENAPI_QUERIES.commonParameters(definition);
   const discriminators = OPENAPI_QUERIES.discriminators(definition);
   const links = OPENAPI_QUERIES.links(definition);
   const parameterSerialization = OPENAPI_QUERIES.parameterSerialization(definition);
@@ -59,6 +60,10 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
       circularRefs: {
         present: !!circularRefs.length,
         locations: circularRefs,
+      },
+      commonParameters: {
+        present: !!commonParameters.length,
+        locations: commonParameters,
       },
       discriminators: {
         present: !!discriminators.length,

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -16,8 +16,8 @@ export function additionalProperties(definition: OASDocument) {
 /**
  * Determine if a given API definition utilizes `callbacks`.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callbackObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object}
  */
 export function callbacks(definition: OASDocument) {
   return query(['$.components.callbacks', '$.paths..callbacks'], definition).map(res => refizePointer(res.pointer));
@@ -43,10 +43,20 @@ export async function circularRefs(definition: OASDocument) {
 }
 
 /**
+ * Determine if a given API definition utilizes common parameters.
+ *
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object}
+ */
+export function commonParameters(definition: OASDocument) {
+  return query(['$..paths[*].parameters'], definition).map(res => refizePointer(res.pointer));
+}
+
+/**
  * Determine if a given API definition utilizes discriminators.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminatorObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminatorObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminator-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object}
  */
 export function discriminators(definition: OASDocument) {
   return query(['$..discriminator'], definition).map(res => refizePointer(res.pointer));
@@ -55,8 +65,8 @@ export function discriminators(definition: OASDocument) {
 /**
  * Determine if a given API definition utilizes `links`.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#linkObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#linkObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#link-object}
  */
 export function links(definition: OASDocument) {
   return query(['$..links'], definition).map(res => refizePointer(res.pointer));
@@ -114,8 +124,8 @@ export function polymorphism(definition: OASDocument) {
 /**
  * Determine every kind of security type that a given API definition has documented.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#securitySchemeObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#securitySchemeObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-scheme-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object}
  */
 export function securityTypes(definition: OASDocument) {
   return Array.from(new Set(query(['$.components.securitySchemes..type'], definition).map(res => res.value as string)));
@@ -124,8 +134,8 @@ export function securityTypes(definition: OASDocument) {
 /**
  * Determine if a given API definition utilizes server variables.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverVariableObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverVariableObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object}
  */
 export function serverVariables(definition: OASDocument) {
   return query(['$.servers..variables^'], definition).map(res => refizePointer(res.pointer));
@@ -134,8 +144,8 @@ export function serverVariables(definition: OASDocument) {
 /**
  * Determine how many operations are defined in a given API definition.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operation-object}
  */
 export function totalOperations(definition: OASDocument) {
   return query(['$..paths[*]'], definition)
@@ -146,7 +156,7 @@ export function totalOperations(definition: OASDocument) {
 /**
  * Determine if a given API definition utilizes `webhooks` support in OpenAPI 3.1.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasWebhooks}
  */
 export function webhooks(definition: OASDocument) {
   return query(['$.webhooks[*]'], definition).map(res => refizePointer(res.pointer));
@@ -156,8 +166,8 @@ export function webhooks(definition: OASDocument) {
  * Determine if a given API definition has XML schemas, payloads, or responses.
  *
  * @todo detect `+xml` media types
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xmlObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xmlObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xml-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object}
  */
 export function xml(definition: OASDocument) {
   return query(

--- a/packages/oas/src/analyzer/types.ts
+++ b/packages/oas/src/analyzer/types.ts
@@ -18,6 +18,7 @@ export interface OASAnalysis {
     additionalProperties: OASAnalysisFeature;
     callbacks: OASAnalysisFeature;
     circularRefs: OASAnalysisFeature;
+    commonParameters: OASAnalysisFeature;
     discriminators: OASAnalysisFeature;
     links: OASAnalysisFeature;
     polymorphism: OASAnalysisFeature;

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -152,8 +152,8 @@ function normalizePath(path: string) {
 /**
  * Generate path matches for a given path and origin on a set of OpenAPI path objects.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#pathsObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathsObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paths-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#paths-object}
  * @param paths The OpenAPI Paths Object to process.
  * @param pathName Path to look for a match.
  * @param origin The origin that we're matching against.
@@ -740,7 +740,7 @@ export default class Oas {
    * Returns the `paths` object that exists in this API definition but with every `method` mapped
    * to an instance of the `Operation` class.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#openapi-object}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    */
   getPaths() {
@@ -748,7 +748,7 @@ export default class Oas {
      * Because a path doesn't need to contain a keyed-object of HTTP methods, we should exclude
      * anything from within the paths object that isn't a known HTTP method.
      *
-     * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-7}
+     * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#fixed-fields-7}
      * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-7}
      */
     const paths: Record<string, Record<RMOAS.HttpMethods, Operation | Webhook>> = {};
@@ -781,7 +781,7 @@ export default class Oas {
    * Returns the `webhooks` object that exists in this API definition but with every `method`
    * mapped to an instance of the `Webhook` class.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#openapi-object}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    */
   getWebhooks() {
@@ -801,7 +801,7 @@ export default class Oas {
   /**
    * Return an array of all tag names that exist on this API definition.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#oasObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#openapi-object}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    * @param setIfMissing If a tag is not present on an operation that operations path will be added
    *    into the list of tags returned.
@@ -876,8 +876,8 @@ export default class Oas {
   /**
    * Determine if a given a custom specification extension exists within the API definition.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    */
   hasExtension(extension: string) {
@@ -887,8 +887,8 @@ export default class Oas {
   /**
    * Retrieve a custom specification extension off of the API definition.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    */
   getExtension(extension: string | keyof Extensions, operation?: Operation) {
@@ -899,8 +899,8 @@ export default class Oas {
    * Determine if a given OpenAPI custom extension is valid or not.
    *
    * @see {@link https://docs.readme.com/docs/openapi-extensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to validate.
    * @throws
    */
@@ -955,8 +955,8 @@ export default class Oas {
    * Validate all of our custom or known OpenAPI extensions, throwing exceptions when necessary.
    *
    * @see {@link https://docs.readme.com/docs/openapi-extensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    */
   validateExtensions() {
     Object.keys(extensionDefaults).forEach((extension: keyof Extensions) => {

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -250,8 +250,8 @@ function searchForValueByPropAndPointer(
  *
  * @todo add support for `schema: false` and `not` cases.
  * @see {@link https://json-schema.org/draft/2019-09/json-schema-validation.html}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  * @param data OpenAPI Schema Object to convert to pure JSON Schema.
  */
 export function toJSONSchema(data: RMOAS.SchemaObject | boolean, opts: toJSONSchemaOptions = {}): RMOAS.SchemaObject {

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -181,7 +181,7 @@ export class Operation {
    *
    * @see {@link https://swagger.io/docs/specification/authentication/#multiple}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#securityRequirementObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-requirement-object}
    * @param filterInvalid Optional flag that, when set to `true`, filters out invalid/nonexistent
    *    security schemes, rather than returning `false`.
    */
@@ -595,8 +595,8 @@ export class Operation {
   /**
    * Retrieve the list of all available media types that the operations request body can accept.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
    */
   getRequestBodyMediaTypes() {
     if (!this.hasRequestBody()) {
@@ -652,8 +652,8 @@ export class Operation {
    * comes back it's in the form of an array with the first key being the selected media type,
    * followed by the media type object in question.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
    * @param mediaType Specific request body media type to retrieve if present.
    */
   getRequestBody(mediaType?: string): RMOAS.MediaTypeObject | false | [string, RMOAS.MediaTypeObject, ...string[]] {
@@ -769,8 +769,8 @@ export class Operation {
   /**
    * Retrieve a specific callback.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callbackObject}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object}
    * @param identifier Callback identifier to look for.
    * @param expression Callback expression to look for.
    * @param method HTTP Method on the callback to look for.
@@ -835,8 +835,8 @@ export class Operation {
   /**
    * Determine if a given a custom specification extension exists within the operation.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    */
   hasExtension(extension: string) {
@@ -846,8 +846,8 @@ export class Operation {
   /**
    * Retrieve a custom specification extension off of the operation.
    *
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specificationExtensions}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    *
    * @deprecated Use `oas.getExtension(extension, operation)` instead.
@@ -907,7 +907,7 @@ export class Callback extends Operation {
    * Return the primary identifier for this callback.
    *
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
-   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject}
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object}
    */
   getIdentifier(): string {
     return this.identifier;

--- a/packages/oas/src/operation/lib/get-mediatype-examples.ts
+++ b/packages/oas/src/operation/lib/get-mediatype-examples.ts
@@ -15,8 +15,8 @@ export interface MediaTypeExample {
  * come from the `example` property, the first item in an `examples` array, or if none of those are
  * present it will generate an example based off its schema.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#mediaTypeObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
  * @param mediaType The media type that we're looking for examples for.
  * @param mediaTypeObject The media type object that we're looking for examples for.
  */

--- a/packages/oas/src/operation/lib/get-parameters-as-json-schema.ts
+++ b/packages/oas/src/operation/lib/get-parameters-as-json-schema.ts
@@ -22,8 +22,8 @@ export interface SchemaWrapper {
  * The order of this object determines how they will be sorted in the compiled JSON Schema
  * representation.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameterObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object}
  */
 export const types: Record<keyof OASDocument, string> = {
   path: 'Path Params',

--- a/packages/oas/src/operation/lib/get-response-as-json-schema.ts
+++ b/packages/oas/src/operation/lib/get-response-as-json-schema.ts
@@ -16,12 +16,12 @@ import { toJSONSchema, getSchemaVersionString } from '../../lib/openapi-to-json-
 const isJSON = matches.json;
 
 /**
- * Turn a header map from OpenAPI 3.0.3 (and some earlier versions too) into a schema.
+ * Turn a header map from OpenAPI 3.0 (and some earlier versions too) into a schema.
  *
- * Note: This does not support OpenAPI 3.1.0's header format.
+ * Note: This does not support OpenAPI 3.1's header format.
  *
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#headerObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.3.md#headerObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#header-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.3.md#header-object}
  * @param response Response object to build a JSON Schema object for its headers for.
  */
 function buildHeadersSchema(

--- a/packages/oas/src/types.ts
+++ b/packages/oas/src/types.ts
@@ -70,8 +70,8 @@ export type HttpMethods =
 // These are organized by how they're defined in the OpenAPI Specification.
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#openapi-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
  */
 // eslint-disable-next-line @typescript-eslint/sort-type-constituents
 export type OASDocument = (OpenAPIV3_1.Document | OpenAPIV3.Document) &
@@ -83,14 +83,14 @@ export type OAS31Document = OpenAPIV3_1.Document &
   Record<string, unknown>;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-object}
  */
 export type ServerObject = OpenAPIV3_1.ServerObject | OpenAPIV3.ServerObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverVariableObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverVariableObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object}
  */
 export type ServerVariableObject = OpenAPIV3_1.ServerVariableObject | OpenAPIV3.ServerVariableObject;
 export type ServerVariablesObject = Record<string, ServerVariableObject>;
@@ -105,26 +105,26 @@ export interface Servers {
 }
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#componentsObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#componentsObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#components-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#components-object}
  */
 export type ComponentsObject = OpenAPIV3_1.ComponentsObject | OpenAPIV3.ComponentsObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#pathsObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathsObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paths-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#paths-object}
  */
 export type PathsObject = OpenAPIV3_1.PathsObject | OpenAPIV3.PathsObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#pathItemObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathItemObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object}
  */
 export type PathItemObject = OpenAPIV3_1.PathItemObject | OpenAPIV3.PathItemObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operationObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operationObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operation-object}
  */
 // eslint-disable-next-line @typescript-eslint/sort-type-constituents
 export type OperationObject = (OpenAPIV3_1.OperationObject | OpenAPIV3.OperationObject) &
@@ -132,58 +132,58 @@ export type OperationObject = (OpenAPIV3_1.OperationObject | OpenAPIV3.Operation
   Record<string, unknown>;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object}
  */
 export type ParameterObject = {
   in: 'cookie' | 'header' | 'path' | 'query';
 } & (OpenAPIV3_1.ParameterObject | OpenAPIV3.ParameterObject);
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#requestBodyObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#requestBodyObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#request-body-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#request-body-object}
  */
 export type RequestBodyObject = OpenAPIV3_1.RequestBodyObject | OpenAPIV3.RequestBodyObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#mediaTypeObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
  */
 export type MediaTypeObject = OpenAPIV3_1.MediaTypeObject | OpenAPIV3.MediaTypeObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responseObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#responseObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#response-object}
  */
 export type ResponseObject = OpenAPIV3_1.ResponseObject | OpenAPIV3.ResponseObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callbackObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object}
  */
 export type CallbackObject = OpenAPIV3_1.CallbackObject | OpenAPIV3.CallbackObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.3.md#exampleObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#example-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.3.md#example-object}
  */
 export type ExampleObject = OpenAPIV3_1.ExampleObject | OpenAPIV3.ExampleObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#tagObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#tagObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#tag-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#tag-object}
  */
 export type TagObject = OpenAPIV3_1.TagObject | OpenAPIV3.TagObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#headerObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#headerObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#header-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#header-object}
  */
 export type HeaderObject = OpenAPIV3_1.HeaderObject | OpenAPIV3.HeaderObject;
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
 export type SchemaObject = {
   // OpenAPI-specific properties
@@ -229,8 +229,8 @@ export function isSchema(check: unknown, isPolymorphicAllOfChild = false): check
 }
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#securitySchemeObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#securitySchemeObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-scheme-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object}
  */
 export type SecuritySchemeObject = OpenAPIV3_1.SecuritySchemeObject | OpenAPIV3.SecuritySchemeObject;
 
@@ -254,7 +254,7 @@ export type KeyedSecuritySchemeObject = SecuritySchemeObject & {
 };
 
 /**
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#securityRequirementObject}
- * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#securityRequirementObject}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-requirement-object}
  */
 export type SecurityRequirementObject = OpenAPIV3_1.SecurityRequirementObject | OpenAPIV3.SecurityRequirementObject;

--- a/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
@@ -39,6 +39,10 @@ exports[`analyzer > should should analyzer an OpenAPI definition 1`] = `
       "locations": [],
       "present": false,
     },
+    "commonParameters": {
+      "locations": [],
+      "present": false,
+    },
     "discriminators": {
       "locations": [],
       "present": false,

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -12,6 +12,7 @@ describe('analyzer queries (OpenAPI)', () => {
   let additionalProperties: OASDocument;
   let callbacks: OASDocument;
   let circular: OASDocument;
+  let commonParameters: OASDocument;
   let complexNesting: OASDocument;
   let discriminators: OASDocument;
   let links: OASDocument;
@@ -28,6 +29,7 @@ describe('analyzer queries (OpenAPI)', () => {
     );
     complexNesting = await import('@readme/oas-examples/3.0/json/complex-nesting.json').then(loadSpec);
     callbacks = await import('@readme/oas-examples/3.0/json/callbacks.json').then(loadSpec);
+    commonParameters = await import('@readme/oas-examples/3.0/json/parameters-common.json').then(loadSpec);
     discriminators = await import('@readme/oas-examples/3.0/json/discriminators.json').then(loadSpec);
     links = await import('@readme/oas-examples/3.0/json/link-example.json').then(loadSpec);
     petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(loadSpec);
@@ -94,6 +96,21 @@ describe('analyzer queries (OpenAPI)', () => {
 
     it("should not find where it doesn't exist", async () => {
       await expect(QUERIES.circularRefs(readme)).resolves.toHaveLength(0);
+    });
+  });
+
+  describe('commonParameters', () => {
+    it('should discover common parameters usage within a definition that has it', () => {
+      expect(QUERIES.commonParameters(commonParameters)).toStrictEqual([
+        '#/paths/~1anything~1{id}/parameters',
+        '#/paths/~1anything~1{id}~1override/parameters',
+        '#/paths/~1anything~1{id}~1{action}/parameters',
+        '#/paths/~1anything~1{id}~1{action}~1{id}/parameters',
+      ]);
+    });
+
+    it("should not find where it doesn't exist", () => {
+      expect(QUERIES.commonParameters(readme)).toHaveLength(0);
     });
   });
 

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -716,7 +716,7 @@ describe('#getSecurityWithTypes()', () => {
   });
 });
 
-// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject
+// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#security-scheme-object
 describe('#prepareSecurity()', () => {
   const path = '/auth';
   const method = 'get';
@@ -725,7 +725,7 @@ describe('#prepareSecurity()', () => {
    * @param schemes SecurtiySchemesObject to create a test API definition for.
    */
   function createSecurityOas(schemes: RMOAS.SecuritySchemesObject): Oas {
-    // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securityRequirementObject
+    // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#security-requirement-object
     const security = Object.keys(schemes).map(scheme => {
       return { [scheme]: [] };
     });

--- a/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
@@ -174,7 +174,7 @@ describe('`enum` handling', () => {
 });
 
 describe('`headers` support', () => {
-  // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responseObject
+  // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object
   it('should include headers if they exist', () => {
     const oas = createOasForOperation({
       responses: {


### PR DESCRIPTION
## 🧰 Changes

This adds support to `oas/analyzer` for surfacing information on if a given API definition utilizes [common parameters](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object).

I've also gone through and updated a bunch of bad deep links to parts of the OAS. Would be nice if the OAI would stop breaking these deep links every couple of years.