### PR TITLE
fix(oas-normalize): support for basic auth in url strings

### DIFF
--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -63,7 +63,8 @@ export default class OASNormalize {
         return resolve(this.file.toString());
 
       case 'url':
-        const resp = await fetch(utils.normalizeURL(this.file)).then(res => res.text());
+        const { url, options } = utils.prepareURL(this.file);
+        const resp = await fetch(url, options).then(res => res.text());
         return resolve(resp);
 
       case 'path':

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -16,8 +16,8 @@ describe('#load', () => {
     ['OpenAPI 3.0', '3.0'],
     ['OpenAPI 3.1', '3.1'],
   ])('%s support', (_, version) => {
-    let json;
-    let yaml;
+    let json: Record<string, unknown>;
+    let yaml: string;
 
     beforeEach(async () => {
       json = await import(`@readme/oas-examples/${version}/json/petstore.json`).then(r => r.default);
@@ -63,6 +63,20 @@ describe('#load', () => {
         nock('https://example.com').get(`/api-${version}.json`).reply(200, json);
 
         const o = new OASNormalize(`https://example.com/api-${version}.json`);
+
+        await expect(o.load()).resolves.toStrictEqual(json);
+      });
+
+      it('should support URLs with basic auth', async () => {
+        nock('https://@example.com', {
+          reqheaders: {
+            Authorization: `Basic ${btoa('username:password')}`,
+          },
+        })
+          .get(`/api-${version}.json`)
+          .reply(200, json);
+
+        const o = new OASNormalize(`https://username:password@example.com/api-${version}.json`);
 
         await expect(o.load()).resolves.toStrictEqual(json);
       });


### PR DESCRIPTION
| 🚥 Resolves https://github.com/readmeio/rdme/issues/1152 |
| :------------------- |

## 🧰 Changes

When we moved `oas-normalize` off `node-fetch` and to native `fetch` we lost the ability to supply basic auth credentials directly in the URL string as `fetch` doesn't support that.