### PR TITLE
feat(jest-expect-openapi): support for CJS and ESM builds

### DIFF
--- a/packages/jest-expect-openapi/package.json
+++ b/packages/jest-expect-openapi/package.json
@@ -4,8 +4,17 @@
   "description": "Jest/Vitest matcher for asserting valid OpenAPI definitions",
   "license": "MIT",
   "author": "Jon Ursenbach <jon@readme.io>",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "engines": {
     "node": ">=20"
   },
@@ -33,7 +42,8 @@
     "url": "https://github.com/readmeio/oas/issues"
   },
   "scripts": {
-    "build": "tsc",
+    "attw": "attw --pack --format ascii --profile node16",
+    "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
     "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",
     "lint:types": "tsc --noEmit",

--- a/packages/jest-expect-openapi/package.json
+++ b/packages/jest-expect-openapi/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/readmeio/oas/issues"
   },
   "scripts": {
-    "attw": "attw --pack --format ascii --profile node16",
+    "attw": "attw --pack --format ascii",
     "build": "tsup",
     "lint": "npm run lint:types && npm run lint:js",
     "lint:js": "eslint . --ext .js,.ts --ignore-path ../../.gitignore",

--- a/packages/jest-expect-openapi/src/index.ts
+++ b/packages/jest-expect-openapi/src/index.ts
@@ -13,7 +13,7 @@ declare global {
        *    can pass a transformer function. It takes a single argument, `spec`, that you should
        *    return.
        */
-      toBeAValidOpenAPIDefinition(transformer?: (spec: unknown) => unknown): Promise<R>;
+      toBeAValidOpenAPIDefinition(transformer?: (spec: Record<string, unknown>) => Record<string, unknown>): Promise<R>;
     }
   }
 }
@@ -27,9 +27,9 @@ declare global {
  */
 export default async function toBeAValidOpenAPIDefinition(
   this: jest.MatcherUtils | MatcherState,
-  definition: unknown,
-  transformer?: (spec: unknown) => unknown,
-) {
+  definition: Record<string, unknown>,
+  transformer?: (spec: Record<string, unknown>) => Record<string, unknown>,
+): Promise<{ message: () => string; pass: boolean }> {
   const { matcherHint, printReceived } = this.utils;
   const message: (
     pass: boolean,

--- a/packages/jest-expect-openapi/test/index.test.ts
+++ b/packages/jest-expect-openapi/test/index.test.ts
@@ -10,7 +10,7 @@ test('should accept a valid OpenAPI', async () => {
 });
 
 test('should accept a valid OpenAPI with transformer', async () => {
-  await expect(valid).toBeAValidOpenAPIDefinition((spec: Record<string, string>) => {
+  await expect(valid).toBeAValidOpenAPIDefinition(spec => {
     // eslint-disable-next-line no-param-reassign
     spec.openapi = '3.1.0';
     return spec;

--- a/packages/jest-expect-openapi/test/tsconfig.json
+++ b/packages/jest-expect-openapi/test/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "es6",
-    "moduleResolution": "node",
-    "strict": false
+    "resolveJsonModule": true
   },
   "include": ["../src/**/*", "*.ts", "**/*"]
 }

--- a/packages/jest-expect-openapi/tsconfig.json
+++ b/packages/jest-expect-openapi/tsconfig.json
@@ -1,12 +1,6 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "baseUrl": "./src/",
-    "declaration": true,
-    "esModuleInterop": true,
-    "lib": ["es2020"],
-    "outDir": "./dist",
-    "resolveJsonModule": true,
     "strict": true
   },
   "include": ["./src/**/*", "global.d.ts"]

--- a/packages/jest-expect-openapi/tsup.config.ts
+++ b/packages/jest-expect-openapi/tsup.config.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'tsup';
+
+import config from '../../tsup.config.js';
+
+export default defineConfig(options => ({
+  ...options,
+  ...config,
+
+  entry: ['src/index.ts'],
+  silent: !options.watch,
+}));


### PR DESCRIPTION
## 🧰 Changes

Like in https://github.com/readmeio/oas/pull/958 this updates `jest-expect-openapi` to support CJS and ESM dists, as well as consolidating its various TS configs to use the core one in this repository.

