### PR TITLE
feat(oas-normalize): exporting some more types from our parser

### DIFF
--- a/packages/oas-normalize/src/lib/types.ts
+++ b/packages/oas-normalize/src/lib/types.ts
@@ -1,5 +1,7 @@
 import type { ParserOptions } from '@readme/openapi-parser';
 
+export type { ValidationResult, ErrorDetails, WarningDetails } from '@readme/openapi-parser';
+
 export interface Options {
   /**
    * Configures if you want validation errors that are thrown to be colorized. The default is


### PR DESCRIPTION
## 🧰 Changes

Updates `oas-normalize` to re-export some more validation types out of `@readme/openapi-parser`