### PR TITLE
refactor: swapping out `type-fest` for a pure TS type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20261,25 +20261,11 @@
         "eslint": "^8.57.0",
         "jest-expect-har": "^7.1.2",
         "tsup": "^8.0.2",
-        "type-fest": "^4.18.3",
         "typescript": "^5.2.2",
         "vitest": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/oas-to-har/node_modules/type-fest": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/oas-to-snippet": {

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -61,7 +61,6 @@
     "eslint": "^8.57.0",
     "jest-expect-har": "^7.1.2",
     "tsup": "^8.0.2",
-    "type-fest": "^4.18.3",
     "typescript": "^5.2.2",
     "vitest": "^3.0.5"
   },

--- a/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
+++ b/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable no-param-reassign */
-import type { Merge } from 'type-fest';
 
 /**
  * This file has been extracted and modified from `swagger-client`.
@@ -123,7 +122,7 @@ function encodeArray({
   explode,
   escape,
   isAllowedReserved = false,
-}: Merge<StylizerConfig, { value: string[] }>) {
+}: Omit<StylizerConfig, 'value'> & { value: string[] }) {
   const valueEncoder = (str: string) =>
     encodeDisallowedCharacters(str, {
       escape,


### PR DESCRIPTION
## 🧰 Changes

This swaps out our dependency on `type-fest` in `oas-to-har` of a `Merge` type with a pure TS replacement.