### PR TITLE
fix(parser): loading in `$RefParser` from the named export

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,6 +1,6 @@
 import type { APIDocument, ParserOptions, ValidationResult, ErrorDetails, WarningDetails } from './types.js';
 
-import $RefParser, { dereferenceInternal, MissingPointerError } from '@apidevtools/json-schema-ref-parser';
+import { $RefParser, dereferenceInternal, MissingPointerError } from '@apidevtools/json-schema-ref-parser';
 
 import { isSwagger, isOpenAPI } from './lib/index.js';
 import { convertOptionsForParser, normalizeArguments, repairSchema } from './util.js';

--- a/packages/parser/test/specs/oas-relative-servers/v3-relative-servers.test.ts
+++ b/packages/parser/test/specs/oas-relative-servers/v3-relative-servers.test.ts
@@ -1,7 +1,7 @@
 import type { OpenAPIV3 } from 'openapi-types';
 import type { MockInstance } from 'vitest';
 
-import $RefParser from '@apidevtools/json-schema-ref-parser';
+import { $RefParser } from '@apidevtools/json-schema-ref-parser';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { parse } from '../../../src/index.js';


### PR DESCRIPTION
## 🧰 Changes

When loading in our new release of `@readme/openapi-parser` into [rdme](https://npm.im/rdme) I began to see a weird problem with the `$RefParser` class we pull from `@apidevtools/json-schema-ref-parser`:

![screenshot_2025-03-05_at_11 11 51___am](https://github.com/user-attachments/assets/e412a5c4-50d3-413c-819c-fbd5c711bf6d)

Because this thing is **definitely** a class and definitely has a constructor something seemed fishy and after looking into the TS configs for the parser and `rdme` I noticed that while `oas` uses `module: ESNext` `rdme` uses `module: NodeNext`. That got me thinking if there was something weird about the way we were importing the class and low-and-behold `$RefParser` is exported from `@apidevtools/json-schema-ref-parser` as the default _and_ a named export. We are loading it in as the default.

This dual and named export problem has been so prevalent with us moving libraries over to supporting CJS and ESM distribution builds that I wrote a custom ESLint rule for sniffing it out in [`readme/no-dual-exports`](https://github.com/readmeio/standards/blob/main/packages/eslint-plugin/docs/rules/no-dual-exports.md). Unfortunately because we no longer have control over `json-schema-ref-parser` as we aren't running a fork anymore we can't remove that default export but we can just load it off the named, which works just fine.

Node 22's `require(esm)` support cannot come soon enough.
