### PR TITLE
refactor: modern TS touchups

### DIFF
--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -95,7 +95,7 @@ export default class OASNormalize {
    * Bundle up the given API definition, resolving any external `$ref` pointers in the process.
    *
    */
-  async bundle() {
+  async bundle(): Promise<OpenAPI.Document> {
     if (this.cache.bundle) return this.cache.bundle;
 
     return this.load()
@@ -120,7 +120,7 @@ export default class OASNormalize {
    * Dereference the given API definition.
    *
    */
-  async deref() {
+  async deref(): Promise<OpenAPI.Document> {
     if (this.cache.deref) return this.cache.deref;
 
     return this.load()

--- a/packages/oas-normalize/src/lib/utils.ts
+++ b/packages/oas-normalize/src/lib/utils.ts
@@ -4,7 +4,7 @@ import YAML, { JSON_SCHEMA } from 'js-yaml';
  * Determine if a given variable is a `Buffer`.
  *
  */
-export function isBuffer(obj: any) {
+export function isBuffer(obj: any): boolean {
   return (
     obj != null &&
     obj.constructor != null &&
@@ -17,7 +17,7 @@ export function isBuffer(obj: any) {
  * Deconstruct a URL into a payload for a `fetch` request.
  *
  */
-export function prepareURL(url: string) {
+export function prepareURL(url: string): { options: RequestInit; url: string } {
   const options: RequestInit = {};
   const u = new URL(url);
 
@@ -48,7 +48,7 @@ export function prepareURL(url: string) {
  * Determine the type of a given variable. Returns `false` if unrecognized.
  *
  */
-export function getType(obj: any) {
+export function getType(obj: any): 'buffer' | 'json' | 'path' | 'string-json' | 'string-yaml' | 'url' | false {
   if (isBuffer(obj)) {
     return 'buffer';
   } else if (typeof obj === 'object') {
@@ -73,7 +73,7 @@ export function getType(obj: any) {
  * Determine if a given schema if an OpenAPI definition.
  *
  */
-export function isOpenAPI(schema: Record<string, unknown>) {
+export function isOpenAPI(schema: Record<string, unknown>): boolean {
   return !!schema.openapi;
 }
 
@@ -96,7 +96,7 @@ export function isPostman(schema: Record<string, unknown>): boolean {
  * Determine if a given schema if an Swagger definition.
  *
  */
-export function isSwagger(schema: Record<string, unknown>) {
+export function isSwagger(schema: Record<string, unknown>): boolean {
   return !!schema.swagger;
 }
 
@@ -119,7 +119,7 @@ export function stringToJSON(string: Record<string, unknown> | string): Record<s
  * Determine if a given schema is an API definition that we can support.
  *
  */
-export function isAPIDefinition(schema: Record<string, unknown>) {
+export function isAPIDefinition(schema: Record<string, unknown>): boolean {
   return isOpenAPI(schema) || isPostman(schema) || isSwagger(schema);
 }
 
@@ -127,7 +127,7 @@ export function isAPIDefinition(schema: Record<string, unknown>) {
  * Retrieve the type of API definition that a given schema is.
  *
  */
-export function getAPIDefinitionType(schema: Record<string, unknown>) {
+export function getAPIDefinitionType(schema: Record<string, unknown>): 'openapi' | 'postman' | 'swagger' | 'unknown' {
   if (isOpenAPI(schema)) {
     return 'openapi';
   } else if (isPostman(schema)) {

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -223,7 +223,15 @@ export default function oasToHar(
   values: DataForHAR = {},
   auth: AuthForHAR = {},
   opts: oasToHarOptions = { proxyUrl: '' },
-) {
+): {
+  log: {
+    entries: readonly [
+      {
+        readonly request: Request;
+      },
+    ];
+  };
+} {
   let operation: Operation;
   if (!operationSchema || typeof operationSchema.getParameters !== 'function') {
     /**
@@ -631,7 +639,7 @@ export default function oasToHar(
         {
           request: har,
         },
-      ],
+      ] as const,
     },
   };
 }

--- a/packages/oas-to-har/src/lib/configure-security.ts
+++ b/packages/oas-to-har/src/lib/configure-security.ts
@@ -3,12 +3,19 @@ import type { OASDocument, SecuritySchemeObject } from 'oas/types';
 
 import { isRef } from 'oas/types';
 
-function harValue(type: 'cookies' | 'headers' | 'queryString', value: { name: string; value: string }) {
+function harValue(
+  type: 'cookies' | 'headers' | 'queryString',
+  value: { name: string; value: string },
+): { type: typeof type; value: typeof value } | undefined {
   if (!value.value) return undefined;
   return { type, value };
 }
 
-export default function configureSecurity(apiDefinition: OASDocument, values: AuthForHAR, scheme: string) {
+export default function configureSecurity(
+  apiDefinition: OASDocument,
+  values: AuthForHAR,
+  scheme: string,
+): ReturnType<typeof harValue> | false | undefined {
   if (!scheme) return undefined;
 
   if (Object.keys(values || {}).length === 0) return undefined;

--- a/packages/oas-to-har/src/lib/style-formatting/index.ts
+++ b/packages/oas-to-har/src/lib/style-formatting/index.ts
@@ -226,7 +226,7 @@ function shouldExplode(parameter: ParameterObject) {
   );
 }
 
-export default function formatStyle(value: unknown, parameter: ParameterObject) {
+export default function formatStyle(value: unknown, parameter: ParameterObject): any {
   // Deep object style only works on objects and arrays, and only works with explode=true.
   if (parameter.style === 'deepObject' && (!value || typeof value !== 'object' || parameter.explode === false)) {
     return undefined;

--- a/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
+++ b/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
@@ -40,7 +40,7 @@ export function encodeDisallowedCharacters(
     returnIfEncoded?: boolean;
   } = {},
   parse?: boolean,
-) {
+): any {
   if (typeof str === 'number') {
     str = (str as number).toString();
   }
@@ -98,7 +98,7 @@ export interface StylizerConfig {
   value: any;
 }
 
-export function stylize(config: StylizerConfig) {
+export function stylize(config: StylizerConfig): any {
   const { value } = config;
 
   if (Array.isArray(value)) {

--- a/packages/oas-to-har/src/lib/types.ts
+++ b/packages/oas-to-har/src/lib/types.ts
@@ -1,6 +1,4 @@
-export type AuthForHAR = Record<string, number | string | { pass?: string; user?: string }>;
-
-export type { DataForHAR } from 'oas/types';
+export type { AuthForHAR, DataForHAR } from 'oas/types';
 
 export interface oasToHarOptions {
   /**

--- a/packages/oas-to-har/src/lib/types.ts
+++ b/packages/oas-to-har/src/lib/types.ts
@@ -1,6 +1,6 @@
 export type AuthForHAR = Record<string, number | string | { pass?: string; user?: string }>;
 
-export { DataForHAR } from 'oas/types';
+export type { DataForHAR } from 'oas/types';
 
 export interface oasToHarOptions {
   /**

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -9,7 +9,7 @@ import { get } from './lodash.js';
 export function hasSchemaType(
   schema: SchemaObject,
   discriminator: 'array' | 'boolean' | 'integer' | 'null' | 'number' | 'object' | 'string',
-) {
+): boolean {
   if (Array.isArray(schema.type)) {
     return schema.type.includes(discriminator);
   }
@@ -24,7 +24,7 @@ export function hasSchemaType(
  * represented in the HAR that we generate.
  *
  */
-export function getSafeRequestBody(obj: any) {
+export function getSafeRequestBody(obj: any): any {
   if ('oneOf' in obj) {
     return getSafeRequestBody(obj.oneOf[0]);
   } else if ('anyOf' in obj) {

--- a/packages/oas-to-snippet/src/languages.ts
+++ b/packages/oas-to-snippet/src/languages.ts
@@ -256,7 +256,7 @@ export function getSupportedLanguages(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     plugins?: ClientPlugin<any>[];
   } = { plugins: [] },
-) {
+): SupportedLanguages {
   // eslint-disable-next-line try-catch-failsafe/json-parse
   const languages: SupportedLanguages = JSON.parse(JSON.stringify(DEFAULT_LANGUAGES));
 
@@ -291,7 +291,14 @@ export function getSupportedLanguages(
   return languages;
 }
 
-export function getLanguageConfig(languages: SupportedLanguages, lang: Language) {
+export function getLanguageConfig(
+  languages: SupportedLanguages,
+  lang: Language,
+): {
+  config: LanguageConfig | undefined;
+  language: TargetId | undefined;
+  target: ClientId | undefined;
+} {
   let config: LanguageConfig | undefined;
   let language: TargetId | undefined;
   let target: ClientId | undefined;
@@ -334,7 +341,7 @@ export function getClientInstallationInstructions(
    * @example @developers/v2.0#17273l2glm9fq4l5
    */
   registryIdentifier?: string,
-) {
+): string | undefined {
   const { config, target } = getLanguageConfig(languages, lang);
 
   const install = config?.httpsnippet.targets[target || '']?.install;

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -9,7 +9,7 @@ import { query, refizePointer } from '../util.js';
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
-export function additionalProperties(definition: OASDocument) {
+export function additionalProperties(definition: OASDocument): string[] {
   return query(['$..additionalProperties'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -19,7 +19,7 @@ export function additionalProperties(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object}
  */
-export function callbacks(definition: OASDocument) {
+export function callbacks(definition: OASDocument): string[] {
   return query(['$.components.callbacks', '$.paths..callbacks'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -29,7 +29,7 @@ export function callbacks(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
-export async function circularRefs(definition: OASDocument) {
+export async function circularRefs(definition: OASDocument): Promise<string[]> {
   // Dereferencing will update the passed in variable, which we don't want to do, so we
   // instantiated `Oas` with a clone.
   // eslint-disable-next-line try-catch-failsafe/json-parse
@@ -48,7 +48,7 @@ export async function circularRefs(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object}
  */
-export function commonParameters(definition: OASDocument) {
+export function commonParameters(definition: OASDocument): string[] {
   return query(['$..paths[*].parameters'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -58,7 +58,7 @@ export function commonParameters(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminator-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object}
  */
-export function discriminators(definition: OASDocument) {
+export function discriminators(definition: OASDocument): string[] {
   return query(['$..discriminator'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -68,7 +68,7 @@ export function discriminators(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#link-object}
  */
-export function links(definition: OASDocument) {
+export function links(definition: OASDocument): string[] {
   return query(['$..links'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -79,7 +79,7 @@ export function links(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#request-body-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#request-body-object}
  */
-export function mediaTypes(definition: OASDocument) {
+export function mediaTypes(definition: OASDocument): string[] {
   const results = Array.from(
     new Set(
       query(['$..paths..content'], definition)
@@ -102,7 +102,7 @@ export function mediaTypes(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object}
  */
-export function parameterSerialization(definition: OASDocument) {
+export function parameterSerialization(definition: OASDocument): string[] {
   return query(['$..parameters[*].style^'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -112,7 +112,7 @@ export function parameterSerialization(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
-export function polymorphism(definition: OASDocument) {
+export function polymorphism(definition: OASDocument): string[] {
   const results = Array.from(
     new Set(query(['$..allOf^', '$..anyOf^', '$..oneOf^'], definition).map(res => refizePointer(res.pointer))),
   );
@@ -127,7 +127,7 @@ export function polymorphism(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-scheme-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object}
  */
-export function securityTypes(definition: OASDocument) {
+export function securityTypes(definition: OASDocument): string[] {
   return Array.from(new Set(query(['$.components.securitySchemes..type'], definition).map(res => res.value as string)));
 }
 
@@ -137,7 +137,7 @@ export function securityTypes(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object}
  */
-export function serverVariables(definition: OASDocument) {
+export function serverVariables(definition: OASDocument): string[] {
   return query(['$.servers..variables^'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -147,7 +147,7 @@ export function serverVariables(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operation-object}
  */
-export function totalOperations(definition: OASDocument) {
+export function totalOperations(definition: OASDocument): number {
   return query(['$..paths[*]'], definition)
     .map(res => Object.keys(res.value))
     .flat().length;
@@ -158,7 +158,7 @@ export function totalOperations(definition: OASDocument) {
  *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasWebhooks}
  */
-export function webhooks(definition: OASDocument) {
+export function webhooks(definition: OASDocument): string[] {
   return query(['$.webhooks[*]'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -169,7 +169,7 @@ export function webhooks(definition: OASDocument) {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xml-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object}
  */
-export function xml(definition: OASDocument) {
+export function xml(definition: OASDocument): string[] {
   return query(
     [
       '$.components.schemas..xml^',

--- a/packages/oas/src/analyzer/queries/readme.ts
+++ b/packages/oas/src/analyzer/queries/readme.ts
@@ -8,7 +8,7 @@ import { query, refizePointer } from '../util.js';
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#authentication-defaults}
  */
-export function authDefaults(definition: OASDocument) {
+export function authDefaults(definition: OASDocument): string[] {
   return query(["$.components.securitySchemes..['x-default']^"], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -18,7 +18,7 @@ export function authDefaults(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#code-sample-languages}
  */
-export function codeSampleLanguages(definition: OASDocument) {
+export function codeSampleLanguages(definition: OASDocument): string[] {
   const results: string[] = Array.from(
     new Set(
       query(["$..['x-readme']['samples-languages']", "$..['x-samples-languages']"], definition)
@@ -37,7 +37,7 @@ export function codeSampleLanguages(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#disable-code-examples}
  */
-export function codeSamplesDisabled(definition: OASDocument) {
+export function codeSamplesDisabled(definition: OASDocument): string[] {
   return Array.from(
     new Set(
       query(
@@ -59,7 +59,7 @@ export function codeSamplesDisabled(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#cors-proxy-enabled}
  */
-export function corsProxyDisabled(definition: OASDocument) {
+export function corsProxyDisabled(definition: OASDocument): string[] {
   return Array.from(
     new Set(
       query(
@@ -81,7 +81,7 @@ export function corsProxyDisabled(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#custom-code-samples}
  */
-export function customCodeSamples(definition: OASDocument) {
+export function customCodeSamples(definition: OASDocument): string[] {
   return query(["$..['x-code-samples']", "$..['x-readme']['code-samples']"], definition)
     .filter(res => {
       // If `code-samples` is an empty array then we ignore it.
@@ -96,7 +96,7 @@ export function customCodeSamples(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#disable-the-api-explorer}
  */
-export function explorerDisabled(definition: OASDocument) {
+export function explorerDisabled(definition: OASDocument): string[] {
   return query(
     [
       "$['x-explorer-enabled']^",
@@ -113,7 +113,7 @@ export function explorerDisabled(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/manual-api-editor#raw-body-content-body-content}
  */
-export function rawBody(definition: OASDocument) {
+export function rawBody(definition: OASDocument): string[] {
   return query(['$..RAW_BODY^^'], definition).map(res => refizePointer(res.pointer));
 }
 
@@ -123,7 +123,7 @@ export function rawBody(definition: OASDocument) {
  *
  * @see {@link https://docs.readme.com/main/docs/openapi-extensions#static-headers}
  */
-export function staticHeaders(definition: OASDocument) {
+export function staticHeaders(definition: OASDocument): string[] {
   return query(["$..['x-headers']", "$..['x-readme']['headers']"], definition)
     .filter(res => {
       // If `headers` is an empty array then we ignore it.
@@ -136,6 +136,6 @@ export function staticHeaders(definition: OASDocument) {
  * Determine if a given API definition previously had references by checking if we added the
  * `x-readme-ref-name` extension after dereferencing.
  */
-export function refNames(definition: OASDocument) {
+export function refNames(definition: OASDocument): string[] {
   return query(["$..['x-readme-ref-name']"], definition).map(res => refizePointer(res.pointer));
 }

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -281,7 +281,7 @@ export const extensionDefaults: Extensions = {
  * Determing if an OpenAPI definition has an extension set in its root schema.
  *
  */
-export function hasRootExtension(extension: string | keyof Extensions, api: OASDocument) {
+export function hasRootExtension(extension: string | keyof Extensions, api: OASDocument): boolean {
   return Boolean(api && extension in api);
 }
 
@@ -289,7 +289,7 @@ export function hasRootExtension(extension: string | keyof Extensions, api: OASD
  * Retrieve a custom specification extension off of the API definition.
  *
  */
-export function getExtension(extension: string | keyof Extensions, api: OASDocument, operation?: Operation) {
+export function getExtension(extension: string | keyof Extensions, api: OASDocument, operation?: Operation): any {
   if (operation) {
     if (operation.hasExtension('x-readme')) {
       const data = operation.getExtension('x-readme') as Extensions;
@@ -341,7 +341,7 @@ export function getExtension(extension: string | keyof Extensions, api: OASDocum
 export function validateParameterOrdering(
   ordering: (typeof extensionDefaults)[typeof PARAMETER_ORDERING] | undefined,
   extension: string,
-) {
+): void {
   const defaultValue = extensionDefaults[PARAMETER_ORDERING];
   const requiredLength = defaultValue.length;
   const defaultsHuman = `${defaultValue.slice(0, -1).join(', ')}, and ${defaultValue.slice(-1)}`;

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -307,14 +307,14 @@ export default class Oas {
    * @param user The information about a user that we should use when pulling auth tokens from
    *    security schemes.
    */
-  static init(oas: Record<string, unknown> | RMOAS.OASDocument, user?: RMOAS.User) {
+  static init(oas: Record<string, unknown> | RMOAS.OASDocument, user?: RMOAS.User): Oas {
     return new Oas(oas as RMOAS.OASDocument, user);
   }
 
   /**
    * Retrieve the OpenAPI version that this API definition is targeted for.
    */
-  getVersion() {
+  getVersion(): string {
     if (this.api.openapi) {
       return this.api.openapi;
     }
@@ -326,17 +326,17 @@ export default class Oas {
    * Retrieve the current OpenAPI API Definition.
    *
    */
-  getDefinition() {
+  getDefinition(): RMOAS.OASDocument {
     return this.api;
   }
 
-  url(selected = 0, variables?: RMOAS.ServerVariable) {
+  url(selected = 0, variables?: RMOAS.ServerVariable): string {
     const url = normalizedUrl(this.api, selected);
     return this.replaceUrl(url, variables || this.defaultVariables(selected)).trim();
   }
 
-  variables(selected = 0) {
-    let variables;
+  variables(selected = 0): RMOAS.ServerVariablesObject {
+    let variables: RMOAS.ServerVariablesObject;
     try {
       variables = this.api.servers[selected].variables;
       if (!variables) throw new Error('no variables');
@@ -348,7 +348,7 @@ export default class Oas {
     return variables;
   }
 
-  defaultVariables(selected = 0) {
+  defaultVariables(selected = 0): RMOAS.ServerVariable {
     const variables = this.variables(selected);
     const defaults: RMOAS.ServerVariable = {};
 
@@ -438,7 +438,7 @@ export default class Oas {
    *
    * @param baseUrl A given URL to extract server variables out of.
    */
-  splitVariables(baseUrl: string) {
+  splitVariables(baseUrl: string): RMOAS.Servers | false {
     const matchedServer = (this.api.servers || [])
       .map((server, i) => {
         const rgx = transformUrlIntoRegex(server.url);
@@ -487,7 +487,7 @@ export default class Oas {
    * @param url A URL to swap variables into.
    * @param variables An object containing variables to swap into the URL.
    */
-  replaceUrl(url: string, variables: RMOAS.ServerVariable = {}) {
+  replaceUrl(url: string, variables: RMOAS.ServerVariable = {}): string {
     // When we're constructing URLs, server URLs with trailing slashes cause problems with doing
     // lookups, so if we have one here on, slice it off.
     return stripTrailingSlash(
@@ -528,7 +528,7 @@ export default class Oas {
        */
       isWebhook?: boolean;
     } = {},
-  ) {
+  ): Operation {
     // If we're unable to locate an operation for this path+method combination within the API
     // definition, we should still set an empty schema on the operation in the `Operation` class
     // because if we don't trying to use any of the accessors on that class are going to fail as
@@ -679,7 +679,7 @@ export default class Oas {
    * @param url A full URL to look up.
    * @param method The cooresponding HTTP method to look up.
    */
-  getOperation(url: string, method: RMOAS.HttpMethods) {
+  getOperation(url: string, method: RMOAS.HttpMethods): Operation {
     const op = this.findOperation(url, method);
     if (op === undefined) {
       return undefined;
@@ -700,7 +700,7 @@ export default class Oas {
    * @see {Operation.getOperationId()}
    * @param id The `operationId` to look up.
    */
-  getOperationById(id: string) {
+  getOperationById(id: string): Operation | Webhook {
     let found: Operation | Webhook;
 
     Object.values(this.getPaths()).forEach(operations => {
@@ -728,7 +728,7 @@ export default class Oas {
    * @param user User
    * @param selectedApp The user app to retrieve an auth key for.
    */
-  getAuth(user: RMOAS.User, selectedApp?: number | string) {
+  getAuth(user: RMOAS.User, selectedApp?: number | string): RMOAS.AuthForHAR {
     if (!this.api?.components?.securitySchemes) {
       return {};
     }
@@ -743,7 +743,7 @@ export default class Oas {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#openapi-object}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    */
-  getPaths() {
+  getPaths(): Record<string, Record<RMOAS.HttpMethods, Operation | Webhook>> {
     /**
      * Because a path doesn't need to contain a keyed-object of HTTP methods, we should exclude
      * anything from within the paths object that isn't a known HTTP method.
@@ -784,7 +784,7 @@ export default class Oas {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#openapi-object}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object}
    */
-  getWebhooks() {
+  getWebhooks(): Record<string, Record<RMOAS.HttpMethods, Webhook>> {
     const webhooks: Record<string, Record<RMOAS.HttpMethods, Webhook>> = {};
     const api = this.api as OpenAPIV3_1.Document;
 
@@ -806,7 +806,7 @@ export default class Oas {
    * @param setIfMissing If a tag is not present on an operation that operations path will be added
    *    into the list of tags returned.
    */
-  getTags(setIfMissing = false) {
+  getTags(setIfMissing = false): string[] {
     const allTags = new Set<string>();
 
     const oasTags =
@@ -880,7 +880,7 @@ export default class Oas {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    */
-  hasExtension(extension: string) {
+  hasExtension(extension: string): boolean {
     return hasRootExtension(extension, this.api);
   }
 
@@ -891,7 +891,7 @@ export default class Oas {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    */
-  getExtension(extension: string | keyof Extensions, operation?: Operation) {
+  getExtension(extension: string | keyof Extensions, operation?: Operation): any {
     return getExtension(extension, this.api, operation);
   }
 
@@ -904,7 +904,7 @@ export default class Oas {
    * @param extension Specification extension to validate.
    * @throws
    */
-  validateExtension(extension: keyof Extensions) {
+  validateExtension(extension: keyof Extensions): void {
     if (this.hasExtension('x-readme')) {
       const data = this.getExtension('x-readme') as Extensions;
       if (typeof data !== 'object' || Array.isArray(data) || data === null) {
@@ -958,7 +958,7 @@ export default class Oas {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#specification-extensions}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    */
-  validateExtensions() {
+  validateExtensions(): void {
     Object.keys(extensionDefaults).forEach((extension: keyof Extensions) => {
       this.validateExtension(extension);
     });
@@ -971,7 +971,7 @@ export default class Oas {
    *
    * @see Oas.dereference
    */
-  getCircularReferences() {
+  getCircularReferences(): string[] {
     if (!this.dereferencing.complete) {
       throw new Error('#dereference() must be called first in order for this method to obtain circular references.');
     }
@@ -999,7 +999,7 @@ export default class Oas {
        */
       preserveRefAsJSONSchemaTitle?: boolean;
     } = { preserveRefAsJSONSchemaTitle: false },
-  ) {
+  ): Promise<(typeof this.promises)[] | boolean> {
     if (this.dereferencing.complete) {
       return new Promise(resolve => {
         resolve(true);

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -768,7 +768,7 @@ export default class Oas {
       }
 
       Object.keys(this.api.paths[path]).forEach((method: RMOAS.HttpMethods) => {
-        if (!supportedMethods.has(method)) return;
+        if (!supportedMethods.includes(method)) return;
 
         paths[path][method] = this.operation(path, method);
       });

--- a/packages/oas/src/lib/find-schema-definition.ts
+++ b/packages/oas/src/lib/find-schema-definition.ts
@@ -7,7 +7,7 @@ import jsonpointer from 'jsonpointer';
  * @param $ref Reference to look up a schema for.
  * @param definition OpenAPI definition to look for the `$ref` pointer in.
  */
-export default function findSchemaDefinition($ref: string, definition = {}) {
+export default function findSchemaDefinition($ref: string, definition = {}): any {
   const origRef = $ref;
 
   $ref = $ref.trim();

--- a/packages/oas/src/lib/get-auth.ts
+++ b/packages/oas/src/lib/get-auth.ts
@@ -73,7 +73,7 @@ export function getAuth(
   api: OpenAPIV3_1.Document | OpenAPIV3.Document,
   user: RMOAS.User,
   selectedApp?: number | string,
-) {
+): RMOAS.AuthForHAR {
   return Object.keys(api?.components?.securitySchemes || {})
     .map(scheme => {
       return {

--- a/packages/oas/src/lib/get-user-variable.ts
+++ b/packages/oas/src/lib/get-user-variable.ts
@@ -8,7 +8,7 @@ import type * as RMOAS from '../types.js';
  * @param property The name of the variable to retrieve.
  * @param selectedApp The user app to retrieve an auth key for.
  */
-export default function getUserVariable(user: RMOAS.User, property: string, selectedApp?: number | string) {
+export default function getUserVariable(user: RMOAS.User, property: string, selectedApp?: number | string): unknown {
   let key = user;
 
   if ('keys' in user && Array.isArray(user.keys) && user.keys.length) {

--- a/packages/oas/src/lib/helpers.ts
+++ b/packages/oas/src/lib/helpers.ts
@@ -1,6 +1,6 @@
 import type { SchemaObject } from '../types.js';
 
-export function hasSchemaType(schema: SchemaObject, discriminator: 'array' | 'object') {
+export function hasSchemaType(schema: SchemaObject, discriminator: 'array' | 'object'): boolean {
   if (Array.isArray(schema.type)) {
     return schema.type.includes(discriminator);
   }
@@ -8,10 +8,10 @@ export function hasSchemaType(schema: SchemaObject, discriminator: 'array' | 'ob
   return schema.type === discriminator;
 }
 
-export function isObject(val: unknown) {
+export function isObject(val: unknown): val is Record<string, unknown> {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
-export function isPrimitive(val: unknown): boolean {
+export function isPrimitive(val: unknown): val is boolean | number | string {
   return typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
 }

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -807,7 +807,7 @@ export class Operation {
 
           if (!RMOAS.isRef(exp)) {
             Object.keys(exp).forEach((method: RMOAS.HttpMethods) => {
-              if (!supportedMethods.has(method)) return;
+              if (!supportedMethods.includes(method)) return;
 
               callbackOperations.push(this.getCallback(callback, expression, method));
             });

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -1,7 +1,7 @@
 import type { Extensions } from '../extensions.js';
 import type { SecurityType } from '../types.js';
 import type { CallbackExamples } from './lib/get-callback-examples.js';
-import type { getParametersAsJSONSchemaOptions } from './lib/get-parameters-as-json-schema.js';
+import type { getParametersAsJSONSchemaOptions, SchemaWrapper } from './lib/get-parameters-as-json-schema.js';
 import type { RequestBodyExamples } from './lib/get-requestbody-examples.js';
 import type { ResponseExamples } from './lib/get-response-examples.js';
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
@@ -508,7 +508,7 @@ export class Operation {
    * Determine if the operation has any (non-request body) parameters.
    *
    */
-  hasParameters() {
+  hasParameters(): boolean {
     return !!this.getParameters().length;
   }
 
@@ -530,7 +530,7 @@ export class Operation {
    * Determine if this operation has any required parameters.
    *
    */
-  hasRequiredParameters() {
+  hasRequiredParameters(): boolean {
     return this.getParameters().some(param => 'required' in param && param.required);
   }
 
@@ -539,7 +539,7 @@ export class Operation {
    * parameter available on the operation.
    *
    */
-  getParametersAsJSONSchema(opts: getParametersAsJSONSchemaOptions = {}) {
+  getParametersAsJSONSchema(opts: getParametersAsJSONSchemaOptions = {}): SchemaWrapper[] {
     return getParametersAsJSONSchema(this, this.api, {
       includeDiscriminatorMappingRefs: true,
       transformer: (s: RMOAS.SchemaObject) => s,
@@ -568,7 +568,7 @@ export class Operation {
        */
       transformer?: (schema: RMOAS.SchemaObject) => RMOAS.SchemaObject;
     } = {},
-  ) {
+  ): RMOAS.SchemaObject {
     return getResponseAsJSONSchema(this, this.api, statusCode, {
       includeDiscriminatorMappingRefs: true,
       transformer: (s: RMOAS.SchemaObject) => s,
@@ -598,7 +598,7 @@ export class Operation {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object}
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
    */
-  getRequestBodyMediaTypes() {
+  getRequestBodyMediaTypes(): string[] {
     if (!this.hasRequestBody()) {
       return [];
     }
@@ -617,7 +617,7 @@ export class Operation {
    * Determine if this operation has a required request body.
    *
    */
-  hasRequiredRequestBody() {
+  hasRequiredRequestBody(): boolean {
     if (!this.hasRequestBody()) {
       return false;
     }
@@ -839,7 +839,7 @@ export class Operation {
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions}
    * @param extension Specification extension to lookup.
    */
-  hasExtension(extension: string) {
+  hasExtension(extension: string): boolean {
     return Boolean(this.schema && extension in this.schema);
   }
 
@@ -852,7 +852,7 @@ export class Operation {
    *
    * @deprecated Use `oas.getExtension(extension, operation)` instead.
    */
-  getExtension(extension: string | keyof Extensions) {
+  getExtension(extension: string | keyof Extensions): any {
     return this.schema?.[extension];
   }
 

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -84,6 +84,10 @@ export class Operation {
     this.responseExamples = undefined;
     this.callbackExamples = undefined;
     this.exampleGroups = undefined;
+    this.headers = {
+      request: [],
+      response: [],
+    };
   }
 
   getSummary(): string {
@@ -279,11 +283,6 @@ export class Operation {
   }
 
   getHeaders(): Operation['headers'] {
-    this.headers = {
-      request: [],
-      response: [],
-    };
-
     const security = this.prepareSecurity();
     if (security.Header) {
       this.headers.request = (security.Header as OpenAPIV3_1.ApiKeySecurityScheme[]).map(h => {

--- a/packages/oas/src/operation/lib/dedupe-common-parameters.ts
+++ b/packages/oas/src/operation/lib/dedupe-common-parameters.ts
@@ -7,7 +7,10 @@ import * as RMOAS from '../../types.js';
  * @param parameters Array of parameters defined at the operation level.
  * @param commonParameters Array of **common** parameters defined at the path item level.
  */
-export function dedupeCommonParameters(parameters: RMOAS.ParameterObject[], commonParameters: RMOAS.ParameterObject[]) {
+export function dedupeCommonParameters(
+  parameters: RMOAS.ParameterObject[],
+  commonParameters: RMOAS.ParameterObject[],
+): RMOAS.ParameterObject[] {
   return commonParameters.filter((param: RMOAS.ParameterObject) => {
     return !parameters.find((param2: RMOAS.ParameterObject) => {
       if (param.name && param2.name) {

--- a/packages/oas/src/operation/lib/get-callback-examples.ts
+++ b/packages/oas/src/operation/lib/get-callback-examples.ts
@@ -16,7 +16,7 @@ export type CallbackExamples = {
  *
  * @param operation Operation to retrieve callback examples from.
  */
-export function getCallbackExamples(operation: RMOAS.OperationObject) {
+export function getCallbackExamples(operation: RMOAS.OperationObject): CallbackExamples {
   const ret: CallbackExamples = [];
 
   // spreads the contents of the map for each callback so there's not nested arrays returned

--- a/packages/oas/src/operation/lib/get-mediatype-examples.ts
+++ b/packages/oas/src/operation/lib/get-mediatype-examples.ts
@@ -34,7 +34,7 @@ export function getMediaTypeExamples(
      */
     includeWriteOnly?: boolean;
   } = {},
-) {
+): MediaTypeExample[] {
   if (mediaTypeObject.example) {
     return [
       {

--- a/packages/oas/src/operation/lib/get-parameters-as-json-schema.ts
+++ b/packages/oas/src/operation/lib/get-parameters-as-json-schema.ts
@@ -81,7 +81,7 @@ export function getParametersAsJSONSchema(
   operation: Operation,
   api: OASDocument,
   opts?: getParametersAsJSONSchemaOptions,
-) {
+): SchemaWrapper[] {
   let hasCircularRefs = false;
   let hasDiscriminatorMappingRefs = false;
 

--- a/packages/oas/src/operation/lib/get-requestbody-examples.ts
+++ b/packages/oas/src/operation/lib/get-requestbody-examples.ts
@@ -13,7 +13,7 @@ export type RequestBodyExamples = {
  *
  * @param operation Operation to retrieve requestBody examples for.
  */
-export function getRequestBodyExamples(operation: RMOAS.OperationObject) {
+export function getRequestBodyExamples(operation: RMOAS.OperationObject): RequestBodyExamples {
   // `requestBody` will never have `$ref` pointers here so we need to work around the type that we
   // have from `RMOAS.OperationObject`.
   const requestBody = operation.requestBody as RMOAS.RequestBodyObject;
@@ -38,5 +38,5 @@ export function getRequestBodyExamples(operation: RMOAS.OperationObject) {
         examples,
       };
     })
-    .filter(Boolean) as RequestBodyExamples;
+    .filter(x => x !== false);
 }

--- a/packages/oas/src/operation/lib/get-response-as-json-schema.ts
+++ b/packages/oas/src/operation/lib/get-response-as-json-schema.ts
@@ -100,7 +100,7 @@ export function getResponseAsJSONSchema(
      */
     transformer?: (schema: SchemaObject) => SchemaObject;
   },
-) {
+): SchemaObject {
   const response = operation.getResponseByStatusCode(statusCode);
   const jsonSchema = [];
 

--- a/packages/oas/src/reducer/index.ts
+++ b/packages/oas/src/reducer/index.ts
@@ -70,7 +70,7 @@ function accumulateUsedRefs(schema: Record<string, unknown>, $refs: Set<string>,
  *
  * @param definition A valid OpenAPI 3.x definition
  */
-export default function reducer(definition: OASDocument, opts: ReducerOptions = {}) {
+export default function reducer(definition: OASDocument, opts: ReducerOptions = {}): OASDocument {
   // Convert tags and paths to lowercase since casing should not matter.
   const reduceTags = 'tags' in opts ? opts.tags.map(tag => tag.toLowerCase()) : [];
   const reducePaths =

--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -214,4 +214,6 @@ function sampleFromSchema(
   return primitive(schema);
 }
 
-export default memoize(sampleFromSchema);
+const memo: typeof sampleFromSchema = memoize(sampleFromSchema);
+
+export default memo;

--- a/packages/oas/src/samples/utils.ts
+++ b/packages/oas/src/samples/utils.ts
@@ -8,7 +8,7 @@ import type * as RMOAS from '../types.js';
 
 import { isObject } from '../lib/helpers.js';
 
-export function usesPolymorphism(schema: RMOAS.SchemaObject) {
+export function usesPolymorphism(schema: RMOAS.SchemaObject): 'allOf' | 'anyOf' | 'oneOf' | false {
   if (schema.oneOf) {
     return 'oneOf';
   } else if (schema.anyOf) {
@@ -28,7 +28,7 @@ export function objectify(thing: Record<string, unknown> | unknown): Record<stri
   return thing;
 }
 
-export function normalizeArray(arr: (number | string)[] | number | string) {
+export function normalizeArray(arr: (number | string)[] | number | string): (number | string)[] {
   if (Array.isArray(arr)) {
     return arr;
   }

--- a/packages/oas/src/types.ts
+++ b/packages/oas/src/types.ts
@@ -37,6 +37,8 @@ export interface DataForHAR {
   };
 }
 
+export type AuthForHAR = Record<string, number | string | { pass?: string; user?: string }>;
+
 export interface User {
   [key: string]: unknown;
   keys?: {

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -2,6 +2,8 @@ import findSchemaDefinition from './lib/find-schema-definition.js';
 import matchesMimeType from './lib/matches-mimetype.js';
 import { types as jsonSchemaTypes } from './operation/lib/get-parameters-as-json-schema.js';
 
-const supportedMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+const methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+
+const supportedMethods: Set<(typeof methods)[number]> = new Set(methods);
 
 export { findSchemaDefinition, jsonSchemaTypes, matchesMimeType, supportedMethods };

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -2,8 +2,6 @@ import findSchemaDefinition from './lib/find-schema-definition.js';
 import matchesMimeType from './lib/matches-mimetype.js';
 import { types as jsonSchemaTypes } from './operation/lib/get-parameters-as-json-schema.js';
 
-const methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
-
-const supportedMethods: Set<(typeof methods)[number]> = new Set(methods);
+const supportedMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
 export { findSchemaDefinition, jsonSchemaTypes, matchesMimeType, supportedMethods };

--- a/packages/oas/test/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/__snapshots__/index.test.ts.snap
@@ -3450,6 +3450,7 @@ Operation {
   "callbackExamples": undefined,
   "contentType": undefined,
   "exampleGroups": undefined,
+  "headers": undefined,
   "method": "get",
   "path": "/unknown",
   "requestBodyExamples": undefined,

--- a/packages/oas/test/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/__snapshots__/index.test.ts.snap
@@ -3450,7 +3450,10 @@ Operation {
   "callbackExamples": undefined,
   "contentType": undefined,
   "exampleGroups": undefined,
-  "headers": undefined,
+  "headers": {
+    "request": [],
+    "response": [],
+  },
   "method": "get",
   "path": "/unknown",
   "requestBodyExamples": undefined,

--- a/packages/oas/test/ts-quirks.test.ts
+++ b/packages/oas/test/ts-quirks.test.ts
@@ -50,6 +50,7 @@ test('should be able to generate enums', () => {
     },
   };
 
+  // @ts-expect-error - We're testing a bug here, so we don't care about the type.
   const oas = new Oas(spec);
   expect(oas.operation('/anything', 'post').getParametersAsJSONSchema()[0].schema.properties.enumType).toStrictEqual({
     type: 'string',

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,17 +1,17 @@
-import type { ParserOptionsStrict } from './options.js';
+import type { ParserOptionsStrict, ParserOptions } from './options.js';
 import type { Document } from './types.js';
-import type $Refs from '@apidevtools/json-schema-ref-parser/lib/refs';
-import type { $RefsCallback, SchemaCallback } from '@apidevtools/json-schema-ref-parser/lib/types';
+import type $Refs from '@apidevtools/json-schema-ref-parser/dist/lib/refs';
+import type { $RefsCallback, SchemaCallback } from '@apidevtools/json-schema-ref-parser/dist/lib/types';
 import type { OpenAPI } from 'openapi-types';
 
 import $RefParser from '@apidevtools/json-schema-ref-parser';
-import _dereference from '@apidevtools/json-schema-ref-parser/lib/dereference';
-import { normalizeArgs } from '@apidevtools/json-schema-ref-parser/lib/normalize-args';
-import maybe from '@apidevtools/json-schema-ref-parser/lib/util/maybe';
+import _dereference from '@apidevtools/json-schema-ref-parser/dist/lib/dereference';
+import { normalizeArgs } from '@apidevtools/json-schema-ref-parser/dist/lib/normalize-args';
+import maybe from '@apidevtools/json-schema-ref-parser/dist/lib/util/maybe';
 import { ono } from '@jsdevtools/ono';
 
 import { isSwagger, isOpenAPI } from './lib/index.js';
-import { getOptions, ParserOptions } from './options.js';
+import { getOptions } from './options.js';
 import { fixOasRelativeServers } from './util.js';
 import { validateSchema } from './validators/schema.js';
 import { validateSpec } from './validators/spec.js';
@@ -20,7 +20,7 @@ const supported31Versions = ['3.1.0', '3.1.1'];
 const supported30Versions = ['3.0.0', '3.0.1', '3.0.2', '3.0.3', '3.0.4'];
 const supportedVersions = [...supported31Versions, ...supported30Versions];
 
-export { ParserOptions };
+export type { ParserOptions };
 
 /**
  * This class parses a Swagger 2.0 or 3.0 OpenAPI API definition, resolves its JSON references and

--- a/packages/parser/src/lib/index.ts
+++ b/packages/parser/src/lib/index.ts
@@ -7,7 +7,7 @@ import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#path-templating}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-templating}
  */
-export const pathParameterTemplateRegExp = /\{([^/}]+)}/g;
+export const pathParameterTemplateRegExp: RegExp = /\{([^/}]+)}/g;
 
 /**
  * List of HTTP verbs used for OperationItem as per the OpenAPI and Swagger specifications
@@ -40,6 +40,8 @@ export function isOpenAPI(schema: any): schema is OpenAPIV3_1.Document | OpenAPI
  * Determine the proper name for the API specification schema used by a given schema.
  *
  */
-export function getSpecificationName(api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document) {
+export function getSpecificationName(
+  api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document,
+): 'OpenAPI' | 'Swagger' {
   return isSwagger(api) ? 'Swagger' : 'OpenAPI';
 }

--- a/packages/parser/src/lib/reduceAjvErrors.ts
+++ b/packages/parser/src/lib/reduceAjvErrors.ts
@@ -11,8 +11,8 @@ import type { ErrorObject } from 'ajv/dist/2020';
  * for them (because really that's **the** error).
  *
  */
-export function reduceAjvErrors(errors: ErrorObject[]) {
-  const flattened = new Map();
+export function reduceAjvErrors(errors: ErrorObject[]): ErrorObject[] {
+  const flattened = new Map<string, ErrorObject>();
 
   errors.forEach(err => {
     // These two errors appear when a child schema of them has a problem and instead of polluting

--- a/packages/parser/src/options.ts
+++ b/packages/parser/src/options.ts
@@ -1,10 +1,10 @@
 import type { Document } from './types.js';
 import type { SchemaValidator } from './validators/schema.js';
 import type { SpecValidator } from './validators/spec.js';
-import type $RefParserOptions from '@apidevtools/json-schema-ref-parser/lib/options';
-import type { DeepPartial } from '@apidevtools/json-schema-ref-parser/lib/options';
+import type $RefParserOptions from '@apidevtools/json-schema-ref-parser/dist/lib/options';
+import type { DeepPartial } from '@apidevtools/json-schema-ref-parser/dist/lib/options';
 
-import { getNewOptions } from '@apidevtools/json-schema-ref-parser/lib/options';
+import { getNewOptions } from '@apidevtools/json-schema-ref-parser/dist/lib/options';
 import merge from 'lodash/merge';
 
 import { validateSchema } from './validators/schema.js';

--- a/packages/parser/src/util.ts
+++ b/packages/parser/src/util.ts
@@ -1,6 +1,6 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
-import * as url from '@apidevtools/json-schema-ref-parser/lib/util/url';
+import * as url from '@apidevtools/json-schema-ref-parser/dist/lib/util/url';
 
 import { isOpenAPI, supportedHTTPMethods } from './lib/index.js';
 

--- a/packages/parser/src/util.ts
+++ b/packages/parser/src/util.ts
@@ -45,7 +45,7 @@ function fixServers(
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#server-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-object}
  */
-export function fixOasRelativeServers(schema: OpenAPI.Document, filePath?: string) {
+export function fixOasRelativeServers(schema: OpenAPI.Document, filePath?: string): void {
   if (!schema || !isOpenAPI(schema) || !filePath || (!filePath.startsWith('http:') && !filePath.startsWith('https:'))) {
     return;
   }

--- a/packages/parser/src/validators/schema.ts
+++ b/packages/parser/src/validators/schema.ts
@@ -122,6 +122,7 @@ export const validateSchema: SchemaValidator = (
 
     let message = `${getSpecificationName(api)} schema validation failed.\n`;
     message += '\n';
+    // @ts-expect-error this has always worked, `betterAjvErrors` must have a bad type here.
     message += betterAjvErrors(schema, api, reducedErrors, {
       colorize: options.colorizeErrors,
       indent: 2,

--- a/packages/parser/src/validators/spec/openapi.ts
+++ b/packages/parser/src/validators/spec/openapi.ts
@@ -236,7 +236,7 @@ function validatePath(
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md}
  */
-export function validateSpec(api: OpenAPIV3_1.Document | OpenAPIV3.Document) {
+export function validateSpec(api: OpenAPIV3_1.Document | OpenAPIV3.Document): void {
   const operationIds: string[] = [];
   Object.keys(api.paths || {}).forEach(pathName => {
     const path = api.paths[pathName];

--- a/packages/parser/src/validators/spec/swagger.ts
+++ b/packages/parser/src/validators/spec/swagger.ts
@@ -302,7 +302,7 @@ function validatePath(api: OpenAPIV2.Document, path: OpenAPIV2.PathItemObject, p
  *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md}
  */
-export function validateSpec(api: OpenAPIV2.Document) {
+export function validateSpec(api: OpenAPIV2.Document): void {
   const operationIds: string[] = [];
   Object.keys(api.paths || {}).forEach(pathName => {
     const path = api.paths[pathName];

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "isolatedDeclarations": true,
+    "isolatedModules": true,
     "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,7 @@
     "outDir": "./dist",
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "verbatimModuleSyntax": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,14 +6,13 @@
     "esModuleInterop": true,
     "isolatedDeclarations": true,
     "isolatedModules": true,
-    "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noImplicitAny": true,
     "outDir": "./dist",
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "ES2020",
+    "target": "ES2024",
     "verbatimModuleSyntax": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "baseUrl": "./src",
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
+    "isolatedDeclarations": true,
     "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
## 🧰 Changes

since we're on modern TS, i enabled the following options in our `tsconfig.base.json` and refactored a bunch of things downstream to account for these changes:
- [`isolatedDeclarations`](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations) - the types in this repo are rather complex, so this should help speed up typechecking (both in this repo and in any TS repo that uses these libraries) and type generation
- [`isolatedModules`](https://www.typescriptlang.org/tsconfig/#isolatedModules) - [per matt pocock](https://www.totaltypescript.com/tsconfig-cheat-sheet#base-options): "this option prevents a few TS features which are unsafe when treating modules as isolated files". didn't have to do any add'l work to enable this so 🤷🏽
- [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) — this makes it so we're stricter about `import type` declarations. this should help with treeshaking.

matt pocock recommends both of these options:
https://www.totaltypescript.com/tsconfig-cheat-sheet#base-options
https://www.totaltypescript.com/typescript-5-3#isolated-declarations

## 🧬 QA & Testing

does everything still pass?
