### PR TITLE
refactor: removing wildcard imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       ],
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.4",
-        "@readme/eslint-config": "^14.6.0",
+        "@readme/eslint-config": "^14.7.2",
         "@vitest/coverage-v8": "^3.1.1",
         "alex": "^11.0.1",
         "eslint": "^8.57.0",
@@ -348,20 +348,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.1",
+        "@emnapi/wasi-threads": "1.0.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
-      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
-      "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
+      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1501,16 +1501,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@nolyfill/is-core-module": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
-      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.4.0"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -2376,19 +2366,19 @@
       }
     },
     "node_modules/@readme/eslint-config": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-14.6.0.tgz",
-      "integrity": "sha512-OAQ6Tu999bVYjrJy3g3XKl+/84UeZlaEQlooCgZhsoyCEP02s2mWeVZJ+ouGQu3UOzwcmR1BYMWT2L3XDPrbAQ==",
+      "version": "14.7.2",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-14.7.2.tgz",
+      "integrity": "sha512-AsaslmYC0GbomoqC8Osi4+JbnuG1G3GRaKegk64IcAdf2w86zI62RaGfPHz8KTq5uHDwoARyrT8/bBoZs//lfw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.24.1",
-        "@typescript-eslint/parser": "^8.24.1",
-        "@typescript-eslint/utils": "^8.24.1",
-        "@vitest/eslint-plugin": "^1.1.32-beta.3",
+        "@typescript-eslint/eslint-plugin": "^8.31.1",
+        "@typescript-eslint/parser": "^8.31.1",
+        "@typescript-eslint/utils": "^8.31.1",
+        "@vitest/eslint-plugin": "^1.1.44",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^10.0.1",
-        "eslint-import-resolver-typescript": "^3.5.5",
+        "eslint-config-prettier": "^10.1.2",
+        "eslint-import-resolver-typescript": "^4.3.4",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^28.3.0",
@@ -2397,9 +2387,9 @@
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-perfectionist": "^4.9.0",
-        "eslint-plugin-react": "^7.34.4",
+        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.0.0",
-        "eslint-plugin-readme": "^2.0.13",
+        "eslint-plugin-readme": "^2.1.2",
         "eslint-plugin-require-extensions": "^0.1.3",
         "eslint-plugin-testing-library": "^7.1.1",
         "eslint-plugin-try-catch-failsafe": "^0.1.4",
@@ -3207,21 +3197,21 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
-      "integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.0.tgz",
+      "integrity": "sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/type-utils": "8.26.0",
-        "@typescript-eslint/utils": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/type-utils": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3231,22 +3221,32 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "@typescript-eslint/parser": "^8.33.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
-      "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.0.tgz",
+      "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/typescript-estree": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/typescript-estree": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3261,15 +3261,16 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
-      "integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.0.tgz",
+      "integrity": "sha512-d1hz0u9l6N+u/gcrk6s6gYdl7/+pp8yHheRTqP6X5hVDKALEaTn8WfGiit7G511yueBEL3OpOEpD+3/MBdoN+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0"
+        "@typescript-eslint/tsconfig-utils": "^8.33.0",
+        "@typescript-eslint/types": "^8.33.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3279,17 +3280,52 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
-      "integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.0.tgz",
+      "integrity": "sha512-LMi/oqrzpqxyO72ltP+dBSP6V0xiUb4saY7WLtxSfiNEBI8m321LLVFU9/QDJxjDQG9/tjSqKz/E3380TEqSTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.26.0",
-        "@typescript-eslint/utils": "8.26.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.0.tgz",
+      "integrity": "sha512-sTkETlbqhEoiFmGr1gsdq5HyVbSOF0145SYDJ/EQmXHtKViCaGvnyLqWFFHtEXoS0J1yU8Wyou2UGmgW88fEug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.0.tgz",
+      "integrity": "sha512-lScnHNCBqL1QayuSrWeqAL5GmqNdVUQAAMTaCwdYEdWfIrSrOGzyLGRCHXcCixa5NK6i5l0AfSO2oBSjCjf4XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3304,9 +3340,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
-      "integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
+      "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3318,20 +3354,22 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
-      "integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.0.tgz",
+      "integrity": "sha512-vegY4FQoB6jL97Tu/lWRsAiUUp8qJTqzAmENH2k59SJhw0Th1oszb9Idq/FyyONLuNqT1OADJPXfyUNOR8SzAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/visitor-keys": "8.26.0",
+        "@typescript-eslint/project-service": "8.33.0",
+        "@typescript-eslint/tsconfig-utils": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3345,16 +3383,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
-      "integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.0.tgz",
+      "integrity": "sha512-lPFuQaLA9aSNa7D5u2EpRiqdAUhzShwGg/nhpBlc4GR6kcTABttCuyjFs8BcEZ8VWrjCBof/bePhP3Q3fS+Yrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.26.0",
-        "@typescript-eslint/types": "8.26.0",
-        "@typescript-eslint/typescript-estree": "8.26.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/typescript-estree": "8.33.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3369,13 +3407,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
-      "integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.0.tgz",
+      "integrity": "sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.26.0",
+        "@typescript-eslint/types": "8.33.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -3405,6 +3443,260 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.7.8.tgz",
+      "integrity": "sha512-rsRK8T7yxraNRDmpFLZCWqpea6OlXPNRRCjWMx24O1V86KFol7u2gj9zJCv6zB1oJjtnzWceuqdnCgOipFcJPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.7.8.tgz",
+      "integrity": "sha512-16yEMWa+Olqkk8Kl6Bu0ltT5OgEedkSAsxcz1B3yEctrDYp3EMBu/5PPAGhWVGnwhtf3hNe3y15gfYBAjOv5tQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.7.8.tgz",
+      "integrity": "sha512-ST4uqF6FmdZQgv+Q73FU1uHzppeT4mhX3IIEmHlLObrv5Ep50olWRz0iQ4PWovadjHMTAmpuJAGaAuCZYb7UAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.7.8.tgz",
+      "integrity": "sha512-Z/A/4Rm2VWku2g25C3tVb986fY6unx5jaaCFpx1pbAj0OKkyuJ5wcQLHvNbIcJ9qhiYwXfrkB7JNlxrAbg7YFg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.7.8.tgz",
+      "integrity": "sha512-HN0p7o38qKmDo3bZUiQa6gP7Qhf0sKgJZtRfSHi6JL2Gi4NaUVF0EO1sQ1RHbeQ4VvfjUGMh3QE5dxEh06BgQQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.7.8.tgz",
+      "integrity": "sha512-HsoVqDBt9G69AN0KWeDNJW+7i8KFlwxrbbnJffgTGpiZd6Jw+Q95sqkXp8y458KhKduKLmXfVZGnKBTNxAgPjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.7.8.tgz",
+      "integrity": "sha512-VfR2yTDUbUvn+e/Aw22CC9fQg9zdShHAfwWctNBdOk7w9CHWl2OtYlcMvjzMAns8QxoHQoqn3/CEnZ4Ts7hfrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.7.8.tgz",
+      "integrity": "sha512-xUauVQNz4uDgs4UJJiUAwMe3N0PA0wvtImh7V0IFu++UKZJhssXbKHBRR4ecUJpUHCX2bc4Wc8sGsB6P+7BANg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.7.8.tgz",
+      "integrity": "sha512-GqyIB+CuSHGhhc8ph5RrurtNetYJjb6SctSHafqmdGcRuGi6uyTMR8l18hMEhZFsXdFMc/MpInPLvmNV22xn+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.7.8.tgz",
+      "integrity": "sha512-eEU3rWIFRv60xaAbtsgwHNWRZGD7cqkpCvNtio/f1TjEE3HfKLzPNB24fA9X/8ZXQrGldE65b7UKK3PmO4eWIQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.7.8.tgz",
+      "integrity": "sha512-GVLI0f4I4TlLqEUoOFvTWedLsJEdvsD0+sxhdvQ5s+N+m2DSynTs8h9jxR0qQbKlpHWpc2Ortz3z48NHRT4l+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.7.8.tgz",
+      "integrity": "sha512-GX1pZ/4ncUreB0Rlp1l7bhKAZ8ZmvDIgXdeb5V2iK0eRRF332+6gRfR/r5LK88xfbtOpsmRHU6mQ4N8ZnwvGEA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.7.8.tgz",
+      "integrity": "sha512-n1N84MnsvDupzVuYqJGj+2pb9s8BI1A5RgXHvtVFHedGZVBCFjDpQVRlmsFMt6xZiKwDPaqsM16O/1isCUGt7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.7.8.tgz",
+      "integrity": "sha512-x94WnaU5g+pCPDVedfnXzoG6lCOF2xFGebNwhtbJCWfceE94Zj8aysSxdxotlrZrxnz5D3ijtyFUYtpz04n39Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.10"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.10.tgz",
+      "integrity": "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.7.8.tgz",
+      "integrity": "sha512-vst2u8EJZ5L6jhJ6iLis3w9rg16aYqRxQuBAMYQRVrPMI43693hLP7DuqyOBRKgsQXy9/jgh204k0ViHkqQgdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.7.8.tgz",
+      "integrity": "sha512-yb3LZOLMFqnA+/ShlE1E5bpYPGDsA590VHHJPB+efnyowT776GJXBoh82em6O9WmYBUq57YblGTcMYAFBm72HA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.8.tgz",
+      "integrity": "sha512-hHKFx+opG5BA3/owMXon8ypwSotBGTdblG6oda/iOu9+OEYnk0cxD2uIcGyGT8jCK578kV+xMrNxqbn8Zjlpgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.1.1",
@@ -3440,13 +3732,15 @@
       }
     },
     "node_modules/@vitest/eslint-plugin": {
-      "version": "1.1.36",
-      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.36.tgz",
-      "integrity": "sha512-IjBV/fcL9NJRxGw221ieaDsqKqj8qUo7rvSupDxMjTXyhsCusHC6M+jFUNqBp4PCkYFcf5bjrKxeZoCEWoPxig==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.2.1.tgz",
+      "integrity": "sha512-JQr1jdVcrsoS7Sdzn83h9sq4DvREf9Q/onTZbJCqTVlv/76qb+TZrLv/9VhjnjSMHweQH5FdpMDeCR6aDe2fgw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.24.0"
+      },
       "peerDependencies": {
-        "@typescript-eslint/utils": "^8.24.0",
         "eslint": ">= 8.57.0",
         "typescript": ">= 5.0.0",
         "vitest": "*"
@@ -6355,9 +6649,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6789,7 +7083,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6800,7 +7093,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7313,16 +7605,44 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.2.tgz",
-      "integrity": "sha512-1105/17ZIMjmCOJOPNfVdbXafLCLj3hPmkmB7dLgt7XsQ/zkxSuDerE/xgO3RxoHysR1N1whmquY0lSn2O0VLg==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "eslint-config-prettier": "build/bin/cli.js"
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.6.tgz",
+      "integrity": "sha512-/e2ZNPDLCrU8niIy0pddcvXuoO2YrKjf3NAIX+60mHJBT4yv7mqCqvVdyCW2E720e25e4S/1OSVef4U6efGLFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash": "^0.0.5"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -7348,25 +7668,25 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.8.3.tgz",
-      "integrity": "sha512-A0bu4Ks2QqDWNpeEgTQMPTngaMhuDu4yv6xpftBMAf+1ziXnpx+eSR1WRfoPTe2BAiAjHFZ7kSNx1fvr5g5pmQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.2.tgz",
+      "integrity": "sha512-GdSOy0PwLYpQCrmnEQujvA+X0NKrdnVCICEbZq1zlmjjD12NHOHCN9MYyrGFR9ydCs4wJwHEV9tts44ajSlGeA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@nolyfill/is-core-module": "1.0.39",
-        "debug": "^4.3.7",
-        "enhanced-resolve": "^5.15.0",
-        "get-tsconfig": "^4.10.0",
-        "is-bun-module": "^1.0.2",
-        "stable-hash": "^0.0.4",
-        "tinyglobby": "^0.2.12"
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.5",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.2"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^16.17.0 || >=18.6.0"
       },
       "funding": {
-        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
       },
       "peerDependencies": {
         "eslint": "*",
@@ -7743,9 +8063,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
-      "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7759,7 +8079,7 @@
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.8",
+        "object.entries": "^1.1.9",
         "object.fromentries": "^2.0.8",
         "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
@@ -7854,9 +8174,9 @@
       }
     },
     "node_modules/eslint-plugin-readme": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-readme/-/eslint-plugin-readme-2.0.13.tgz",
-      "integrity": "sha512-3TL7DehxwZXuEBp3+7woO/OKxLNM12Ki/wQ7L+GSo1YhgGlufNLozaNnXMidXzytC4Z6AIYKvlDKmJtilvj2NQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-readme/-/eslint-plugin-readme-2.1.2.tgz",
+      "integrity": "sha512-dehWYYHv7y005dqjC8IJjufWdL0Zpct4YF6TI6EVhlAC3qCwFWWbncRJb19tZSY1OrGyE1tB+Wc1QT/dD5jqYA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -9011,9 +9331,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10524,13 +10844,13 @@
       }
     },
     "node_modules/is-bun-module": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-1.3.0.tgz",
-      "integrity": "sha512-DgXeu5UWI0IsMQundYb5UAOzm6G2eVnarJ0byP6Tm55iZNKceD59LNPA2L4VvsScTtHcw0yEkVwSf7PC+QoLSA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.6.3"
+        "semver": "^7.7.1"
       }
     },
     "node_modules/is-callable": {
@@ -14417,6 +14737,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
+      "integrity": "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -15130,15 +15466,16 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
-      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17577,7 +17914,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -18230,9 +18567,9 @@
       }
     },
     "node_modules/stable-hash": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
-      "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
     },
@@ -19122,9 +19459,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19989,6 +20326,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.8.tgz",
+      "integrity": "sha512-2zsXwyOXmCX9nGz4vhtZRYhe30V78heAv+KDc21A/KMdovGHbZcixeD5JHEF0DrFXzdytwuzYclcPbvp8A3Jlw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.2.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-darwin-arm64": "1.7.8",
+        "@unrs/resolver-binding-darwin-x64": "1.7.8",
+        "@unrs/resolver-binding-freebsd-x64": "1.7.8",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.8",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.8",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.7.8",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.7.8",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.8",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.8",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.7.8",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.7.8",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.7.8",
+        "@unrs/resolver-binding-linux-x64-musl": "1.7.8",
+        "@unrs/resolver-binding-wasm32-wasi": "1.7.8",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.7.8",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.7.8",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.7.8"
       }
     },
     "node_modules/upath": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
-    "@readme/eslint-config": "^14.6.0",
+    "@readme/eslint-config": "^14.7.2",
     "@vitest/coverage-v8": "^3.1.1",
     "alex": "^11.0.1",
     "eslint": "^8.57.0",

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -1,8 +1,8 @@
 import type { OASAnalysis } from './types.js';
 import type { OASDocument } from '../types.js';
 
-import * as OPENAPI_QUERIES from './queries/openapi.js';
-import * as README_QUERIES from './queries/readme.js';
+import * as OPENAPI_QUERIES from './queries/openapi.js'; // eslint-disable-line readme/no-wildcard-imports
+import * as README_QUERIES from './queries/readme.js'; // eslint-disable-line readme/no-wildcard-imports
 
 /**
  * Analyze a given OpenAPI or Swagger definition for any OpenAPI, JSON Schema, and ReadMe-specific

--- a/packages/oas/src/lib/get-auth.ts
+++ b/packages/oas/src/lib/get-auth.ts
@@ -1,5 +1,4 @@
-import type * as RMOAS from '../types.js';
-import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import type { AuthForHAR, KeyedSecuritySchemeObject, OASDocument, SecuritySchemeObject, User } from '../types.js';
 
 type authKey = unknown | { password: number | string; user: number | string } | null;
 
@@ -7,7 +6,7 @@ type authKey = unknown | { password: number | string; user: number | string } | 
  * @param user User to retrieve retrieve an auth key for.
  * @param scheme The type of security scheme that we want a key for.
  */
-function getKey(user: RMOAS.User, scheme: RMOAS.KeyedSecuritySchemeObject): authKey {
+function getKey(user: User, scheme: KeyedSecuritySchemeObject): authKey {
   switch (scheme.type) {
     case 'oauth2':
     case 'apiKey':
@@ -43,8 +42,8 @@ function getKey(user: RMOAS.User, scheme: RMOAS.KeyedSecuritySchemeObject): auth
  * @param selectedApp The user app to retrieve an auth key for.
  */
 export function getByScheme(
-  user: RMOAS.User,
-  scheme = <RMOAS.KeyedSecuritySchemeObject>{},
+  user: User,
+  scheme = {} as KeyedSecuritySchemeObject,
   selectedApp?: number | string,
 ): authKey {
   if (user?.keys && user.keys.length) {
@@ -69,11 +68,7 @@ export function getByScheme(
  * @param user User
  * @param selectedApp The user app to retrieve an auth key for.
  */
-export function getAuth(
-  api: OpenAPIV3_1.Document | OpenAPIV3.Document,
-  user: RMOAS.User,
-  selectedApp?: number | string,
-): RMOAS.AuthForHAR {
+export function getAuth(api: OASDocument, user: User, selectedApp?: number | string): AuthForHAR {
   return Object.keys(api?.components?.securitySchemes || {})
     .map(scheme => {
       return {
@@ -82,7 +77,7 @@ export function getAuth(
           {
             // This sucks but since we dereference we'll never have a `$ref` pointer here with a
             // `ReferenceObject` type.
-            ...(api.components.securitySchemes[scheme] as RMOAS.SecuritySchemeObject),
+            ...(api.components.securitySchemes[scheme] as SecuritySchemeObject),
             _key: scheme,
           },
           selectedApp,

--- a/packages/oas/src/lib/get-user-variable.ts
+++ b/packages/oas/src/lib/get-user-variable.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../types.js';
+import type { User } from '../types.js';
 
 /**
  * Retrieve a user variable off of a given user.
@@ -8,7 +8,7 @@ import type * as RMOAS from '../types.js';
  * @param property The name of the variable to retrieve.
  * @param selectedApp The user app to retrieve an auth key for.
  */
-export default function getUserVariable(user: RMOAS.User, property: string, selectedApp?: number | string): unknown {
+export default function getUserVariable(user: User, property: string, selectedApp?: number | string): unknown {
   let key = user;
 
   if ('keys' in user && Array.isArray(user.keys) && user.keys.length) {

--- a/packages/oas/src/operation/lib/dedupe-common-parameters.ts
+++ b/packages/oas/src/operation/lib/dedupe-common-parameters.ts
@@ -1,4 +1,6 @@
-import * as RMOAS from '../../types.js';
+import type { ParameterObject } from '../../types.js';
+
+import { isRef } from '../../types.js';
 
 /**
  * With an array of common parameters filter down them to what isn't already present in a list of
@@ -8,14 +10,14 @@ import * as RMOAS from '../../types.js';
  * @param commonParameters Array of **common** parameters defined at the path item level.
  */
 export function dedupeCommonParameters(
-  parameters: RMOAS.ParameterObject[],
-  commonParameters: RMOAS.ParameterObject[],
-): RMOAS.ParameterObject[] {
-  return commonParameters.filter((param: RMOAS.ParameterObject) => {
-    return !parameters.find((param2: RMOAS.ParameterObject) => {
+  parameters: ParameterObject[],
+  commonParameters: ParameterObject[],
+): ParameterObject[] {
+  return commonParameters.filter((param: ParameterObject) => {
+    return !parameters.find((param2: ParameterObject) => {
       if (param.name && param2.name) {
         return param.name === param2.name && param.in === param2.in;
-      } else if (RMOAS.isRef(param) && RMOAS.isRef(param2)) {
+      } else if (isRef(param) && isRef(param2)) {
         return param.$ref === param2.$ref;
       }
 

--- a/packages/oas/src/operation/lib/get-callback-examples.ts
+++ b/packages/oas/src/operation/lib/get-callback-examples.ts
@@ -1,5 +1,5 @@
 import type { ResponseExamples } from './get-response-examples.js';
-import type * as RMOAS from '../../types.js';
+import type { CallbackObject, OperationObject } from '../../types.js';
 
 import { getResponseExamples } from './get-response-examples.js';
 
@@ -16,20 +16,20 @@ export type CallbackExamples = {
  *
  * @param operation Operation to retrieve callback examples from.
  */
-export function getCallbackExamples(operation: RMOAS.OperationObject): CallbackExamples {
+export function getCallbackExamples(operation: OperationObject): CallbackExamples {
   const ret: CallbackExamples = [];
 
   // spreads the contents of the map for each callback so there's not nested arrays returned
   return ret.concat(
     ...Object.keys(operation.callbacks || {}).map(identifier => {
-      const callback = operation.callbacks[identifier] as RMOAS.CallbackObject;
+      const callback = operation.callbacks[identifier] as CallbackObject;
 
       // spreads the contents again so there's not nested arrays returned
       return []
         .concat(
           ...Object.keys(callback).map(expression => {
             return Object.keys(callback[expression]).map(method => {
-              const pathItem = callback[expression] as Record<string, RMOAS.OperationObject>;
+              const pathItem = callback[expression] as Record<string, OperationObject>;
               const example = getResponseExamples(pathItem[method]);
               if (example.length === 0) return false;
 

--- a/packages/oas/src/operation/lib/get-example-groups.ts
+++ b/packages/oas/src/operation/lib/get-example-groups.ts
@@ -1,5 +1,5 @@
 import type { MediaTypeExample } from './get-mediatype-examples.js';
-import type * as RMOAS from '../../types.js';
+import type { DataForHAR } from '../../types.js';
 import type { Operation } from '../index.js';
 import type { OpenAPIV3 } from 'openapi-types';
 
@@ -39,7 +39,7 @@ export type ExampleGroups = Record<
      * Mutually exclusive of `customCodeSamples`. If `customCodeSamples` is present,
      * any request example definitions are ignored.
      */
-    request?: RMOAS.DataForHAR;
+    request?: DataForHAR;
 
     /**
      * Object containing the example response data for the current example key.

--- a/packages/oas/src/operation/lib/get-mediatype-examples.ts
+++ b/packages/oas/src/operation/lib/get-mediatype-examples.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../../types.js';
+import type { MediaTypeObject } from '../../types.js';
 
 import matchesMimeType from '../../lib/matches-mimetype.js';
 import sampleFromSchema from '../../samples/index.js';
@@ -22,7 +22,7 @@ export interface MediaTypeExample {
  */
 export function getMediaTypeExamples(
   mediaType: string,
-  mediaTypeObject: RMOAS.MediaTypeObject,
+  mediaTypeObject: MediaTypeObject,
   opts: {
     /**
      * If you wish to include data that's flagged as `readOnly`.

--- a/packages/oas/src/operation/lib/get-requestbody-examples.ts
+++ b/packages/oas/src/operation/lib/get-requestbody-examples.ts
@@ -1,5 +1,5 @@
 import type { MediaTypeExample } from './get-mediatype-examples.js';
-import type * as RMOAS from '../../types.js';
+import type { OperationObject, RequestBodyObject } from '../../types.js';
 
 import { getMediaTypeExamples } from './get-mediatype-examples.js';
 
@@ -13,10 +13,10 @@ export type RequestBodyExamples = {
  *
  * @param operation Operation to retrieve requestBody examples for.
  */
-export function getRequestBodyExamples(operation: RMOAS.OperationObject): RequestBodyExamples {
+export function getRequestBodyExamples(operation: OperationObject): RequestBodyExamples {
   // `requestBody` will never have `$ref` pointers here so we need to work around the type that we
-  // have from `RMOAS.OperationObject`.
-  const requestBody = operation.requestBody as RMOAS.RequestBodyObject;
+  // have from `OperationObject`.
+  const requestBody = operation.requestBody as RequestBodyObject;
   if (!requestBody || !requestBody.content) {
     return [];
   }

--- a/packages/oas/src/operation/lib/get-response-examples.ts
+++ b/packages/oas/src/operation/lib/get-response-examples.ts
@@ -1,5 +1,5 @@
 import type { MediaTypeExample } from './get-mediatype-examples.js';
-import type * as RMOAS from '../../types.js';
+import type { OperationObject } from '../../types.js';
 
 import { isRef } from '../../types.js';
 
@@ -16,7 +16,7 @@ export type ResponseExamples = {
  *
  * @param operation Operation to retrieve response examples for.
  */
-export function getResponseExamples(operation: RMOAS.OperationObject) {
+export function getResponseExamples(operation: OperationObject) {
   return Object.keys(operation.responses || {})
     .map(status => {
       const response = operation.responses[status];

--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/samples/fn.js}
  */
-import type * as RMOAS from '../types.js';
+import type { SchemaObject } from '../types.js';
 
 import mergeJSONSchemaAllOf from 'json-schema-merge-allof';
 import memoize from 'memoizee';
@@ -12,11 +12,11 @@ import memoize from 'memoizee';
 import { objectify, usesPolymorphism, isFunc, normalizeArray, deeplyStripKey } from './utils.js';
 
 const sampleDefaults = (genericSample: boolean | number | string) => {
-  return (schema: RMOAS.SchemaObject): typeof genericSample =>
+  return (schema: SchemaObject): typeof genericSample =>
     typeof schema.default === typeof genericSample ? schema.default : genericSample;
 };
 
-const primitives: Record<string, (arg: RMOAS.SchemaObject | void) => boolean | number | string> = {
+const primitives: Record<string, (arg: SchemaObject | void) => boolean | number | string> = {
   string: sampleDefaults('string'),
   string_email: sampleDefaults('user@example.com'),
   'string_date-time': sampleDefaults(new Date().toISOString()),
@@ -32,7 +32,7 @@ const primitives: Record<string, (arg: RMOAS.SchemaObject | void) => boolean | n
   boolean: sampleDefaults(true),
 };
 
-const primitive = (schema: RMOAS.SchemaObject) => {
+const primitive = (schema: SchemaObject) => {
   schema = objectify(schema);
   const { format } = schema;
   let { type } = schema;
@@ -69,7 +69,7 @@ const primitive = (schema: RMOAS.SchemaObject) => {
  * @param schema JSON Schema to generate a sample for.
  */
 function sampleFromSchema(
-  schema: RMOAS.SchemaObject,
+  schema: SchemaObject,
   opts: {
     /**
      * If you wish to include data that's flagged as `readOnly`.
@@ -102,7 +102,7 @@ function sampleFromSchema(
       return undefined;
     }
   } else if (hasPolymorphism) {
-    const samples = (objectifySchema[hasPolymorphism] as RMOAS.SchemaObject[]).map(s => {
+    const samples = (objectifySchema[hasPolymorphism] as SchemaObject[]).map(s => {
       return sampleFromSchema(s, opts);
     });
 
@@ -188,11 +188,11 @@ function sampleFromSchema(
     }
 
     if (Array.isArray(items.anyOf)) {
-      return items.anyOf.map((i: RMOAS.SchemaObject) => sampleFromSchema(i, opts));
+      return items.anyOf.map((i: SchemaObject) => sampleFromSchema(i, opts));
     }
 
     if (Array.isArray(items.oneOf)) {
-      return items.oneOf.map((i: RMOAS.SchemaObject) => sampleFromSchema(i, opts));
+      return items.oneOf.map((i: SchemaObject) => sampleFromSchema(i, opts));
     }
 
     return [sampleFromSchema(items, opts)];

--- a/packages/oas/src/samples/utils.ts
+++ b/packages/oas/src/samples/utils.ts
@@ -4,11 +4,11 @@
  * @license Apache-2.0
  * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/src/core/utils.js}
  */
-import type * as RMOAS from '../types.js';
+import type { SchemaObject } from '../types.js';
 
 import { isObject } from '../lib/helpers.js';
 
-export function usesPolymorphism(schema: RMOAS.SchemaObject): 'allOf' | 'anyOf' | 'oneOf' | false {
+export function usesPolymorphism(schema: SchemaObject): 'allOf' | 'anyOf' | 'oneOf' | false {
   if (schema.oneOf) {
     return 'oneOf';
   } else if (schema.anyOf) {
@@ -50,12 +50,12 @@ export function deeplyStripKey(
   input: unknown,
   keyToStrip: string,
   predicate = (obj: unknown, key?: string): boolean => true, // eslint-disable-line @typescript-eslint/no-unused-vars
-): RMOAS.SchemaObject | any {
+): SchemaObject | any {
   if (typeof input !== 'object' || Array.isArray(input) || input === null || !keyToStrip) {
     return input;
   }
 
-  const obj = { ...input } as Record<string, RMOAS.SchemaObject>;
+  const obj = { ...input } as Record<string, SchemaObject>;
 
   Object.keys(obj).forEach(k => {
     if (k === keyToStrip && predicate(obj[k], k)) {

--- a/packages/oas/test/.eslintrc
+++ b/packages/oas/test/.eslintrc
@@ -1,6 +1,3 @@
 {
   "extends": "@readme/eslint-config/testing/vitest",
-  "rules": {
-    "readme/no-wildcard-imports": "off",
-  },
 }

--- a/packages/oas/test/.eslintrc
+++ b/packages/oas/test/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@readme/eslint-config/testing/vitest"
+  "extends": "@readme/eslint-config/testing/vitest",
+  "rules": {
+    "readme/no-wildcard-imports": "off",
+  },
 }

--- a/packages/oas/test/__fixtures__/create-oas.ts
+++ b/packages/oas/test/__fixtures__/create-oas.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../../src/types.js';
+import type { ComponentsObject, OASDocument, OperationObject, PathsObject } from '../../src/types.js';
 
 import Oas from '../../src/index.js';
 
@@ -6,7 +6,7 @@ import Oas from '../../src/index.js';
  * @param operation Operation to create a fake API definition and Oas instance for.
  * @param components Schema components to add into the fake API definition.
  */
-export function createOasForOperation(operation: RMOAS.OperationObject, components?: RMOAS.ComponentsObject): Oas {
+export function createOasForOperation(operation: OperationObject, components?: ComponentsObject): Oas {
   const schema = {
     openapi: '3.0.3',
     info: { title: 'testing', version: '1.0.0' },
@@ -15,7 +15,7 @@ export function createOasForOperation(operation: RMOAS.OperationObject, componen
         get: operation,
       },
     },
-  } as RMOAS.OASDocument;
+  } as OASDocument;
 
   if (components) {
     schema.components = components;
@@ -28,14 +28,14 @@ export function createOasForOperation(operation: RMOAS.OperationObject, componen
  * @param paths Path objects to create a fake API definition and Oas instance for.
  * @param components Schema components to add into the fake API definition.
  */
-export function createOasForPaths(paths: RMOAS.PathsObject, components?: RMOAS.ComponentsObject): Oas {
+export function createOasForPaths(paths: PathsObject, components?: ComponentsObject): Oas {
   const schema = {
     openapi: '3.0.3',
     info: { title: 'testing', version: '1.0.0' },
     paths: {
       ...paths,
     },
-  } as RMOAS.OASDocument;
+  } as OASDocument;
 
   if (components) {
     schema.components = components;

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -2,7 +2,7 @@ import type { OASDocument } from '../../../src/types.js';
 
 import { describe, beforeAll, expect, it } from 'vitest';
 
-import * as QUERIES from '../../../src/analyzer/queries/openapi.js';
+import * as QUERIES from '../../../src/analyzer/queries/openapi.js'; // eslint-disable-line readme/no-wildcard-imports
 
 function loadSpec(r: any) {
   return r.default as unknown as OASDocument;

--- a/packages/oas/test/analyzer/queries/readme.test.ts
+++ b/packages/oas/test/analyzer/queries/readme.test.ts
@@ -2,7 +2,7 @@ import type { OASDocument } from '../../../src/types.js';
 
 import { describe, beforeAll, expect, it } from 'vitest';
 
-import * as QUERIES from '../../../src/analyzer/queries/readme.js';
+import * as QUERIES from '../../../src/analyzer/queries/readme.js'; // eslint-disable-line readme/no-wildcard-imports
 import Oas from '../../../src/index.js';
 
 function loadSpec(r: any) {

--- a/packages/oas/test/extensions.test.ts
+++ b/packages/oas/test/extensions.test.ts
@@ -1,7 +1,7 @@
 import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 import { describe, beforeEach, it, expect } from 'vitest';
 
-import * as extensions from '../src/extensions.js';
+import * as extensions from '../src/extensions.js'; // eslint-disable-line readme/no-wildcard-imports
 import Oas from '../src/index.js';
 
 describe('extension defaults', () => {

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../src/types.js';
+import type { HttpMethods, OASDocument, RequestBodyObject, SchemaObject } from '../src/types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 import { beforeAll, describe, it, expect, vi } from 'vitest';
@@ -31,8 +31,8 @@ describe('Oas', () => {
     expect(petstore.api.info.version).toBe('1.0.0');
   });
 
-  it('should be able to accept an `RMOAS.OASDocument` in the constructor', () => {
-    expect(new Oas(petstoreSpec as RMOAS.OASDocument).getVersion()).toBe('3.0.0');
+  it('should be able to accept an `OASDocument` in the constructor', () => {
+    expect(new Oas(petstoreSpec as OASDocument).getVersion()).toBe('3.0.0');
   });
 
   it('should be able to accept a string in the constructor', () => {
@@ -1274,7 +1274,7 @@ describe('Oas', () => {
           method: 'put',
         };
 
-        const method = source.method.toLowerCase() as RMOAS.HttpMethods;
+        const method = source.method.toLowerCase() as HttpMethods;
         const oas = new Oas(apiDefinition, { region: 'eu' });
         const operation = oas.getOperation(source.url, method);
 
@@ -1286,7 +1286,7 @@ describe('Oas', () => {
       it("should be able to find an operation where the variable **doesn't** match the url", () => {
         const source = {
           url: 'https://eu.node.example.com/v14/api/esm',
-          method: 'put' as RMOAS.HttpMethods,
+          method: 'put' as HttpMethods,
         };
 
         const oas = new Oas(apiDefinition, { region: 'us' });
@@ -1300,7 +1300,7 @@ describe('Oas', () => {
       it('should be able to find an operation if there are no user variables present', () => {
         const source = {
           url: 'https://eu.node.example.com/v14/api/esm',
-          method: 'put' as RMOAS.HttpMethods,
+          method: 'put' as HttpMethods,
         };
 
         const oas = new Oas(apiDefinition);
@@ -1314,7 +1314,7 @@ describe('Oas', () => {
       it('should fail to find a match on a url that doesnt quite match', () => {
         const source = {
           url: 'https://eu.buster.example.com/v14/api/esm',
-          method: 'put' as RMOAS.HttpMethods,
+          method: 'put' as HttpMethods,
         };
 
         const oas = new Oas(apiDefinition, { region: 'us' });
@@ -1343,7 +1343,7 @@ describe('Oas', () => {
 
         const source = {
           url: 'https://us.node.example.com/v14/api/esm',
-          method: 'put' as RMOAS.HttpMethods,
+          method: 'put' as HttpMethods,
         };
 
         const operation = oas.getOperation(source.url, source.method);
@@ -1356,7 +1356,7 @@ describe('Oas', () => {
       it('should be able to find a match on a url that contains colons', () => {
         const source = {
           url: 'https://api.example.com/people/GWID:3',
-          method: 'post' as RMOAS.HttpMethods,
+          method: 'post' as HttpMethods,
         };
 
         const operation = pathVariableQuirks.getOperation(source.url, source.method);
@@ -1600,8 +1600,9 @@ describe('Oas', () => {
         const oas = await import('./__datasets__/complex-nesting.json').then(r => r.default).then(Oas.init);
         await oas.dereference();
 
-        const schema = (oas.api.paths['/multischema/of-everything'].post.requestBody as RMOAS.RequestBodyObject)
-          .content['application/json'].schema as RMOAS.SchemaObject;
+        const schema = (oas.api.paths['/multischema/of-everything'].post.requestBody as RequestBodyObject).content[
+          'application/json'
+        ].schema as SchemaObject;
 
         expect(schema.title).toBeUndefined();
         expect(schema['x-readme-ref-name']).toBe('MultischemaOfEverything');
@@ -1613,8 +1614,8 @@ describe('Oas', () => {
         const oas = Oas.init(petstoreSpec);
         await oas.dereference({ preserveRefAsJSONSchemaTitle: true });
 
-        const schema = (oas.api.paths['/pet'].post.requestBody as RMOAS.RequestBodyObject).content['application/json']
-          .schema as RMOAS.SchemaObject;
+        const schema = (oas.api.paths['/pet'].post.requestBody as RequestBodyObject).content['application/json']
+          .schema as SchemaObject;
 
         expect(schema.title).toBe('Pet');
         expect(schema['x-readme-ref-name']).toBe('Pet');
@@ -1703,7 +1704,7 @@ describe('Oas', () => {
       }
 
       it('should only dereference once when called multiple times', async () => {
-        const oas = new TestOas(petstoreSpec as RMOAS.OASDocument);
+        const oas = new TestOas(petstoreSpec as OASDocument);
         const spy = vi.fn<never>();
 
         await Promise.all([oas.dereference({ cb: spy }), oas.dereference({ cb: spy }), oas.dereference({ cb: spy })]);
@@ -1716,7 +1717,7 @@ describe('Oas', () => {
       });
 
       it('should only **ever** dereference once', async () => {
-        const oas = new TestOas(petstoreSpec as RMOAS.OASDocument);
+        const oas = new TestOas(petstoreSpec as OASDocument);
         const spy = vi.fn<never>();
 
         await oas.dereference({ cb: spy });

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../../src/types.js';
+import type { HttpMethods, SecuritySchemesObject } from '../../src/types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json';
 import { validate } from '@readme/openapi-parser';
@@ -724,7 +724,7 @@ describe('#prepareSecurity()', () => {
   /**
    * @param schemes SecurtiySchemesObject to create a test API definition for.
    */
-  function createSecurityOas(schemes: RMOAS.SecuritySchemesObject): Oas {
+  function createSecurityOas(schemes: SecuritySchemesObject): Oas {
     // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#security-requirement-object
     const security = Object.keys(schemes).map(scheme => {
       return { [scheme]: [] };
@@ -878,7 +878,7 @@ describe('#prepareSecurity()', () => {
 describe('#getHeaders()', () => {
   it('should return an object containing request headers if params exist', () => {
     const uri = 'http://petstore.swagger.io/v2/pet/1';
-    const method = 'DELETE' as RMOAS.HttpMethods;
+    const method = 'DELETE' as HttpMethods;
 
     const logOperation = petstore.findOperation(uri, method);
     const operation = new Operation(
@@ -896,7 +896,7 @@ describe('#getHeaders()', () => {
 
   it('should return an object containing content-type request header if media types exist in request body', () => {
     const uri = 'http://petstore.swagger.io/v2/pet';
-    const method = 'POST' as RMOAS.HttpMethods;
+    const method = 'POST' as HttpMethods;
 
     const logOperation = petstore.findOperation(uri, method);
     const operation = new Operation(
@@ -914,7 +914,7 @@ describe('#getHeaders()', () => {
 
   it('should return an object containing accept and content-type headers if media types exist in response', () => {
     const uri = 'http://petstore.swagger.io/v2/pet/findByStatus';
-    const method = 'GET' as RMOAS.HttpMethods;
+    const method = 'GET' as HttpMethods;
 
     const logOperation = petstore.findOperation(uri, method);
     const operation = new Operation(
@@ -932,7 +932,7 @@ describe('#getHeaders()', () => {
 
   it('should return an object containing request headers if security exists', () => {
     const uri = 'http://example.com/multiple-combo-auths';
-    const method = 'POST' as RMOAS.HttpMethods;
+    const method = 'POST' as HttpMethods;
 
     const logOperation = multipleSecurities.findOperation(uri, method);
     const operation = new Operation(
@@ -950,7 +950,7 @@ describe('#getHeaders()', () => {
 
   it('should return a Cookie header if security is located in cookie scheme', () => {
     const uri = 'http://local-link.com/2.0/users/johnSmith';
-    const method = 'GET' as RMOAS.HttpMethods;
+    const method = 'GET' as HttpMethods;
 
     const logOperation = referenceSpec.findOperation(uri, method);
     const operation = new Operation(
@@ -972,7 +972,7 @@ describe('#getHeaders()', () => {
       ['HTTP Bearer', '/anything/bearer', 'post'],
       ['OAuth2', '/anything/oauth2', 'post'],
     ])('should find an authorization header for a %s request', (_, path, method) => {
-      const operation = securities.operation(path, method as RMOAS.HttpMethods);
+      const operation = securities.operation(path, method as HttpMethods);
       const headers = operation.getHeaders();
 
       expect(headers.request).toContain('Authorization');
@@ -981,7 +981,7 @@ describe('#getHeaders()', () => {
 
   it('should target parameter refs and return names if applicable', () => {
     const uri = 'http://local-link.com/2.0/repositories/janeDoe/oas/pullrequests';
-    const method = 'GET' as RMOAS.HttpMethods;
+    const method = 'GET' as HttpMethods;
 
     const logOperation = referenceSpec.findOperation(uri, method);
     const operation = new Operation(
@@ -999,7 +999,7 @@ describe('#getHeaders()', () => {
 
   it('should not fail if there are no responses', () => {
     const uri = 'http://petstore.swagger.io/v2/pet/1';
-    const method: RMOAS.HttpMethods = 'delete';
+    const method: HttpMethods = 'delete';
 
     const logOperation = oas31NoResponses.findOperation(uri, method);
     const operation = new Operation(
@@ -1671,7 +1671,7 @@ describe('#getResponseStatusCodes()', () => {
   });
 
   it('should return an empty array if there are no responses', () => {
-    const operation = petstore.operation('/pet/findByStatus', 'doesnotexist' as RMOAS.HttpMethods);
+    const operation = petstore.operation('/pet/findByStatus', 'doesnotexist' as HttpMethods);
 
     expect(operation.getResponseStatusCodes()).toStrictEqual([]);
   });

--- a/packages/oas/test/operation/lib/get-response-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-response-examples.test.ts
@@ -1,4 +1,4 @@
-import type * as RMOAS from '../../../src/types.js';
+import type { HttpMethods } from '../../../src/types.js';
 
 import { beforeAll, describe, test, expect, it } from 'vitest';
 
@@ -245,7 +245,7 @@ describe('defined within response `content`', () => {
   });
 
   describe('`examples`', () => {
-    it.each<[string, string, RMOAS.HttpMethods]>([
+    it.each<[string, string, HttpMethods]>([
       ['should return examples', '/examples-at-mediaType-level', 'post'],
       [
         'should return examples if there are examples for the operation, and one of the examples is a $ref',

--- a/packages/oas/test/samples/index.test.ts
+++ b/packages/oas/test/samples/index.test.ts
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  * @see {@link https://github.com/swagger-api/swagger-ui/blob/master/test/unit/core/plugins/samples/fn.js}
  */
-import type * as RMOAS from '../../src/types.js';
+import type { SchemaObject } from '../../src/types.js';
 
 import { describe, it, expect } from 'vitest';
 
@@ -12,7 +12,7 @@ import sampleFromSchema from '../../src/samples/index.js';
 
 describe('sampleFromSchema', () => {
   it('should be memoized', async () => {
-    const schema: RMOAS.SchemaObject = {
+    const schema: SchemaObject = {
       type: 'string',
       format: 'date-time',
     };
@@ -27,7 +27,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object with no readonly fields for parameter', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         id: {
@@ -48,7 +48,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object with readonly fields for parameter, with includeReadOnly', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         id: {
@@ -71,7 +71,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object without deprecated fields for parameter', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         id: {
@@ -92,7 +92,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object without writeonly fields for parameter', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         id: {
@@ -113,7 +113,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns early if it find an examples property', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         id: {
@@ -135,7 +135,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object with writeonly fields for parameter, with includeWriteOnly', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         id: {
@@ -157,7 +157,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object without any $$ref fields at the root schema level', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         message: {
@@ -183,7 +183,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object without any $$ref fields at nested schema levels', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         message: {
@@ -213,7 +213,7 @@ describe('sampleFromSchema', () => {
   });
 
   it('returns object with any $$ref fields that appear to be user-created', () => {
-    const definition: RMOAS.SchemaObject = {
+    const definition: SchemaObject = {
       type: 'object',
       properties: {
         message: {
@@ -244,7 +244,7 @@ describe('sampleFromSchema', () => {
 
   describe('primitive type handling', () => {
     it('should handle when an unknown type is detected', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         // @ts-expect-error We're testing the failure case for `png` not being a valid type.
         items: {
@@ -258,7 +258,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('should return an undefined value for a `file` type', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         // @ts-expect-error We're testing the failure case for `file` not being a valid type.
         items: {
@@ -273,7 +273,7 @@ describe('sampleFromSchema', () => {
 
     describe('`type: mixed`', () => {
       it('returns a boolean for a `boolean` array type', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: ['boolean'],
         };
 
@@ -281,7 +281,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a non-null example for a mixed type of two types', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: ['null', 'boolean'],
         };
 
@@ -289,7 +289,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a non-null example for a mixed type of more than two types', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: ['null', 'integer', 'boolean'],
         };
 
@@ -298,7 +298,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('should be able to handle a mixed `null` and `object` type', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           anyOf: [
             {
               type: 'null',
@@ -322,7 +322,7 @@ describe('sampleFromSchema', () => {
 
     describe('`type: null`', () => {
       it('returns a null for a null type', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'null',
         };
 
@@ -334,7 +334,7 @@ describe('sampleFromSchema', () => {
 
     describe('`type: boolean`', () => {
       it('returns a boolean for a boolean', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'boolean',
         };
 
@@ -344,7 +344,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a default value for a boolean with a default present', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'boolean',
           default: false,
         };
@@ -357,7 +357,7 @@ describe('sampleFromSchema', () => {
 
     describe('`type: number`', () => {
       it('returns a number for a number with no format', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'number',
         };
 
@@ -367,7 +367,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a number for a number with format=float', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'number',
           format: 'float',
         };
@@ -378,7 +378,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a default value for a number with a default present', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'number',
           default: 123,
         };
@@ -391,7 +391,7 @@ describe('sampleFromSchema', () => {
 
     describe('`type: string`', () => {
       it('returns a date-time for a string with format=date-time', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'date-time',
         };
@@ -401,7 +401,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a date for a string with format=date', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'date',
         };
@@ -412,7 +412,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a UUID for a string with format=uuid', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'uuid',
         };
@@ -423,7 +423,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a hostname for a string with format=hostname', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'hostname',
         };
@@ -434,7 +434,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns an IPv4 address for a string with format=ipv4', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'ipv4',
         };
@@ -445,7 +445,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns an IPv6 address for a string with format=ipv6', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'ipv6',
         };
@@ -456,7 +456,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns an email for a string with format=email', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           format: 'email',
         };
@@ -467,7 +467,7 @@ describe('sampleFromSchema', () => {
       });
 
       it('returns a default value for a string with a default present', () => {
-        const definition: RMOAS.SchemaObject = {
+        const definition: SchemaObject = {
           type: 'string',
           default: 'test',
         };
@@ -481,7 +481,7 @@ describe('sampleFromSchema', () => {
 
   describe('mising `type`', () => {
     it('should handle if an object is present but is missing `type: object`', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         properties: {
           foo: {
             type: 'string',
@@ -497,7 +497,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('should handle if an array is present but is missing `type: array`', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         items: {
           type: 'string',
         },
@@ -510,7 +510,7 @@ describe('sampleFromSchema', () => {
 
     // Techncally this is a malformed schema, but we should do our best to support it.
     it('should handle if an array if present but is missing `items`', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
       };
 
@@ -520,7 +520,7 @@ describe('sampleFromSchema', () => {
     });
 
     it("should handle a case where no type is present and the schema can't be determined to be an object or array", () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'object',
         properties: {
           foo: {
@@ -539,7 +539,7 @@ describe('sampleFromSchema', () => {
 
   describe('`type: array`', () => {
     it('returns array with sample of array type', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'integer',
@@ -552,7 +552,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns string for example for array that has example of type string', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -566,7 +566,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of examples for array that has examples', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -580,7 +580,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of samples for oneOf type', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -598,7 +598,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of samples for oneOf types', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -619,7 +619,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of samples for oneOf examples', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -642,7 +642,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of samples for anyOf type', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -660,7 +660,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of samples for anyOf types', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -681,7 +681,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns array of samples for anyOf examples', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'array',
         items: {
           type: 'string',
@@ -704,7 +704,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns null for a null example', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'object',
         properties: {
           foo: {
@@ -723,7 +723,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns null for a null object-level example', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'object',
         properties: {
           foo: {
@@ -746,7 +746,7 @@ describe('sampleFromSchema', () => {
 
   describe('additionalProperties', () => {
     it('returns object with additional props', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'object',
         properties: {
           dog: {
@@ -767,7 +767,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns object with additional props=true', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'object',
         properties: {
           dog: {
@@ -786,7 +786,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns object with 2 properties with no type passed but properties', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         properties: {
           alien: {
             type: 'string',
@@ -806,7 +806,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns object with additional props with no type passed', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         additionalProperties: {
           type: 'string',
         },
@@ -822,7 +822,7 @@ describe('sampleFromSchema', () => {
 
   describe('enums', () => {
     it('returns default value when enum provided', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'string',
         default: 'one',
         enum: ['two', 'one'],
@@ -834,7 +834,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('returns example value when provided', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'string',
         default: 'one',
         example: 'two',
@@ -847,7 +847,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('sets first enum if provided', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         type: 'string',
         enum: ['one', 'two'],
       };
@@ -875,7 +875,7 @@ describe('sampleFromSchema', () => {
 
   describe('polymorphism', () => {
     it('should handle an allOf schema', () => {
-      const definition: RMOAS.SchemaObject = {
+      const definition: SchemaObject = {
         allOf: [
           {
             type: 'object',
@@ -910,7 +910,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('should grab properties from allOf polymorphism', () => {
-      const polymorphismSchema: RMOAS.SchemaObject = {
+      const polymorphismSchema: SchemaObject = {
         allOf: [
           {
             type: 'object',
@@ -960,7 +960,7 @@ describe('sampleFromSchema', () => {
     });
 
     it('should grab first property from anyOf/oneOf polymorphism', () => {
-      const polymorphismSchema: RMOAS.SchemaObject = {
+      const polymorphismSchema: SchemaObject = {
         allOf: [
           {
             type: 'object',


### PR DESCRIPTION
## 🧰 Changes

We have a new custom ESLint rule [readme/no-wildcard-imports](https://github.com/readmeio/standards/blob/main/packages/eslint-plugin/docs/rules/no-wildcard-imports.md) for banning `import * as something from 'module'` as we've been having issues with tree shaking in some old libraries. This updates our shared ESLint config and implements this rule across every package here.
