### PR TITLE
feat(jest-expect-har): support for CJS and ESM builds

### DIFF
--- a/packages/jest-expect-har/package.json
+++ b/packages/jest-expect-har/package.json
@@ -4,8 +4,17 @@
   "description": "Jest/Vitest matcher for asserting valid HAR definitions",
   "license": "MIT",
   "author": "Jon Ursenbach <jon@readme.io>",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "engines": {
     "node": ">=20"
   },
@@ -33,7 +42,8 @@
     "url": "https://github.com/readmeio/oas/issues"
   },
   "scripts": {
-    "build": "tsc",
+    "attw": "attw --pack --format ascii --profile node16",
+    "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
     "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",

--- a/packages/jest-expect-har/package.json
+++ b/packages/jest-expect-har/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/readmeio/oas/issues"
   },
   "scripts": {
-    "attw": "attw --pack --format ascii --profile node16",
+    "attw": "attw --pack --format ascii",
     "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
     "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",

--- a/packages/jest-expect-har/test/tsconfig.json
+++ b/packages/jest-expect-har/test/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "es6",
-    "moduleResolution": "node",
-    "strict": false
+    "resolveJsonModule": true
   },
   "include": ["../src/**/*", "*.ts", "**/*"]
 }

--- a/packages/jest-expect-har/tsconfig.json
+++ b/packages/jest-expect-har/tsconfig.json
@@ -1,12 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./src/",
-    "declaration": true,
-    "esModuleInterop": true,
-    "lib": ["es2020"],
-    "outDir": "./dist",
-    "resolveJsonModule": true,
     "strict": true
   },
   "include": ["./src/**/*", "global.d.ts"]

--- a/packages/jest-expect-har/tsup.config.ts
+++ b/packages/jest-expect-har/tsup.config.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'tsup';
+
+import config from '../../tsup.config.js';
+
+export default defineConfig(options => ({
+  ...options,
+  ...config,
+
+  entry: ['src/index.ts'],
+  silent: !options.watch,
+}));


### PR DESCRIPTION
## 🧰 Changes

This updates `jest-expect-har` to support CJS and ESM dists, as well as consolidating its various TS configs to use the core one in this repository.