### PR TITLE
feat: dropping support for node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "vitest": "^3.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -23143,7 +23143,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/jest-expect-har": {
@@ -23161,7 +23161,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "jest": "^29.0.2"
@@ -23242,7 +23242,7 @@
         "vitest": "^3.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "jest": "^29.0.2"
@@ -23332,7 +23332,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/oas-examples": {
@@ -23382,7 +23382,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/oas-to-har": {
@@ -23405,7 +23405,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/oas-to-snippet": {
@@ -23427,7 +23427,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "packages/parser": {
@@ -23451,7 +23451,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
@@ -23557,7 +23557,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/readmeio/oas.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "workspaces": [
     "./packages/*"

--- a/packages/http-status-codes/package.json
+++ b/packages/http-status-codes/package.json
@@ -17,7 +17,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"

--- a/packages/jest-expect-har/package.json
+++ b/packages/jest-expect-har/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist/"

--- a/packages/jest-expect-openapi/package.json
+++ b/packages/jest-expect-openapi/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist/"

--- a/packages/oas-normalize/package.json
+++ b/packages/oas-normalize/package.json
@@ -26,7 +26,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -25,7 +25,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"

--- a/packages/oas-to-snippet/package.json
+++ b/packages/oas-to-snippet/package.json
@@ -25,7 +25,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -49,7 +49,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -17,7 +17,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"

--- a/packages/postman-types/package.json
+++ b/packages/postman-types/package.json
@@ -17,7 +17,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.cts",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## 🧰 Changes

Node 18 hits EOL at the end of next month and with the upcoming ESM improvements in Node 20+, with which we'll be able to simplify our build processes, we're getting ahead of the gate and dropping Node 18 now.