### PR TITLE
refactor(oas): removing our `json-schema-ref-parser` fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2304,18 +2304,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@readme/json-schema-ref-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.2.0.tgz",
-      "integrity": "sha512-Bt3QVovFSua4QmHa65EHUmh2xS0XJ3rgTEUPH998f4OW4VVJke3BuS16f+kM0ZLOGdvIrzrPRqwihuv5BAjtrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/@readme/oas-examples": {
       "version": "5.18.2",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-5.18.2.tgz",
@@ -20208,7 +20196,7 @@
       "version": "25.3.0",
       "license": "MIT",
       "dependencies": {
-        "@readme/json-schema-ref-parser": "^1.2.0",
+        "@readme/openapi-parser": "file:../parser",
         "@types/json-schema": "^7.0.11",
         "json-schema-merge-allof": "^0.8.1",
         "jsonpath-plus": "^10.0.0",
@@ -20220,7 +20208,6 @@
       },
       "devDependencies": {
         "@readme/oas-examples": "^5.13.0",
-        "@readme/openapi-parser": "file:../parser",
         "@types/json-schema-merge-allof": "^0.6.5",
         "@types/memoizee": "^0.4.11",
         "@types/node": "^22.7.6",

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -88,7 +88,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@readme/json-schema-ref-parser": "^1.2.0",
+    "@readme/openapi-parser": "file:../parser",
     "@types/json-schema": "^7.0.11",
     "json-schema-merge-allof": "^0.8.1",
     "jsonpath-plus": "^10.0.0",
@@ -100,7 +100,6 @@
   },
   "devDependencies": {
     "@readme/oas-examples": "^5.13.0",
-    "@readme/openapi-parser": "file:../parser",
     "@types/json-schema-merge-allof": "^0.6.5",
     "@types/memoizee": "^0.4.11",
     "@types/node": "^22.7.6",

--- a/packages/oas/test/__datasets__/invalid/misplaced-type.json
+++ b/packages/oas/test/__datasets__/invalid/misplaced-type.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Invalid definition with a misplaced parameter `type` property"
+  },
+  "servers": [
+    {
+      "url": "http://httpbin.org/anything"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "type": "array",
+            "schema": {
+              "items": {
+                "type": "string",
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -89,8 +89,13 @@ describe('analyzer queries (OpenAPI)', () => {
   describe('circularRefs', () => {
     it('should determine if a definition has circular refs when it does', async () => {
       await expect(QUERIES.circularRefs(circular)).resolves.toStrictEqual([
+        '#/components/schemas/BodyPart/properties/parent',
+        '#/components/schemas/MultiPart/properties/bodyParts/items',
         '#/components/schemas/MultiPart/properties/parent',
         '#/components/schemas/ZoneOffset/properties/rules',
+        '#/components/schemas/ZoneOffsetTransition/properties/offsetAfter',
+        '#/components/schemas/ZoneOffsetTransition/properties/offsetBefore',
+        '#/components/schemas/ZoneRules/properties/transitions/items',
       ]);
     });
 

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1486,10 +1486,20 @@ describe('Oas', () => {
   });
 
   describe('.dereference()', () => {
-    it('should not fail on a empty, null or undefined API definitions', async () => {
-      await expect(Oas.init({}).dereference()).resolves.toStrictEqual([]);
-      await expect(Oas.init(undefined).dereference()).resolves.toStrictEqual([]);
-      await expect(Oas.init(null).dereference()).resolves.toStrictEqual([]);
+    describe('given an invalid API definition', () => {
+      describe('that is empty, null, or undefined', () => {
+        it('should not throw a validation error', async () => {
+          await expect(Oas.init({}).dereference()).resolves.toBeUndefined();
+          await expect(Oas.init(undefined).dereference()).resolves.toBeUndefined();
+          await expect(Oas.init(null).dereference()).resolves.toBeUndefined();
+        });
+      });
+
+      it('should not throw a validation error', async () => {
+        const definition = await import('./__datasets__/invalid/misplaced-type.json').then(r => r.default);
+
+        await expect(Oas.init(definition).dereference()).resolves.toBeUndefined();
+      });
     });
 
     it('should dereference the current OAS', async () => {
@@ -1710,7 +1720,11 @@ describe('Oas', () => {
 
       expect(oas.getCircularReferences()).toStrictEqual([
         '#/components/schemas/offsetTransition/properties/offsetAfter',
+        '#/components/schemas/offsetTransition/properties/offsetBefore',
         '#/components/schemas/ProductStock/properties/test_param/items',
+        '#/components/schemas/rules/properties/transitions/items',
+        '#/components/schemas/offset/properties/rules',
+        '#/components/schemas/SalesLine/properties/stock',
       ]);
     });
 


### PR DESCRIPTION
## 🧰 Changes

This fully swaps our our, now deprecated, `json-schema-ref-parser` fork with our OpenAPI parser as it does everything that we were using that for.