### PR TITLE
fix(snippet): hide install instructions for fetch fallback

### DIFF
--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -157,7 +157,7 @@ export default function oasToSnippet(
     return {
       code: code ? code[0] : false,
       highlightMode,
-      install,
+      install: false,
     };
   }
 }

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -523,6 +523,7 @@ formData.append('filename', await new Response(fs.createReadStream('owlbert-shru
 
       expect(snippet.code).toContain('fetch');
       expect(snippet.highlightMode).toBe('javascript');
+      expect(snippet.install).toBe(false);
     });
 
     it('should gracefully fallback to `fetch` snippets if our `api` plugin isnt loaded', () => {


### PR DESCRIPTION
## 🧰 Changes

as part of the issue in [this thread](https://readmeio.slack.com/archives/C089VLEECKC/p1741034582475949), it feels like unexpected behavior that we show `api` installation instructions when the snippet generation fails and we fallback to `fetch`. this fixes that.
