### PR TITLE
feat(oas-normalize): adding support for parser options on `.deref()`

### DIFF
--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -30,6 +30,7 @@ export default class OASNormalize {
     this.opts = {
       colorizeErrors: false,
       enablePaths: false,
+      parser: {},
       ...opts,
     };
 
@@ -98,6 +99,7 @@ export default class OASNormalize {
    */
   async bundle(): Promise<OpenAPI.Document> {
     if (this.cache.bundle) return this.cache.bundle;
+    const parserOptions = this.opts.parser || {};
 
     return this.load()
       .then(schema => {
@@ -110,7 +112,7 @@ export default class OASNormalize {
 
         return schema;
       })
-      .then(schema => bundle(schema))
+      .then(schema => bundle(schema, parserOptions))
       .then(bundled => {
         this.cache.bundle = bundled;
         return bundled;
@@ -121,8 +123,9 @@ export default class OASNormalize {
    * Dereference the given API definition.
    *
    */
-  async deref(): Promise<OpenAPI.Document> {
+  async dereference(): Promise<OpenAPI.Document> {
     if (this.cache.deref) return this.cache.deref;
+    const parserOptions = this.opts.parser || {};
 
     return this.load()
       .then(schema => {
@@ -135,11 +138,22 @@ export default class OASNormalize {
 
         return schema;
       })
-      .then(schema => dereference(schema))
+      .then(schema => dereference(schema, parserOptions))
       .then(dereferenced => {
         this.cache.deref = dereferenced;
         return dereferenced;
       });
+  }
+
+  /**
+   * Dereference the given API definition.
+   *
+   * This method is deprecated in favor of `dereference`. It will be removed in a future release.
+   *
+   * @deprecated
+   */
+  async deref(): Promise<OpenAPI.Document> {
+    return this.dereference();
   }
 
   /**
@@ -181,10 +195,18 @@ export default class OASNormalize {
    */
   async validate(
     opts: {
+      /**
+       * Options to supply to our OpenAPI parser. See `@readme/openapi-parser` for documentation.
+       * This option is deprecated in favor of the `parser` option on the constructor. It will be
+       * removed in a future release.
+       *
+       * @see {@link https://npm.im/@readme/openapi-parser}
+       * @deprecated
+       */
       parser?: ParserOptions;
     } = {},
   ): Promise<ValidationResult> {
-    const parserOptions = opts.parser || {};
+    const parserOptions = opts.parser || this.opts.parser || {};
     if (!parserOptions.validate) parserOptions.validate = {};
     if (!parserOptions.validate.errors) parserOptions.validate.errors = {};
 

--- a/packages/oas-normalize/src/lib/types.ts
+++ b/packages/oas-normalize/src/lib/types.ts
@@ -1,4 +1,21 @@
+import type { ParserOptions } from '@readme/openapi-parser';
+
 export interface Options {
+  /**
+   * Configures if you want validation errors that are thrown to be colorized. The default is
+   * `false`.
+   */
   colorizeErrors?: boolean;
+
+  /**
+   * If you want to allow fetching of local paths. For security reasons the default is `false`.
+   */
   enablePaths?: boolean;
+
+  /**
+   * Options to supply to our OpenAPI parser. See `@readme/openapi-parser` for documentation.
+   *
+   * @see {@link https://npm.im/@readme/openapi-parser}
+   */
+  parser?: ParserOptions;
 }

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -343,8 +343,8 @@ describe('#dereference', () => {
             },
           });
 
-          await expect(o.dereference()).rejects.toMatchInlineSnapshot(
-            '[ReferenceError: Circular $ref pointer found at /Users/erunion/code/readme/oas/#/components/schemas/ErrorMessage/properties/inner]',
+          await expect(o.dereference()).rejects.toThrow(
+            /Circular \$ref pointer found at \/(.*)\/components\/schemas\/ErrorMessage\/properties\/inner/,
           );
         });
       });

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -256,7 +256,7 @@ describe('#convert', () => {
   });
 });
 
-describe('#deref', () => {
+describe('#dereference', () => {
   it('should dereference a definition', async () => {
     const openapi = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default);
 
@@ -265,9 +265,9 @@ describe('#deref', () => {
     });
 
     const o = new OASNormalize(structuredClone(openapi));
-    const deref = (await o.deref()) as OpenAPIV3.Document;
+    const dereferenced = (await o.dereference()) as OpenAPIV3.Document;
 
-    expect(deref?.paths?.['/pet']?.post?.requestBody).toStrictEqual({
+    expect(dereferenced?.paths?.['/pet']?.post?.requestBody).toStrictEqual({
       description: 'Pet object that needs to be added to the store',
       required: true,
       content: {
@@ -282,9 +282,9 @@ describe('#deref', () => {
       const postman = await import('./__fixtures__/postman/petstore.collection.json').then(r => r.default);
 
       const o = new OASNormalize(postman);
-      const deref = (await o.deref()) as OpenAPIV3.Document;
+      const dereferenced = (await o.dereference()) as OpenAPIV3.Document;
 
-      expect(deref?.paths?.['/v2/pet']?.post?.requestBody).toStrictEqual({
+      expect(dereferenced?.paths?.['/v2/pet']?.post?.requestBody).toStrictEqual({
         content: {
           'application/json': {
             schema: {
@@ -294,6 +294,80 @@ describe('#deref', () => {
               }),
             },
           },
+        },
+      });
+    });
+  });
+
+  describe('parser options', () => {
+    describe('given a circular API definition', () => {
+      let openapi: any;
+
+      beforeEach(async () => {
+        ({ default: openapi } = await import('@readme/oas-examples/3.0/json/circular.json'));
+      });
+
+      describe('and we want to ignore circular refs', () => {
+        it('should support supplying options down to the parser', async () => {
+          expect(openapi?.components?.schemas?.ErrorMessage).toMatchObject({
+            properties: expect.objectContaining({
+              inner: { $ref: '#/components/schemas/ErrorMessage' },
+            }),
+          });
+
+          const o = new OASNormalize(structuredClone(openapi), {
+            parser: {
+              dereference: {
+                circular: 'ignore',
+              },
+            },
+          });
+
+          const dereferenced = (await o.dereference()) as OpenAPIV3.Document;
+
+          expect(dereferenced?.components?.schemas?.ErrorMessage).toMatchObject({
+            properties: expect.objectContaining({
+              inner: { $ref: '#/components/schemas/ErrorMessage' },
+            }),
+          });
+        });
+      });
+
+      describe('and we want to prevent circular refs', () => {
+        it('should support supplying options down to the parser', async () => {
+          const o = new OASNormalize(structuredClone(openapi), {
+            parser: {
+              dereference: {
+                circular: false,
+              },
+            },
+          });
+
+          await expect(o.dereference()).rejects.toMatchInlineSnapshot(
+            '[ReferenceError: Circular $ref pointer found at /Users/erunion/code/readme/oas/#/components/schemas/ErrorMessage/properties/inner]',
+          );
+        });
+      });
+    });
+  });
+
+  describe('#deref alias', () => {
+    it('should dereference a definition', async () => {
+      const openapi = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default);
+
+      expect(openapi.paths['/pet'].post.requestBody).toStrictEqual({
+        $ref: '#/components/requestBodies/Pet',
+      });
+
+      const o = new OASNormalize(structuredClone(openapi));
+      const dereferenced = (await o.deref()) as OpenAPIV3.Document;
+
+      expect(dereferenced?.paths?.['/pet']?.post?.requestBody).toStrictEqual({
+        description: 'Pet object that needs to be added to the store',
+        required: true,
+        content: {
+          'application/json': expect.any(Object),
+          'application/xml': expect.any(Object),
         },
       });
     });


### PR DESCRIPTION
## 🧰 Changes

I'm running into a bit of a problem when upgrading [api](https://npm.im/api) to the latest release of `oas` and `oas-normalize` in because `OASNormalize.validate()` now only returns a boolean I was previously expecting a fully dereferenced API definition there. Unfortunately in changing `.validate()` to return only a boolean we lost the ability to dereference at the same time, as well as supplying parser options for dereferencing in order to ignore circular `$ref` pointers. This adds support for that back in.

* [x] Adding support for supplying `ParserOptions` to a new `parser` option on the main `OASNormalize` class.
* [x] Deprecating `.deref()` in favor of `.dereference()`
* [x] Deprecating the `parser` option on `.validate()` in favor of the new `parser` option on the class.
* [x] Updating `.bundle()` to also take advantage of this new `parser` option to supply options down to that as well.