### PR TITLE
fix(oas): typings on `getResponseAsJSONSchema` are wrong

### DIFF
--- a/packages/oas/src/operation/lib/get-response-as-json-schema.ts
+++ b/packages/oas/src/operation/lib/get-response-as-json-schema.ts
@@ -13,6 +13,13 @@ import { isPrimitive } from '../../lib/helpers.js';
 import matches from '../../lib/matches-mimetype.js';
 import { toJSONSchema, getSchemaVersionString } from '../../lib/openapi-to-json-schema.js';
 
+interface ResponseSchemaObject {
+  description?: string;
+  label: string;
+  schema: SchemaObject;
+  type: string[] | string;
+}
+
 const isJSON = matches.json;
 
 /**
@@ -100,9 +107,9 @@ export function getResponseAsJSONSchema(
      */
     transformer?: (schema: SchemaObject) => SchemaObject;
   },
-): SchemaObject {
+): ResponseSchemaObject[] | null {
   const response = operation.getResponseByStatusCode(statusCode);
-  const jsonSchema = [];
+  const jsonSchema: ResponseSchemaObject[] = [];
 
   if (!response) {
     return null;


### PR DESCRIPTION
## 🧰 Changes

Stumbled upon this while updating `oas` over in [api](https://npm.im/api) but the response typings on `Operation.getResponseAsJSONSchema()`, a `SchemaObject`, do not line up with what's actually being returned.

I _think_ that this slipped through because are aren't running in TS strict mode and the `jsonSchema` array we're composing is being  created as `any[]`. Then again, even without strict mode I don't understand how TS could see `any[]` and think that validates as `SchemaObject`.

Regardless, this fixes it up!
