### PR TITLE
feat: add timeout support

### DIFF
--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -131,6 +131,12 @@ export interface ParserOptions {
     };
   };
 
+  /**
+   * The maximum amount of time (in milliseconds) that JSON Schema $Ref Parser will spend dereferencing a single schema.
+   * It will throw a timeout error if the operation takes longer than this.
+   */
+  timeoutMs?: number;
+
   validate?: {
     errors?: {
       /**

--- a/packages/parser/src/util.ts
+++ b/packages/parser/src/util.ts
@@ -71,5 +71,7 @@ export function convertOptionsForParser(options: ParserOptions): Partial<$RefPar
         timeout: options?.resolve?.http && 'timeout' in options.resolve.http ? options.resolve.http.timeout : 5000,
       },
     },
+
+    timeoutMs: options?.timeoutMs,
   };
 }

--- a/packages/parser/test/specs/timeout/timeout.test.ts
+++ b/packages/parser/test/specs/timeout/timeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, assert } from 'vitest';
+
+import { validate } from '../../../src/index.js';
+import { relativePath } from '../../utils.js';
+import { toValidate } from '../../vitest.matchers.js';
+
+expect.extend({ toValidate });
+
+describe('API validation timeout', () => {
+  it('should timeout validation if timeout is exceeded', async () => {
+    try {
+      await validate(relativePath('specs/large-file-memory-leak/cloudflare.json'), { timeoutMs: 5 });
+      assert.fail();
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toContain('timeout');
+    }
+  });
+
+  it('should succeed validation if timeout is not exceeded', async () => {
+    await expect(relativePath('specs/circular/circular.yaml')).toValidate({ options: { timeoutMs: 5000 } });
+  });
+});


### PR DESCRIPTION
## 🧰 Changes

- Add the ability to pass a timeout to openapi-parser, which will pass it through to json-schema-ref-parser

## 🧬 QA & Testing

- Added a test
