### PR TITLE
feat(extensions): add support for template engine in code samples

### DIFF
--- a/packages/oas-examples/3.0/json/readme-extensions.json
+++ b/packages/oas-examples/3.0/json/readme-extensions.json
@@ -145,6 +145,12 @@
               "code": "import something from 'requestidk';\n\nconsole.log('do something idk');",
               "install": "npm install requestidk",
               "correspondingExample": "curlExample"
+            },
+            {
+              "name": "Templated code snippet",
+              "language": "node",
+              "templateEngine": "mustache",
+              "code": "sdk.put().data({{#harRequest.postData.jsonObj}}{\n{{/harRequest.postData.jsonObj}}{{#harRequest.postData.jsonObj.name}}  name: {{harRequest.postData.jsonObj.name}}\n{{/harRequest.postData.jsonObj.name}}{{#harRequest.postData.jsonObj.id}}  id: {{harRequest.postData.jsonObj.id}}\n{{/harRequest.postData.jsonObj.id}}{{#harRequest.postData.jsonObj}}\n}{{/harRequest.postData.jsonObj}})"
             }
           ],
           "samples-languages": ["shell", "python", "node"]

--- a/packages/oas-examples/3.0/yaml/readme-extensions.yaml
+++ b/packages/oas-examples/3.0/yaml/readme-extensions.yaml
@@ -107,6 +107,15 @@ paths:
               console.log('do something idk');
             install: npm install requestidk
             correspondingExample: curlExample
+          - name: Templated code snippet
+            language: node
+            templateEngine: mustache
+            code: |-
+              sdk.put().data({{#harRequest.postData.jsonObj}}{
+              {{/harRequest.postData.jsonObj}}{{#harRequest.postData.jsonObj.name}}  name: {{harRequest.postData.jsonObj.name}}
+              {{/harRequest.postData.jsonObj.name}}{{#harRequest.postData.jsonObj.id}}  id: {{harRequest.postData.jsonObj.id}}
+              {{/harRequest.postData.jsonObj.id}}{{#harRequest.postData.jsonObj}}
+              }{{/harRequest.postData.jsonObj}})
         samples-languages:
           - shell
           - python

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -228,6 +228,11 @@ export interface Extensions {
      * @example "Custom cURL snippet"
      */
     name?: string;
+    /**
+     * Optional template engine for dynamic code samples
+     * @example "mustache"
+     */
+    templateEngine?: string;
   }[];
   [DISABLE_TAG_SORTING]: boolean;
   [EXPLORER_ENABLED]: boolean;

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -232,7 +232,7 @@ export interface Extensions {
      * Optional template engine for dynamic code samples
      * @example "mustache"
      */
-    templateEngine?: string;
+    templateEngine?: 'mustache';
   }[];
   [DISABLE_TAG_SORTING]: boolean;
   [EXPLORER_ENABLED]: boolean;

--- a/packages/oas/test/operation/lib/__snapshots__/get-example-groups.test.ts.snap
+++ b/packages/oas/test/operation/lib/__snapshots__/get-example-groups.test.ts.snap
@@ -197,6 +197,17 @@ curl -X POST https://api.example.com/v2/alert",
         "name": "Default #3",
         "originalIndex": 2,
       },
+      {
+        "code": "sdk.put().data({{#harRequest.postData.jsonObj}}{
+{{/harRequest.postData.jsonObj}}{{#harRequest.postData.jsonObj.name}}  name: {{harRequest.postData.jsonObj.name}}
+{{/harRequest.postData.jsonObj.name}}{{#harRequest.postData.jsonObj.id}}  id: {{harRequest.postData.jsonObj.id}}
+{{/harRequest.postData.jsonObj.id}}{{#harRequest.postData.jsonObj}}
+}{{/harRequest.postData.jsonObj}})",
+        "language": "node",
+        "name": "Templated code snippet",
+        "originalIndex": 6,
+        "templateEngine": "mustache",
+      },
     ],
     "name": "Default #3",
   },


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

- Introduced a new optional property `templateEngine` in the Extensions interface to allow dynamic code samples.
- Added a new templated code snippet example using Mustache in both JSON and YAML readme files for better demonstration of the feature.

for: https://github.com/readmeio/readme/pull/14297
## 🧬 QA & Testing

* updated test fixtures
