### PR TITLE
fix(oas-normalize): `enablePaths` wasn't properly being configured

### DIFF
--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -34,6 +34,12 @@ export default class OASNormalize {
       ...opts,
     };
 
+    if (!this.opts.enablePaths) {
+      if (!this.opts.parser) this.opts.parser = {};
+      if (!this.opts.parser.resolve) this.opts.parser.resolve = {};
+      this.opts.parser.resolve = { file: false };
+    }
+
     this.type = utils.getType(this.file);
 
     this.cache = {

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -107,6 +107,34 @@ describe('#load', () => {
 
         await expect(o.load()).rejects.toThrow('Use `opts.enablePaths` to enable accessing local files.');
       });
+
+      it('should not allow you to `$ref` files from the filesystem if `enablePaths` is disabled', async () => {
+        const spec = {
+          openapi: '3.1.0',
+          info: {
+            version: '1.0.0',
+            title: 'Swagger Petstore',
+          },
+          paths: {
+            '/': {
+              post: {
+                parameters: [
+                  {
+                    in: 'query',
+                    name: 'filter',
+                    schema: {
+                      $ref: '/etc/passwd',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const o = new OASNormalize(spec, { enablePaths: false });
+        await expect(o.validate()).rejects.toThrow('Unable to resolve $ref pointer "/etc/passwd"');
+      });
     });
   });
 

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -116,6 +116,12 @@ export interface ParserOptions {
      */
     external?: boolean;
 
+    /**
+     * Determines if local files are allowed to be resolved. If this option is `true` then the
+     * default behavior within `@apidevtools/json-schema-ref-parser` will be utilized.
+     */
+    file?: boolean;
+
     http?: {
       /**
        * The amount of time (in milliseconds) to wait for a response from a server when downloading

--- a/packages/parser/src/util.ts
+++ b/packages/parser/src/util.ts
@@ -38,6 +38,7 @@ export function normalizeArguments<S extends APIDocument = APIDocument>(
  */
 export function convertOptionsForParser(options: ParserOptions): Partial<$RefParserOptions> {
   const parserOptions = getJsonSchemaRefParserDefaultOptions();
+
   return {
     ...parserOptions,
     dereference: {
@@ -62,6 +63,8 @@ export function convertOptionsForParser(options: ParserOptions): Partial<$RefPar
 
       external:
         options?.resolve && 'external' in options.resolve ? options.resolve.external : parserOptions.resolve.external,
+
+      file: options?.resolve && 'file' in options.resolve ? options.resolve.file : parserOptions.resolve.file,
 
       http: {
         ...(typeof parserOptions.resolve.http === 'object' ? parserOptions.resolve.http : {}),


### PR DESCRIPTION
## 🧰 Changes

This resolves a problem in `oas-normalize` where the `enablePaths` option wasn't being supplied down into `@readme/openapi-parser`.