### PR TITLE
ci: enabling knip on the repository

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -1,0 +1,42 @@
+import type { KnipConfig } from 'knip';
+
+const config: KnipConfig = {
+  ignore: ['packages/**/dist/**', 'packages/**/tsup.config.ts', 'tsup.config.ts'],
+
+  // `attw` is used to ensure that our dists have proper typings.
+  ignoreBinaries: ['attw'],
+
+  workspaces: {
+    'packages/oas': {
+      entry: [
+        'src/index.ts',
+        'src/analyzer/index.ts',
+        'src/analyzer/types.ts',
+        'src/extensions.ts',
+        'src/operation/index.ts',
+        'src/operation/lib/get-parameters-as-json-schema.ts',
+        'src/reducer/index.ts',
+        'src/utils.ts',
+        'src/types.ts',
+      ],
+    },
+    'packages/oas-normalize': {
+      entry: ['src/index.ts', 'src/lib/types.ts', 'src/lib/utils.ts'],
+    },
+    'packages/oas-to-har': {
+      entry: ['src/index.ts', 'src/lib/configure-security.ts', 'src/lib/types.ts'],
+    },
+    'packages/oas-to-snippet': {
+      entry: ['src/index.ts', 'src/languages.ts', 'src/types.ts'],
+      ignoreDependencies: ['@types/har-format'],
+    },
+    'packages/parser': {
+      entry: ['src/index.ts'],
+    },
+    'packages/postman-types': {
+      entry: ['src/index.ts'],
+    },
+  },
+};
+
+export default config;

--- a/knip.ts
+++ b/knip.ts
@@ -6,37 +6,13 @@ const config: KnipConfig = {
   // `attw` is used to ensure that our dists have proper typings.
   ignoreBinaries: ['attw'],
 
-  workspaces: {
-    'packages/oas': {
-      entry: [
-        'src/index.ts',
-        'src/analyzer/index.ts',
-        'src/analyzer/types.ts',
-        'src/extensions.ts',
-        'src/operation/index.ts',
-        'src/operation/lib/get-parameters-as-json-schema.ts',
-        'src/reducer/index.ts',
-        'src/utils.ts',
-        'src/types.ts',
-      ],
-    },
-    'packages/oas-normalize': {
-      entry: ['src/index.ts', 'src/lib/types.ts', 'src/lib/utils.ts'],
-    },
-    'packages/oas-to-har': {
-      entry: ['src/index.ts', 'src/lib/configure-security.ts', 'src/lib/types.ts'],
-    },
-    'packages/oas-to-snippet': {
-      entry: ['src/index.ts', 'src/languages.ts', 'src/types.ts'],
-      ignoreDependencies: ['@types/har-format'],
-    },
-    'packages/parser': {
-      entry: ['src/index.ts'],
-    },
-    'packages/postman-types': {
-      entry: ['src/index.ts'],
-    },
-  },
+  ignoreDependencies: [
+    // This is pulled in for `oas-to-har` via `import 'har-format'` in order to package up and
+    // export some HAR typings.
+    '@types/har-format',
+  ],
+
+  // workspaces: ['packages/*'],
 };
 
 export default config;

--- a/knip.ts
+++ b/knip.ts
@@ -11,8 +11,6 @@ const config: KnipConfig = {
     // export some HAR typings.
     '@types/har-format',
   ],
-
-  // workspaces: ['packages/*'],
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vitest/coverage-v8": "^3.0.6",
         "alex": "^11.0.1",
         "eslint": "^8.57.0",
+        "knip": "^5.44.4",
         "lerna": "^8.1.2",
         "prettier": "^3.2.5",
         "vitest": "^3.0.6"
@@ -2680,6 +2681,24 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@snyk/github-codeowners": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@snyk/github-codeowners/-/github-codeowners-1.1.0.tgz",
+      "integrity": "sha512-lGFf08pbkEac0NYgVf4hdANpAgApRjNByLXB+WBip3qj1iendOIyAwP2GKkKbQMNVy2r1xxDf0ssfWscoiC+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^4.1.1",
+        "ignore": "^5.1.8",
+        "p-map": "^4.0.0"
+      },
+      "bin": {
+        "github-codeowners": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=8.10"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -2832,13 +2851,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6439,6 +6451,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/easy-table": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
+      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "optionalDependencies": {
+        "wcwidth": "^1.0.1"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -6503,9 +6528,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8109,9 +8134,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8119,7 +8144,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -11048,6 +11073,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -11339,6 +11374,120 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/knip": {
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-5.44.4.tgz",
+      "integrity": "sha512-Ryn8LwWHLId8jSK1DgtT0hmg5DbzkqAtH+Gg3vZJpmSMgGHMspej9Ag+qKTm8wsPLDjVetuEz/lIsobo0XCMvQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        },
+        {
+          "type": "polar",
+          "url": "https://polar.sh/webpro-nl"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@nodelib/fs.walk": "3.0.1",
+        "@snyk/github-codeowners": "1.1.0",
+        "easy-table": "1.2.0",
+        "enhanced-resolve": "^5.18.0",
+        "fast-glob": "^3.3.3",
+        "jiti": "^2.4.2",
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.8",
+        "picocolors": "^1.1.0",
+        "picomatch": "^4.0.1",
+        "pretty-ms": "^9.0.0",
+        "smol-toml": "^1.3.1",
+        "strip-json-comments": "5.0.1",
+        "summary": "2.1.0",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18",
+        "typescript": ">=5.0.4"
+      }
+    },
+    "node_modules/knip/node_modules/@nodelib/fs.scandir": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-4.0.1.tgz",
+      "integrity": "sha512-vAkI715yhnmiPupY+dq+xenu5Tdf2TBQ66jLvBIcCddtz+5Q8LbMKaf9CIJJreez8fQ8fgaY+RaywQx8RJIWpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "4.0.0",
+        "run-parallel": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/knip/node_modules/@nodelib/fs.stat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-4.0.0.tgz",
+      "integrity": "sha512-ctr6bByzksKRCV0bavi8WoQevU6plSp2IkllIsEqaiKe2mwNNnaluhnRhcsgGZHrrHk57B3lf95MkLMO3STYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/knip/node_modules/@nodelib/fs.walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-3.0.1.tgz",
+      "integrity": "sha512-nIh/M6Kh3ZtOmlY00DaUYB4xeeV6F3/ts1l29iwl3/cfyY/OuCfUx+v08zgx8TKPTifXRcjjqVQ4KB2zOYSbyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "4.0.1",
+        "fastq": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/knip/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -15046,6 +15195,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-path": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
@@ -15459,6 +15621,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proc-log": {
@@ -17125,6 +17303,19 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
+      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
@@ -17785,6 +17976,13 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/summary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/summary/-/summary-2.1.0.tgz",
+      "integrity": "sha512-nMIjMrd5Z2nuB2RZCKJfFMjgS3fygbeyGk9PxPPaJR1RIcyN9yn4A63Isovzm3ZtQuEkLBVgMdPup8UeLH7aQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -20075,6 +20273,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -20197,7 +20418,6 @@
         "ajv-draft-04": "^1.0.0"
       },
       "devDependencies": {
-        "@types/lodash": "^4.17.15",
         "@types/node": "^22.13.1",
         "eslint": "^8.56.0",
         "openapi-types": "^12.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bench": "vitest bench",
     "build": "npx lerna run build --stream",
     "clean": "npx lerna clean",
-    "lint": "npm run lint:types && npm run lint:js && npm run prettier",
+    "lint": "knip && npm run lint:types && npm run lint:js && npm run prettier",
     "lint:js": "npm run lint:js --if-present --workspaces",
     "lint:types": "npm run lint:types --if-present --workspaces",
     "prettier": "prettier --check .",
@@ -31,6 +31,7 @@
     "@vitest/coverage-v8": "^3.0.6",
     "alex": "^11.0.1",
     "eslint": "^8.57.0",
+    "knip": "^5.44.4",
     "lerna": "^8.1.2",
     "prettier": "^3.2.5",
     "vitest": "^3.0.6"

--- a/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
+++ b/packages/oas-to-har/src/lib/style-formatting/style-serializer.ts
@@ -27,7 +27,7 @@ function isObject(value: unknown) {
   return typeof value === 'object' && value !== null;
 }
 
-export function encodeDisallowedCharacters(
+function encodeDisallowedCharacters(
   str: string,
   {
     escape,

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -69,7 +69,6 @@
     "openapi-types": ">=7"
   },
   "devDependencies": {
-    "@types/lodash": "^4.17.15",
     "@types/node": "^22.13.1",
     "eslint": "^8.56.0",
     "openapi-types": "^12.1.3",

--- a/packages/parser/src/validators/schema.ts
+++ b/packages/parser/src/validators/schema.ts
@@ -9,11 +9,6 @@ import { ValidationError } from '../errors.js';
 import { getSpecificationName, isSwagger } from '../lib/index.js';
 import { reduceAjvErrors } from '../lib/reduceAjvErrors.js';
 
-export type SchemaValidator = (
-  api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document,
-  options?: { colorizeErrors?: boolean },
-) => void;
-
 /**
  * We've had issues with specs larger than 2MB+ with 1,000+ errors causing memory leaks so if we
  * have a spec with more than `LARGE_SPEC_ERROR_CAP` errors and it's **stringified** length is
@@ -53,10 +48,10 @@ function initializeAjv(draft04: boolean = true) {
  * Validates the given Swagger API against the Swagger 2.0 or OpenAPI 3.0 and 3.1 schemas.
  *
  */
-export const validateSchema: SchemaValidator = (
+export function validateSchema(
   api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document,
   options: { colorizeErrors?: boolean } = {},
-) => {
+): void {
   let ajv;
 
   // Choose the appropriate schema (Swagger or OpenAPI)
@@ -133,4 +128,4 @@ export const validateSchema: SchemaValidator = (
 
     throw new ValidationError(message, { details: err, totalErrors });
   }
-};
+}

--- a/packages/parser/src/validators/spec.ts
+++ b/packages/parser/src/validators/spec.ts
@@ -5,17 +5,15 @@ import { isOpenAPI } from '../lib/index.js';
 import { validateSpec as validateOpenAPI } from './spec/openapi.js';
 import { validateSpec as validateSwagger } from './spec/swagger.js';
 
-export type SpecValidator = (api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document) => void;
-
 /**
  * Validates either a Swagger 2.0 or OpenAPI 3.x API definition against cases that aren't covered
  * by their JSON Schema definitions.
  *
  */
-export const validateSpec: SpecValidator = (api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document) => {
+export function validateSpec(api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document): void {
   if (isOpenAPI(api)) {
     return validateOpenAPI(api);
   }
 
   return validateSwagger(api);
-};
+}


### PR DESCRIPTION
## 🧰 Changes

This enables [Knip](https://knip.dev) across the repository and cleans up a couple things that were being exported but unused.