### PR TITLE
feat(parser): replacing `ono` with regular errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20310,13 +20310,11 @@
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.9.0",
-        "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^2.2.2",
         "@readme/openapi-schemas": "^3.1.0",
         "@types/json-schema": "^7.0.15",
         "ajv": "^8.12.0",
-        "ajv-draft-04": "^1.0.0",
-        "lodash": "^4.17.21"
+        "ajv-draft-04": "^1.0.0"
       },
       "devDependencies": {
         "@types/lodash": "^4.17.15",

--- a/packages/oas-normalize/README.md
+++ b/packages/oas-normalize/README.md
@@ -123,7 +123,7 @@ REQUIRED must have required property 'url'
   12 |   ],
 ```
 
-However if you would like to programatically access this information the `SyntaxError` error that is thrown contains a `details` array of [AJV](https://npm.im/ajv) errors:
+However if you would like to programatically access this information the `ValidationError` error that is thrown it contains a `details` array of [AJV](https://npm.im/ajv) errors:
 
 ```json
 [

--- a/packages/oas-normalize/test/__snapshots__/index.test.ts.snap
+++ b/packages/oas-normalize/test/__snapshots__/index.test.ts.snap
@@ -14513,7 +14513,7 @@ exports[`#convert > Swagger 2.0 support > should validate a YAML path as expecte
 `;
 
 exports[`#validate > should colorize errors when \`opts.colorizeErrors\` is present 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+[ValidationError: OpenAPI schema validation failed.
 
 [31m[1mREQUIRED[22m must have required property 'name'[39m
 
@@ -14527,7 +14527,7 @@ exports[`#validate > should colorize errors when \`opts.colorizeErrors\` is pres
 `;
 
 exports[`#validate > should error out when a definition doesn't match the schema 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+[ValidationError: OpenAPI schema validation failed.
 
 REQUIRED must have required property 'name'
 
@@ -14541,7 +14541,7 @@ REQUIRED must have required property 'name'
 `;
 
 exports[`#validate > should error out when a definition doesn't match the spec 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+[ValidationError: OpenAPI schema validation failed.
 
 REQUIRED must have required property 'paths'
 

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -4,6 +4,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { ValidationError } from '@readme/openapi-parser';
 import nock from 'nock';
 import { describe, afterEach, beforeAll, beforeEach, it, expect, assert } from 'vitest';
 
@@ -350,7 +351,7 @@ describe('#validate', () => {
       await o.validate();
       assert.fail();
     } catch (err) {
-      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err).toBeInstanceOf(ValidationError);
       expect(err.message).toMatchSnapshot();
       expect(err.details).toMatchSnapshot();
     }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -59,13 +59,11 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.9.0",
-    "@jsdevtools/ono": "^7.1.3",
     "@readme/better-ajv-errors": "^2.2.2",
     "@readme/openapi-schemas": "^3.1.0",
     "@types/json-schema": "^7.0.15",
     "ajv": "^8.12.0",
-    "ajv-draft-04": "^1.0.0",
-    "lodash": "^4.17.21"
+    "ajv-draft-04": "^1.0.0"
   },
   "peerDependencies": {
     "openapi-types": ">=7"

--- a/packages/parser/src/errors.ts
+++ b/packages/parser/src/errors.ts
@@ -1,6 +1,6 @@
 import type { ErrorObject } from 'ajv';
 
-export class ValidationError extends SyntaxError {
+export class ValidationError extends Error {
   details: ErrorObject[];
 
   totalErrors: number;

--- a/packages/parser/src/errors.ts
+++ b/packages/parser/src/errors.ts
@@ -1,0 +1,15 @@
+import type { ErrorObject } from 'ajv';
+
+export class ValidationError extends SyntaxError {
+  details: ErrorObject[];
+
+  totalErrors: number;
+
+  constructor(message: string, data?: { details: ErrorObject[]; totalErrors: number }) {
+    super(message);
+
+    this.name = 'ValidationError';
+    this.details = data?.details || [];
+    this.totalErrors = data?.totalErrors || 0;
+  }
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,7 +1,6 @@
 import type { APIDocument, ParserOptions } from './types.js';
 
 import $RefParser, { dereferenceInternal } from '@apidevtools/json-schema-ref-parser';
-import { ono } from '@jsdevtools/ono';
 
 import { isSwagger, isOpenAPI } from './lib/index.js';
 import { convertOptionsForParser, normalizeArguments, repairSchema } from './util.js';
@@ -119,7 +118,7 @@ export async function validate<S extends APIDocument = APIDocument>(
   await parser.dereference(args.path, args.schema, parserOptions);
 
   if (!isSwagger(parser.schema) && !isOpenAPI(parser.schema)) {
-    throw ono.syntax('Supplied schema is not a valid API definition.');
+    throw new SyntaxError('Supplied schema is not a valid API definition.');
   }
 
   // Restore the original options, now that we're done dereferencing
@@ -137,7 +136,7 @@ export async function validate<S extends APIDocument = APIDocument>(
       dereferenceInternal<S>(parser, parserOptions);
     } else if (circular$RefOption === false) {
       // The API has circular references but we're configured to not permit that.
-      throw ono.reference('The API contains circular references');
+      throw new ReferenceError('The API contains circular references');
     }
   }
 

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -2,12 +2,15 @@ import type { APIDocument, ParserOptions } from './types.js';
 
 import $RefParser, { dereferenceInternal } from '@apidevtools/json-schema-ref-parser';
 
+import { ValidationError } from './errors.js';
 import { isSwagger, isOpenAPI } from './lib/index.js';
 import { convertOptionsForParser, normalizeArguments, repairSchema } from './util.js';
 import { validateSchema } from './validators/schema.js';
 import { validateSpec } from './validators/spec.js';
 
 export type { ParserOptions };
+
+export { ValidationError };
 
 /**
  * Parses the given API definition, in JSON or YAML format, and returns it as a JSON object. This
@@ -118,7 +121,7 @@ export async function validate<S extends APIDocument = APIDocument>(
   await parser.dereference(args.path, args.schema, parserOptions);
 
   if (!isSwagger(parser.schema) && !isOpenAPI(parser.schema)) {
-    throw new SyntaxError('Supplied schema is not a valid API definition.');
+    throw new ValidationError('Supplied schema is not a valid API definition.');
   }
 
   // Restore the original options, now that we're done dereferencing

--- a/packages/parser/src/util.ts
+++ b/packages/parser/src/util.ts
@@ -2,7 +2,6 @@ import type { APIDocument, ParserOptions } from './types.js';
 import type { ParserOptions as $RefParserOptions } from '@apidevtools/json-schema-ref-parser';
 
 import { getJsonSchemaRefParserDefaultOptions } from '@apidevtools/json-schema-ref-parser';
-import merge from 'lodash/merge.js';
 
 import { isOpenAPI } from './lib/index.js';
 import { fixOasRelativeServers } from './repair.js';
@@ -38,11 +37,18 @@ export function normalizeArguments<S extends APIDocument = APIDocument>(
  *
  */
 export function convertOptionsForParser(options: ParserOptions): Partial<$RefParserOptions> {
-  return merge(getJsonSchemaRefParserDefaultOptions(), {
+  const parserOptions = getJsonSchemaRefParserDefaultOptions();
+  return {
+    ...parserOptions,
     dereference: {
-      circular: options?.dereference && 'circular' in options.dereference ? options.dereference.circular : undefined,
-      onCircular: options?.dereference?.onCircular || undefined,
-      onDereference: options?.dereference?.onDereference || undefined,
+      ...parserOptions.dereference,
+
+      circular:
+        options?.dereference && 'circular' in options.dereference
+          ? options.dereference.circular
+          : parserOptions.dereference.circular,
+      onCircular: options?.dereference?.onCircular || parserOptions.dereference.onCircular,
+      onDereference: options?.dereference?.onDereference || parserOptions.dereference.onDereference,
 
       // OpenAPI 3.1 allows for `summary` and `description` properties at the same level as a `$ref`
       // pointer to be preserved when that `$ref` pointer is dereferenced. The default behavior of
@@ -51,7 +57,10 @@ export function convertOptionsForParser(options: ParserOptions): Partial<$RefPar
       preservedProperties: ['summary', 'description'],
     },
     resolve: {
-      external: options?.resolve && 'external' in options.resolve ? options.resolve.external : undefined,
+      ...parserOptions.resolve,
+
+      external:
+        options?.resolve && 'external' in options.resolve ? options.resolve.external : parserOptions.resolve.external,
     },
-  });
+  };
 }

--- a/packages/parser/src/validators/schema.ts
+++ b/packages/parser/src/validators/schema.ts
@@ -1,11 +1,11 @@
 import type { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
-import { ono } from '@jsdevtools/ono';
 import betterAjvErrors from '@readme/better-ajv-errors';
 import { openapi } from '@readme/openapi-schemas';
 import Ajv from 'ajv/dist/2020.js';
 import AjvDraft4 from 'ajv-draft-04';
 
+import { ValidationError } from '../errors.js';
 import { getSpecificationName, isSwagger } from '../lib/index.js';
 import { reduceAjvErrors } from '../lib/reduceAjvErrors.js';
 
@@ -131,7 +131,6 @@ export const validateSchema: SchemaValidator = (
       message += `Plus an additional ${additionalErrors} errors. Please resolve the above and re-run validation to see more.`;
     }
 
-    // @ts-expect-error `ono` doens't like the types on this but good news! we're going to get rid of `ono`.
-    throw ono.syntax(err, { details: err, totalErrors }, message);
+    throw new ValidationError(message, { details: err, totalErrors });
   }
 };

--- a/packages/parser/src/validators/spec/openapi.ts
+++ b/packages/parser/src/validators/spec/openapi.ts
@@ -1,7 +1,5 @@
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
-import { ono } from '@jsdevtools/ono';
-
 import { supportedHTTPMethods, pathParameterTemplateRegExp, isOpenAPI31, isOpenAPI30 } from '../../lib/index.js';
 
 type ParameterObject =
@@ -12,7 +10,7 @@ type ParameterObject =
  * Checks the given parameter list for duplicates.
  *
  */
-function checkForDuplicates(params: ParameterObject[]) {
+function checkForDuplicates(params: ParameterObject[], schemaId: string) {
   for (let i = 0; i < params.length - 1; i++) {
     const outer = params[i];
     for (let j = i + 1; j < params.length; j++) {
@@ -22,7 +20,9 @@ function checkForDuplicates(params: ParameterObject[]) {
       }
 
       if (outer.name === inner.name && outer.in === inner.in) {
-        throw ono.syntax(`Validation failed. Found multiple ${outer.in} parameters named "${outer.name}"`);
+        throw new SyntaxError(
+          `Validation failed. Found multiple \`${outer.in}\` parameters named \`${outer.name}\` in \`${schemaId}\`.`,
+        );
       }
     }
   }
@@ -34,7 +34,7 @@ function checkForDuplicates(params: ParameterObject[]) {
  */
 function validateSchema(schema: OpenAPIV3_1.SchemaObject | OpenAPIV3.SchemaObject, schemaId: string) {
   if (schema.type === 'array' && !schema.items) {
-    throw ono.syntax(`Validation failed. ${schemaId} is an array, so it must include an "items" schema`);
+    throw new SyntaxError(`Validation failed. \`${schemaId}\` is an array, so it must include an \`items\` schema.`);
   }
 }
 
@@ -53,17 +53,15 @@ function validatePathParameters(params: ParameterObject[], pathId: string, opera
     .filter(param => param.in === 'path')
     .forEach(param => {
       if (param.required !== true) {
-        throw ono.syntax(
-          'Validation failed. Path parameters cannot be optional. ' +
-            `Set required=true for the "${param.name}" parameter at ${operationId}`,
+        throw new SyntaxError(
+          `Validation failed. Path parameters cannot be optional. Set \`required=true\` for the \`${param.name}\` parameter at \`${operationId}\`.`,
         );
       }
 
       const match = placeholders.indexOf(`{${param.name}}`);
       if (match === -1) {
-        throw ono.syntax(
-          `Validation failed. ${operationId} has a path parameter named "${param.name}", ` +
-            `but there is no corresponding {${param.name}} in the path string`,
+        throw new SyntaxError(
+          `Validation failed. \`${operationId}\` has a path parameter named \`${param.name}\`, but there is no corresponding \`{${param.name}}\` in the path string.`,
         );
       }
 
@@ -71,7 +69,11 @@ function validatePathParameters(params: ParameterObject[], pathId: string, opera
     });
 
   if (placeholders.length > 0) {
-    throw ono.syntax(`Validation failed. ${operationId} is missing path parameter(s) for ${placeholders}`);
+    const list = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }).format(
+      placeholders.map(placeholder => `\`${placeholder}\``),
+    );
+
+    throw new SyntaxError(`Validation failed. \`${operationId}\` is missing path parameter(s) for ${list}.`);
   }
 }
 
@@ -116,18 +118,10 @@ function validateParameters(
   const operationParams = operation.parameters || [];
 
   // Check for duplicate path parameters.
-  try {
-    checkForDuplicates(pathParams);
-  } catch (e) {
-    throw ono.syntax(e, `Validation failed. ${pathId} has duplicate parameters`);
-  }
+  checkForDuplicates(pathParams, pathId);
 
   // Check for duplicate operation parameters.
-  try {
-    checkForDuplicates(operationParams);
-  } catch (e) {
-    throw ono.syntax(e, `Validation failed. ${operationId} has duplicate parameters`);
-  }
+  checkForDuplicates(operationParams, operationId);
 
   // Combine the path and operation parameters, with the operation params taking precedence over
   // the path params.
@@ -208,7 +202,9 @@ function validatePath(
         if (!operationIds.includes(declaredOperationId)) {
           operationIds.push(declaredOperationId);
         } else {
-          throw ono.syntax(`Validation failed. Duplicate operation id '${declaredOperationId}'`);
+          throw new SyntaxError(
+            `Validation failed. The operationId \`${declaredOperationId}\` is duplicated and must be made unique.`,
+          );
         }
       }
 
@@ -261,8 +257,8 @@ export function validateSpec(api: OpenAPIV3_1.Document | OpenAPIV3.Document): vo
           const componentId = `/components/${componentType}/${componentName}`;
 
           if (!/^[a-zA-Z0-9.\-_]+$/.test(componentName)) {
-            throw ono.syntax(
-              `Validation failed. ${componentId} has an invalid name. Component names should match against: /^[a-zA-Z0-9.-_]+$/`,
+            throw new SyntaxError(
+              `Validation failed. \`${componentId}\` has an invalid name. Component names should match against: /^[a-zA-Z0-9.-_]+$/`,
             );
           }
         });
@@ -279,7 +275,7 @@ export function validateSpec(api: OpenAPIV3_1.Document | OpenAPIV3.Document): vo
    */
   if (isOpenAPI31(api)) {
     if (!Object.keys(api.paths || {}).length && !Object.keys(api.webhooks || {}).length) {
-      throw ono.syntax(
+      throw new SyntaxError(
         'Validation failed. OpenAPI 3.1 definitions must contain at least one entry in either `paths` or `webhook`.',
       );
     }

--- a/packages/parser/src/validators/spec/swagger.ts
+++ b/packages/parser/src/validators/spec/swagger.ts
@@ -1,20 +1,20 @@
 import type { IJsonSchema, OpenAPIV2 } from 'openapi-types';
 
-import { ono } from '@jsdevtools/ono';
-
 import { swaggerHTTPMethods, pathParameterTemplateRegExp } from '../../lib/index.js';
 
 /**
  * Checks the given parameter list for duplicates.
  *
  */
-function checkForDuplicates(params: OpenAPIV2.ParameterObject[]) {
+function checkForDuplicates(params: OpenAPIV2.ParameterObject[], schemaId: string) {
   for (let i = 0; i < params.length - 1; i++) {
     const outer = params[i];
     for (let j = i + 1; j < params.length; j++) {
       const inner = params[j];
       if (outer.name === inner.name && outer.in === inner.in) {
-        throw ono.syntax(`Validation failed. Found multiple ${outer.in} parameters named "${outer.name}"`);
+        throw new SyntaxError(
+          `Validation failed. Found multiple \`${outer.in}\` parameters named \`${outer.name}\` in \`${schemaId}\`.`,
+        );
       }
     }
   }
@@ -49,8 +49,8 @@ function validateRequiredPropertiesExist(schema: IJsonSchema, schemaId: string) 
     collectProperties(schema, props);
     schema.required.forEach(requiredProperty => {
       if (!props[requiredProperty]) {
-        throw ono.syntax(
-          `Validation failed. Property '${requiredProperty}' listed as required but does not exist in '${schemaId}'`,
+        throw new SyntaxError(
+          `Validation failed. Property \`${requiredProperty}\` is listed as required but does not exist in \`${schemaId}\`.`,
         );
       }
     });
@@ -63,7 +63,7 @@ function validateRequiredPropertiesExist(schema: IJsonSchema, schemaId: string) 
  */
 function validateSchema(schema: OpenAPIV2.SchemaObject, schemaId: string) {
   if (schema.type === 'array' && !schema.items) {
-    throw ono.syntax(`Validation failed. ${schemaId} is an array, so it must include an "items" schema`);
+    throw new SyntaxError(`Validation failed. \`${schemaId}\` is an array, so it must include an \`items\` schema.`);
   }
 }
 
@@ -72,22 +72,18 @@ function validateSchema(schema: OpenAPIV2.SchemaObject, schemaId: string) {
  *
  */
 function validateBodyParameters(params: OpenAPIV2.ParameterObject[], operationId: string) {
-  const bodyParams = params.filter(param => {
-    return param.in === 'body';
-  });
-  const formParams = params.filter(param => {
-    return param.in === 'formData';
-  });
+  const bodyParams = params.filter(param => param.in === 'body');
+  const formParams = params.filter(param => param.in === 'formData');
 
   // There can only be one "body" parameter
   if (bodyParams.length > 1) {
-    throw ono.syntax(
-      `Validation failed. ${operationId} has ${bodyParams.length} body parameters. Only one is allowed.`,
+    throw new SyntaxError(
+      `Validation failed. \`${operationId}\` has ${bodyParams.length} body parameters. Only one is allowed.`,
     );
   } else if (bodyParams.length > 0 && formParams.length > 0) {
     // "body" params and "formData" params are mutually exclusive
-    throw ono.syntax(
-      `Validation failed. ${operationId} has body parameters and formData parameters. Only one or the other is allowed.`,
+    throw new SyntaxError(
+      `Validation failed. \`${operationId}\` has \`body\` and \`formData\` parameters. Only one or the other is allowed.`,
     );
   }
 }
@@ -104,7 +100,9 @@ function validatePathParameters(params: OpenAPIV2.ParameterObject[], pathId: str
   for (let i = 0; i < placeholders.length; i++) {
     for (let j = i + 1; j < placeholders.length; j++) {
       if (placeholders[i] === placeholders[j]) {
-        throw ono.syntax(`Validation failed. ${operationId} has multiple path placeholders named ${placeholders[i]}`);
+        throw new SyntaxError(
+          `Validation failed. \`${operationId}\` has multiple path placeholders named \`${placeholders[i]}\`.`,
+        );
       }
     }
   }
@@ -113,17 +111,15 @@ function validatePathParameters(params: OpenAPIV2.ParameterObject[], pathId: str
     .filter(param => param.in === 'path')
     .forEach(param => {
       if (param.required !== true) {
-        throw ono.syntax(
-          'Validation failed. Path parameters cannot be optional. ' +
-            `Set required=true for the "${param.name}" parameter at ${operationId}`,
+        throw new SyntaxError(
+          `Validation failed. Path parameters cannot be optional. Set \`required=true\` for the \`${param.name}\` parameter at \`${operationId}\`.`,
         );
       }
 
       const match = placeholders.indexOf(`{${param.name}}`);
       if (match === -1) {
-        throw ono.syntax(
-          `Validation failed. ${operationId} has a path parameter named "${param.name}", ` +
-            `but there is no corresponding {${param.name}} in the path string`,
+        throw new SyntaxError(
+          `Validation failed. \`${operationId}\` has a path parameter named \`${param.name}\`, but there is no corresponding \`{${param.name}}\` in the path string.`,
         );
       }
 
@@ -131,7 +127,11 @@ function validatePathParameters(params: OpenAPIV2.ParameterObject[], pathId: str
     });
 
   if (placeholders.length > 0) {
-    throw ono.syntax(`Validation failed. ${operationId} is missing path parameter(s) for ${placeholders}`);
+    const list = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }).format(
+      placeholders.map(placeholder => `\`${placeholder}\``),
+    );
+
+    throw new SyntaxError(`Validation failed. \`${operationId}\` is missing path parameter(s) for ${list}.`);
   }
 }
 
@@ -175,9 +175,8 @@ function validateParameterTypes(
       });
 
       if (!hasValidMimeType) {
-        throw ono.syntax(
-          `Validation failed. ${operationId} has a file parameter, so it must consume multipart/form-data ` +
-            'or application/x-www-form-urlencoded',
+        throw new SyntaxError(
+          `Validation failed. \`${operationId}\` has a file parameter, so it must consume \`multipart/form-data\` or \`application/x-www-form-urlencoded\`.`,
         );
       }
     }
@@ -201,18 +200,10 @@ function validateParameters(
   ) as OpenAPIV2.ParameterObject[];
 
   // Check for duplicate path parameters
-  try {
-    checkForDuplicates(pathParams);
-  } catch (e) {
-    throw ono.syntax(e, `Validation failed. ${pathId} has duplicate parameters`);
-  }
+  checkForDuplicates(pathParams, pathId);
 
   // Check for duplicate operation parameters
-  try {
-    checkForDuplicates(operationParams);
-  } catch (e) {
-    throw ono.syntax(e, `Validation failed. ${operationId} has duplicate parameters`);
-  }
+  checkForDuplicates(operationParams, operationId);
 
   // Combine the path and operation parameters,
   // with the operation params taking precedence over the path params
@@ -244,7 +235,7 @@ function validateResponse(code: number | string, response: OpenAPIV2.ResponseObj
       (typeof code === 'number' && (code < 100 || code > 599)) ||
       (typeof code === 'string' && (Number(code) < 100 || Number(code) > 599))
     ) {
-      throw ono.syntax(`Validation failed. ${responseId} has an invalid response code (${code})`);
+      throw new SyntaxError(`Validation failed. \`${responseId}\` has an invalid response code: ${code}`);
     }
   }
 
@@ -278,7 +269,9 @@ function validatePath(api: OpenAPIV2.Document, path: OpenAPIV2.PathItemObject, p
         if (!operationIds.includes(declaredOperationId)) {
           operationIds.push(declaredOperationId);
         } else {
-          throw ono.syntax(`Validation failed. Duplicate operation id '${declaredOperationId}'`);
+          throw new SyntaxError(
+            `Validation failed. The operationId \`${declaredOperationId}\` is duplicated and must be made unique.`,
+          );
         }
       }
       validateParameters(api, path, pathId, operation, operationId);
@@ -318,8 +311,8 @@ export function validateSpec(api: OpenAPIV2.Document): void {
     const definitionId = `/definitions/${definitionName}`;
 
     if (!/^[a-zA-Z0-9.\-_]+$/.test(definitionName)) {
-      throw ono.syntax(
-        `Validation failed. ${definitionId} has an invalid name. Definition names should match against: /^[a-zA-Z0-9.-_]+$/`,
+      throw new SyntaxError(
+        `Validation failed. \`${definitionId}\` has an invalid name. Definition names should match against: /^[a-zA-Z0-9.-_]+$/`,
       );
     }
 

--- a/packages/parser/test/specs/better-errors/better-errors.test.ts
+++ b/packages/parser/test/specs/better-errors/better-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, assert } from 'vitest';
 
+import { ValidationError } from '../../../src/errors.js';
 import { validate } from '../../../src/index.js';
 import { relativePath } from '../../utils.js';
 
@@ -8,7 +9,7 @@ async function assertInvalid(file: string, error: string) {
     await validate(relativePath(`specs/better-errors/${file}`));
     assert.fail('Validation should have failed, but it succeeded!');
   } catch (err) {
-    expect(err).to.be.an.instanceOf(SyntaxError);
+    expect(err).to.be.an.instanceOf(ValidationError);
     expect(err.message).to.contain(error);
   }
 }

--- a/packages/parser/test/specs/colorize-errors-option/colorize-errors-option.test.ts
+++ b/packages/parser/test/specs/colorize-errors-option/colorize-errors-option.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, assert } from 'vitest';
 
+import { ValidationError } from '../../../src/errors.js';
 import { validate } from '../../../src/index.js';
 import { relativePath } from '../../utils.js';
 
@@ -9,7 +10,7 @@ describe('`validate.colorizeErrors` option', () => {
       await validate(relativePath('specs/colorize-errors-option/invalid.json'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.contain('> 19 |             "type": "array",');
     }
   });
@@ -24,7 +25,7 @@ describe('`validate.colorizeErrors` option', () => {
 
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.contain('\u001b');
     }
   });

--- a/packages/parser/test/specs/invalid/invalid.test.ts
+++ b/packages/parser/test/specs/invalid/invalid.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, assert } from 'vitest';
 
+import { ValidationError } from '../../../src/errors.js';
 import { validate } from '../../../src/index.js';
 import { relativePath } from '../../utils.js';
 
@@ -9,7 +10,7 @@ describe("Invalid APIs (can't be parsed)", () => {
       await validate(relativePath('specs/invalid/not-swagger.yaml'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.contain('Supplied schema is not a valid API definition.');
     }
   });
@@ -19,7 +20,7 @@ describe("Invalid APIs (can't be parsed)", () => {
       await validate(relativePath('specs/invalid/no-paths-or-webhooks.yaml'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.matchSnapshot();
     }
   });
@@ -29,7 +30,7 @@ describe("Invalid APIs (can't be parsed)", () => {
       await validate(relativePath('specs/invalid/old-version.yaml'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.matchSnapshot();
     }
   });
@@ -39,7 +40,7 @@ describe("Invalid APIs (can't be parsed)", () => {
       await validate(relativePath('specs/invalid/newer-version.yaml'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.matchSnapshot();
     }
   });
@@ -49,7 +50,7 @@ describe("Invalid APIs (can't be parsed)", () => {
       await validate(relativePath('specs/invalid/numeric-version.yaml'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.matchSnapshot();
     }
   });
@@ -59,7 +60,7 @@ describe("Invalid APIs (can't be parsed)", () => {
       await validate(relativePath('specs/invalid/numeric-info-version.yaml'));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.matchSnapshot();
     }
   });

--- a/packages/parser/test/specs/large-file-memory-leak/large-file-memory-leak.test.ts
+++ b/packages/parser/test/specs/large-file-memory-leak/large-file-memory-leak.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, assert } from 'vitest';
 
+import { ValidationError } from '../../../src/errors.js';
 import { validate } from '../../../src/index.js';
 import { relativePath } from '../../utils.js';
 
@@ -12,7 +13,7 @@ describe('Large file memory leak protection', { timeout: 20000 }, () => {
       await validate(relativePath(`specs/large-file-memory-leak/${file}`));
       assert.fail();
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
       expect((err.message.match(/4xx is not expected to be here!/g) || []).length).to.equal(20);
       expect(err.message).to.contain(

--- a/packages/parser/test/specs/real-world/known-errors.ts
+++ b/packages/parser/test/specs/real-world/known-errors.ts
@@ -70,7 +70,7 @@ const knownErrors: KnownError[] = [
   {
     api: 'amadeus.com:amadeus-hotel-ratings',
     error:
-      "Property 'avgHotelAvailabilityResponseTime' listed as required but does not exist in '/definitions/HotelSentiment'",
+      'Property `avgHotelAvailabilityResponseTime` is listed as required but does not exist in `/definitions/HotelSentiment`.',
   },
   {
     api: 'billbee.io',

--- a/packages/parser/test/specs/validate-schema/validate-schema.test.ts
+++ b/packages/parser/test/specs/validate-schema/validate-schema.test.ts
@@ -116,7 +116,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
       await validate(relativePath(`specs/validate-schema/invalid/${file}`));
       assert.fail('Validation should have failed, but it succeeded!');
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       if (isOpenAPI) {
         expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
       } else {

--- a/packages/parser/test/specs/validate-schema/validate-schema.test.ts
+++ b/packages/parser/test/specs/validate-schema/validate-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, assert } from 'vitest';
 
+import { ValidationError } from '../../../src/errors.js';
 import { validate } from '../../../src/index.js';
 import { relativePath } from '../../utils.js';
 
@@ -9,7 +10,7 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
       await validate(relativePath('specs/validate-schema/invalid/multiple-invalid-properties.yaml'));
       assert.fail('Validation should have failed, but it succeeded!');
     } catch (err) {
-      expect(err).to.be.an.instanceOf(SyntaxError);
+      expect(err).to.be.an.instanceOf(ValidationError);
       expect(err.message).to.match(/^OpenAPI schema validation failed.\n(.*)+/);
 
       expect(err.details).to.be.an('array').to.have.length(3);

--- a/packages/parser/test/specs/validate-spec/__snapshots__/validate-spec.test.ts.snap
+++ b/packages/parser/test/specs/validate-spec/__snapshots__/validate-spec.test.ts.snap
@@ -1,0 +1,73 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Invalid APIs (specification validation) > components / definitions > should catch a component schema name that contains a space > OpenAPI 3.1 1`] = `
+[SyntaxError: OpenAPI schema validation failed.
+
+PROPERTY must match pattern "^[a-zA-Z0-9._-]+$"
+
+  26 |   "components": {
+  27 |     "securitySchemes": {
+> 28 |       "Basic Access Authentication": {
+     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must match pattern ^[a-zA-Z0-9._-]+$
+  29 |         "type": "apiKey",
+  30 |         "name": "API-TOKEN",
+  31 |         "in": "header"]
+`;
+
+exports[`Invalid APIs (specification validation) > components / definitions > should catch a component schema name that contains invalid characters > OpenAPI 3.1 1`] = `
+[SyntaxError: OpenAPI schema validation failed.
+
+PROPERTY must match pattern "^[a-zA-Z0-9._-]+$"
+
+  36 |   "components": {
+  37 |     "schemas": {
+> 38 |       "User«Information»": {
+     |       ^^^^^^^^^^^^^^^^^^^ must match pattern ^[a-zA-Z0-9._-]+$
+  39 |         "type": "object",
+  40 |         "properties": {
+  41 |           "first": {]
+`;
+
+exports[`Invalid APIs (specification validation) > should catch invalid discriminators > OpenAPI 3.0 1`] = `
+[ValidationError: OpenAPI schema validation failed.
+
+TYPE must be object
+
+  19 |               "schema": {
+  20 |                 "type": "object",
+> 21 |                 "discriminator": "",
+     |                                  ^ type must be object
+  22 |                 "properties": {
+  23 |                   "appKey": {
+  24 |                     "type": "string"
+
+TYPE must be object
+
+  39 |                 "schema": {
+  40 |                   "type": "object",
+> 41 |                   "discriminator": "",
+     |                                    ^ type must be object
+  42 |                   "properties": {
+  43 |                     "accessToken": {
+  44 |                       "type": "string"
+
+TYPE must be object
+
+  64 |       "TokenCreateRequest": {
+  65 |         "type": "object",
+> 66 |         "discriminator": "",
+     |                          ^ type must be object
+  67 |         "properties": {
+  68 |           "appKey": {
+  69 |             "type": "string"
+
+TYPE must be object
+
+  76 |       "Token": {
+  77 |         "type": "object",
+> 78 |         "discriminator": "",
+     |                          ^ type must be object
+  79 |         "properties": {
+  80 |           "accessToken": {
+  81 |             "type": "string"]
+`;

--- a/packages/parser/test/specs/validate-spec/__snapshots__/validate-spec.test.ts.snap
+++ b/packages/parser/test/specs/validate-spec/__snapshots__/validate-spec.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Invalid APIs (specification validation) > components / definitions > should catch a component schema name that contains a space > OpenAPI 3.1 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+[ValidationError: OpenAPI schema validation failed.
 
 PROPERTY must match pattern "^[a-zA-Z0-9._-]+$"
 
@@ -15,7 +15,7 @@ PROPERTY must match pattern "^[a-zA-Z0-9._-]+$"
 `;
 
 exports[`Invalid APIs (specification validation) > components / definitions > should catch a component schema name that contains invalid characters > OpenAPI 3.1 1`] = `
-[SyntaxError: OpenAPI schema validation failed.
+[ValidationError: OpenAPI schema validation failed.
 
 PROPERTY must match pattern "^[a-zA-Z0-9._-]+$"
 

--- a/packages/parser/test/specs/validate-spec/validate-spec.test.ts
+++ b/packages/parser/test/specs/validate-spec/validate-spec.test.ts
@@ -14,7 +14,7 @@ async function assertInvalid(file: string, error: string) {
     assert.fail('Validation should have failed, but it succeeded!');
   } catch (err) {
     expect(err).to.be.an.instanceOf(SyntaxError);
-    expect(err.message).to.contain(error);
+    expect(err.message).to.equal(error);
   }
 }
 
@@ -23,63 +23,63 @@ describe('Invalid APIs (specification validation)', () => {
     it('should catch invalid response codes', () => {
       return assertInvalid(
         '2.0/invalid-response-code.yaml',
-        'Validation failed. /paths/users/get/responses/888 has an invalid response code (888)',
+        'Validation failed. `/paths/users/get/responses/888` has an invalid response code: 888',
       );
     });
 
     it('should catch multiple body parameters in path', () => {
       return assertInvalid(
         '2.0/multiple-path-body-params.yaml',
-        'Validation failed. /paths/users/{username}/get has 2 body parameters. Only one is allowed.',
+        'Validation failed. `/paths/users/{username}/get` has 2 body parameters. Only one is allowed.',
       );
     });
 
     it('should catch multiple body parameters in operation', () => {
       return assertInvalid(
         '2.0/multiple-operation-body-params.yaml',
-        'Validation failed. /paths/users/{username}/patch has 2 body parameters. Only one is allowed.',
+        'Validation failed. `/paths/users/{username}/patch` has 2 body parameters. Only one is allowed.',
       );
     });
 
     it('should catch multiple body parameters in path & operation', () => {
       return assertInvalid(
         '2.0/multiple-body-params.yaml',
-        'Validation failed. /paths/users/{username}/post has 2 body parameters. Only one is allowed.',
+        'Validation failed. `/paths/users/{username}/post` has 2 body parameters. Only one is allowed.',
       );
     });
 
     it('should catch if there are body and formData parameters', () => {
       return assertInvalid(
         '2.0/body-and-form-params.yaml',
-        'Validation failed. /paths/users/{username}/post has body parameters and formData parameters. Only one or the other is allowed.',
+        'Validation failed. `/paths/users/{username}/post` has `body` and `formData` parameters. Only one or the other is allowed.',
       );
     });
 
     it('should catch duplicate path placeholders', () => {
       return assertInvalid(
         '2.0/duplicate-path-placeholders.yaml',
-        'Validation failed. /paths/users/{username}/profile/{username}/image/{img_id}/get has multiple path placeholders named {username}',
+        'Validation failed. `/paths/users/{username}/profile/{username}/image/{img_id}/get` has multiple path placeholders named `{username}`.',
       );
     });
 
     it('should catch `file` parameters without a `consumes` declaration', () => {
       return assertInvalid(
         '2.0/file-no-consumes.yaml',
-        'Validation failed. /paths/users/{username}/profile/image/post has a file parameter, so it must consume multipart/form-data or application/x-www-form-urlencoded',
+        'Validation failed. `/paths/users/{username}/profile/image/post` has a file parameter, so it must consume `multipart/form-data` or `application/x-www-form-urlencoded`.',
       );
     });
 
     it('should catch `file` parameters with an invalid `consumes` declaration', () => {
       return assertInvalid(
         '2.0/file-invalid-consumes.yaml',
-        'Validation failed. /paths/users/{username}/profile/image/post has a file parameter, so it must consume multipart/form-data or application/x-www-form-urlencoded',
+        'Validation failed. `/paths/users/{username}/profile/image/post` has a file parameter, so it must consume `multipart/form-data` or `application/x-www-form-urlencoded`.',
       );
     });
 
     it("should catch if a required property in a component doesn't exist", () => {
       return assertInvalid(
         '2.0/required-property-not-defined-definitions.yaml',
-        "Validation failed. Property 'photoUrls' listed as required but does not exist in '/definitions/Pet'",
+        'Validation failed. Property `photoUrls` listed as required but does not exist in `/definitions/Pet`.',
       );
     });
 
@@ -96,14 +96,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/duplicate-header-params.yaml',
-        'Validation failed. /paths/users/{username} has duplicate parameters \nValidation failed. Found multiple header parameters named "foo"',
+        'Validation failed. Found multiple `header` parameters named `foo` in `/paths/users/{username}`.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/duplicate-header-params.yaml',
-        'Validation failed. /paths/users/{username} has duplicate parameters \nValidation failed. Found multiple header parameters named "foo"',
+        'Validation failed. Found multiple `header` parameters named `foo` in `/paths/users/{username}`.',
       );
     });
   });
@@ -112,14 +112,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/duplicate-operation-params.yaml',
-        'Validation failed. /paths/users/{username}/get has duplicate parameters \nValidation failed. Found multiple path parameters named "username"',
+        'Validation failed. Found multiple `path` parameters named `username` in `/paths/users/{username}/get`.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/duplicate-operation-params.yaml',
-        'Validation failed. /paths/users/{username}/get has duplicate parameters \nValidation failed. Found multiple path parameters named "username"',
+        'Validation failed. Found multiple `path` parameters named `username` in `/paths/users/{username}/get`.',
       );
     });
   });
@@ -128,14 +128,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/path-param-no-placeholder.yaml',
-        'Validation failed. /paths/users/{username}/post has a path parameter named "foo", but there is no corresponding {foo} in the path string',
+        'Validation failed. `/paths/users/{username}/post` has a path parameter named `foo`, but there is no corresponding `{foo}` in the path string.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/path-param-no-placeholder.yaml',
-        'Validation failed. /paths/users/{username}/post has a path parameter named "foo", but there is no corresponding {foo} in the path string',
+        'Validation failed. `/paths/users/{username}/post` has a path parameter named `foo`, but there is no corresponding `{foo}` in the path string.',
       );
     });
   });
@@ -144,14 +144,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/path-placeholder-no-param.yaml',
-        'Validation failed. /paths/users/{username}/{foo}/get is missing path parameter(s) for {foo}',
+        'Validation failed. `/paths/users/{username}/{foo}/get` is missing path parameter(s) for `{foo}`.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/path-placeholder-no-param.yaml',
-        'Validation failed. /paths/users/{username}/{foo}/get is missing path parameter(s) for {foo}',
+        'Validation failed. `/paths/users/{username}/{foo}/get` is missing path parameter(s) for `{foo}`.',
       );
     });
   });
@@ -160,14 +160,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/no-path-params.yaml',
-        'Validation failed. /paths/users/{username}/{foo}/get is missing path parameter(s) for {username},{foo}',
+        'Validation failed. `/paths/users/{username}/{foo}/get` is missing path parameter(s) for `{username}` and `{foo}`.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/no-path-params.yaml',
-        'Validation failed. /paths/users/{username}/{foo}/get is missing path parameter(s) for {username},{foo}',
+        'Validation failed. `/paths/users/{username}/{foo}/get` is missing path parameter(s) for `{username}` and `{foo}`.',
       );
     });
   });
@@ -176,14 +176,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/array-no-items.yaml',
-        'Validation failed. /paths/users/get/parameters/tags is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/get/parameters/tags` is an array, so it must include an `items` schema.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/array-no-items.yaml',
-        'Validation failed. /paths/users/get/parameters/tags is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/get/parameters/tags` is an array, so it must include an `items` schema.',
       );
     });
   });
@@ -192,7 +192,7 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/array-body-no-items.yaml',
-        'Validation failed. /paths/users/post/parameters/people is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/post/parameters/people` is an array, so it must include an `items` schema.',
       );
     });
 
@@ -201,7 +201,7 @@ describe('Invalid APIs (specification validation)', () => {
     it.skip('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/array-body-no-items.yaml',
-        'Validation failed. /paths/users/post/parameters/people is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/post/parameters/people` is an array, so it must include an `items` schema.',
       );
     });
   });
@@ -210,14 +210,14 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/array-response-header-no-items.yaml',
-        'Validation failed. /paths/users/get/responses/default/headers/Last-Modified is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/get/responses/default/headers/Last-Modified` is an array, so it must include an `items` schema.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/array-response-header-no-items.yaml',
-        'Validation failed. /paths/users/get/responses/default/headers/Last-Modified is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/get/responses/default/headers/Last-Modified` is an array, so it must include an `items` schema.',
       );
     });
 
@@ -225,7 +225,7 @@ describe('Invalid APIs (specification validation)', () => {
       it('OpenAPI 3.x', () => {
         return assertInvalid(
           '3.x/array-response-header-content-no-items.yaml',
-          'Validation failed. /paths/users/get/responses/default/headers/Last-Modified/content/application/json/schema is an array, so it must include an "items" schema',
+          'Validation failed. `/paths/users/get/responses/default/headers/Last-Modified/content/application/json/schema` is an array, so it must include an `items` schema.',
         );
       });
     });
@@ -235,7 +235,7 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/required-property-not-defined-input.yaml',
-        "Validation failed. Property 'notExists' listed as required but does not exist in '/paths/pets/post/parameters/pet'",
+        'Validation failed. Property `notExists` is listed as required but does not exist in `/paths/pets/post/parameters/pet`.',
       );
     });
 
@@ -244,7 +244,7 @@ describe('Invalid APIs (specification validation)', () => {
     it.skip('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/required-property-not-defined-input.yaml',
-        "Validation failed. Property 'notExists' listed as required but does not exist in '/paths/pets/post/parameters/pet'",
+        'Validation failed. Property `notExists listed as required but does not exist in `/paths/pets/post/parameters/pet`.',
       );
     });
   });
@@ -263,11 +263,17 @@ describe('Invalid APIs (specification validation)', () => {
 
   describe('should catch duplicate operation IDs', () => {
     it('Swagger 2.0', () => {
-      return assertInvalid('2.0/duplicate-operation-ids.yaml', "Validation failed. Duplicate operation id 'users'");
+      return assertInvalid(
+        '2.0/duplicate-operation-ids.yaml',
+        'Validation failed. The operationId `users` is duplicated and must be made unique.',
+      );
     });
 
     it('OpenAPI 3.x', () => {
-      return assertInvalid('3.x/duplicate-operation-ids.yaml', "Validation failed. Duplicate operation id 'users'");
+      return assertInvalid(
+        '3.x/duplicate-operation-ids.yaml',
+        'Validation failed. The operationId `users` is duplicated and must be made unique.',
+      );
     });
   });
 
@@ -275,23 +281,25 @@ describe('Invalid APIs (specification validation)', () => {
     it('Swagger 2.0', () => {
       return assertInvalid(
         '2.0/array-response-body-no-items.yaml',
-        'Validation failed. /paths/users/get/responses/200/schema is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/get/responses/200/schema` is an array, so it must include an `items` schema.',
       );
     });
 
     it('OpenAPI 3.x', () => {
       return assertInvalid(
         '3.x/array-response-body-no-items.yaml',
-        'Validation failed. /paths/users/get/responses/200/content/application/json/schema is an array, so it must include an "items" schema',
+        'Validation failed. `/paths/users/get/responses/200/content/application/json/schema` is an array, so it must include an `items` schema.',
       );
     });
   });
 
-  describe('should catch invalid discriminators', () => {
+  describe.only('should catch invalid discriminators', () => {
     // Invalid discriminators are only **not** picked up with the 3.1 spec, so for 3.0 we can fall
     // back to our normal schema validation -- which'll give us a different error message.
-    it('OpenAPI 3.0', () => {
-      return assertInvalid('3.0/invalid-discriminator.yaml', 'type must be object');
+    it('OpenAPI 3.0', async () => {
+      await expect(
+        validate(relativePath('specs/validate-spec/invalid/3.0/invalid-discriminator.yaml')),
+      ).rejects.to.matchSnapshot();
     });
 
     /**
@@ -303,8 +311,10 @@ describe('Invalid APIs (specification validation)', () => {
      * @todo
      */
     // eslint-disable-next-line vitest/no-disabled-tests
-    it.skip('OpenAPI 3.1', () => {
-      return assertInvalid('3.1/invalid-discriminator.yaml', 'TKTK');
+    it.skip('OpenAPI 3.1', async () => {
+      await expect(
+        validate(relativePath('specs/validate-spec/invalid/3.1/invalid-discriminator.yaml')),
+      ).rejects.to.matchSnapshot();
     });
   });
 
@@ -325,14 +335,16 @@ describe('Invalid APIs (specification validation)', () => {
       it('OpenAPI 3.0', () => {
         return assertInvalid(
           '3.0/component-schema-with-space.yaml',
-          'Validation failed. /components/securitySchemes/Basic Access Authentication has an invalid name. Component names should match against: /^[a-zA-Z0-9.-_]+$/',
+          'Validation failed. `/components/securitySchemes/Basic Access Authentication` has an invalid name. Component names should match against: /^[a-zA-Z0-9.-_]+$/',
         );
       });
 
-      // Components with spaces is only **not** picked up with the 3.0 spec, so for 3.1 we can fallback to the normal
-      // schema validation -- which'll give us a different error message.
-      it('OpenAPI 3.1', () => {
-        return assertInvalid('3.1/component-schema-with-space.yaml', 'PROPERTY must match pattern "^[a-zA-Z0-9._-]+$');
+      // Components with spaces is only **not** picked up with the 3.0 spec, so for 3.1 we can
+      // fallback to the normal schema validation -- which'll give us a different error message.
+      it('OpenAPI 3.1', async () => {
+        await expect(
+          validate(relativePath('specs/validate-spec/invalid/3.1/component-schema-with-space.yaml')),
+        ).rejects.to.matchSnapshot();
       });
     });
 
@@ -340,24 +352,23 @@ describe('Invalid APIs (specification validation)', () => {
       it('Swagger 2.0', () => {
         return assertInvalid(
           '2.0/definition-schema-with-invalid-characters.yaml',
-          'Validation failed. /definitions/User«Information» has an invalid name. Definition names should match against: /^[a-zA-Z0-9.-_]+$/',
+          'Validation failed. `/definitions/User«Information»` has an invalid name. Definition names should match against: /^[a-zA-Z0-9.-_]+$/',
         );
       });
 
       it('OpenAPI 3.0', () => {
         return assertInvalid(
           '3.0/component-schema-with-invalid-characters.yaml',
-          'Validation failed. /components/schemas/User«Information» has an invalid name. Component names should match against: /^[a-zA-Z0-9.-_]+$/',
+          'Validation failed. `/components/schemas/User«Information»` has an invalid name. Component names should match against: /^[a-zA-Z0-9.-_]+$/',
         );
       });
 
       // Components with invalid characters is only **not** picked up with the 3.0 spec, so for 3.1 we can fallback to the
       // normal schema validation -- which'll give us a different error message.
-      it('OpenAPI 3.1', () => {
-        return assertInvalid(
-          '3.1/component-schema-with-invalid-characters.yaml',
-          'PROPERTY must match pattern "^[a-zA-Z0-9._-]+$',
-        );
+      it('OpenAPI 3.1', async () => {
+        await expect(
+          validate(relativePath('specs/validate-spec/invalid/3.1/component-schema-with-invalid-characters.yaml')),
+        ).rejects.to.matchSnapshot();
       });
     });
   });

--- a/packages/parser/test/specs/validate-spec/validate-spec.test.ts
+++ b/packages/parser/test/specs/validate-spec/validate-spec.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, assert } from 'vitest';
 
+import { ValidationError } from '../../../src/errors.js';
 import { validate } from '../../../src/index.js';
 import { relativePath } from '../../utils.js';
 
@@ -13,7 +14,7 @@ async function assertInvalid(file: string, error: string) {
     await validate(relativePath(`specs/validate-spec/invalid/${file}`));
     assert.fail('Validation should have failed, but it succeeded!');
   } catch (err) {
-    expect(err).to.be.an.instanceOf(SyntaxError);
+    expect(err).to.be.an.instanceOf(ValidationError);
     expect(err.message).to.equal(error);
   }
 }
@@ -79,7 +80,7 @@ describe('Invalid APIs (specification validation)', () => {
     it("should catch if a required property in a component doesn't exist", () => {
       return assertInvalid(
         '2.0/required-property-not-defined-definitions.yaml',
-        'Validation failed. Property `photoUrls` listed as required but does not exist in `/definitions/Pet`.',
+        'Validation failed. Property `photoUrls` is listed as required but does not exist in `/definitions/Pet`.',
       );
     });
 
@@ -293,7 +294,7 @@ describe('Invalid APIs (specification validation)', () => {
     });
   });
 
-  describe.only('should catch invalid discriminators', () => {
+  describe('should catch invalid discriminators', () => {
     // Invalid discriminators are only **not** picked up with the 3.1 spec, so for 3.0 we can fall
     // back to our normal schema validation -- which'll give us a different error message.
     it('OpenAPI 3.0', async () => {

--- a/packages/parser/test/tsconfig.json
+++ b/packages/parser/test/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "isolatedDeclarations": false,
-    "module": "ES2020",
     "noImplicitAny": false
   },
   "include": ["./**/*"]

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    // DOM is needed because `@apidevtools/json-schema-ref-parser` uses `window` and `location`.
-    "lib": ["DOM"]
+    "lib": [
+      // Needed because `@apidevtools/json-schema-ref-parser` uses `window` and `location`.
+      "DOM",
+
+      // Needed because we use `Intl.ListFormat()` in some error messsages. Unfortunately it has
+      // to be pegged at ES2021 as `ES2022.Intl` does not work.
+      "ES2021.Intl"
+    ]
   },
   "include": ["./src/**/*"],
   "exclude": ["dist"]


### PR DESCRIPTION
## 🧰 Changes

* [x] Replaces our dependency on `@jsdevtools/ono` with a mix of `ReferenceError` and a new custom `ValidationError` class. I'm still not sold on using these three though and will likely revisit them when I start on the new error warning level system.
* [x] Rewriting most every bespoke error that we throw so that they're more consistent, have properties wrapped in backticks, or to properly use list formatting.
* [x] Removes our dependency on `lodash` for building configs for `json-schema-ref-parser`.
