### PR TITLE
feat(http-status-codes): adding explicit return types to exports

### DIFF
--- a/packages/http-status-codes/src/index.ts
+++ b/packages/http-status-codes/src/index.ts
@@ -112,7 +112,7 @@ export const codes = {
  * Returns whether the provided status code is valid or not.
  *
  */
-export function isStatusCodeValid(code: number | string) {
+export function isStatusCodeValid(code: number | string): boolean {
   return code in codes;
 }
 
@@ -127,7 +127,7 @@ export function isStatusCodeValid(code: number | string) {
  *   success: false,
  * }
  */
-export function getStatusCode(code: number | string) {
+export function getStatusCode(code: number | string): { code: number | string; message: string; success: boolean } {
   if (!isStatusCodeValid(code)) {
     throw new Error(`${code} is not a known HTTP status code.`);
   }
@@ -148,7 +148,7 @@ export function getStatusCode(code: number | string) {
  * @example
  * getStatusCodeMessage('1XX') -> "1XX Informational"
  */
-export function getStatusCodeMessage(code: number | string) {
+export function getStatusCodeMessage(code: number | string): string {
   const res = getStatusCode(code);
   return `${res.code} ${res.message}`;
 }
@@ -159,7 +159,7 @@ export function getStatusCodeMessage(code: number | string) {
  * @example
  * isStatusCodeSuccessful(200) -> true
  */
-export function isStatusCodeSuccessful(code: number | string) {
+export function isStatusCodeSuccessful(code: number | string): boolean {
   try {
     return getStatusCode(code).success;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/http-status-codes/tsconfig.json
+++ b/packages/http-status-codes/tsconfig.json
@@ -1,10 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src/",
-    "declaration": true,
-    "noImplicitAny": true,
-    "outDir": "./dist",
-    "skipLibCheck": true,
     "strict": true
   },
   "include": ["./src/**/*"]


### PR DESCRIPTION
## 🧰 Changes

This consolidates the TS config for `http-status-codes` and adds explicit return types to all of its exports.
