### PR TITLE
feat(oas): add support for displaying definition size in analyzer

### DIFF
--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -272,11 +272,11 @@ console.log(await analyzer(petstore));
 <!-- prettier-ignore-start -->
 | Metric | Description |
 | :--- | :--- |
+| `dereferencedFileSize` | Size of the definition after resolving all references. |
 | `mediaTypes` | What are the different media type shapes that your API operations support? |
 | `operationTotal` | The total amount of operations in your definition. |
-| `securityTypes`  | The different types of security that your API contains. |
-| `rawFileSize`  | Size of the definition in its raw form. |
-| `dereferencedFileSize`  | Size of the definition after resolving all references. |
+| `rawFileSize` | Size of the definition in its raw form. |
+| `securityTypes` | The different types of security that your API contains. |
 <!-- prettier-ignore-end -->
 
 ##### OpenAPI Features

--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -275,6 +275,8 @@ console.log(await analyzer(petstore));
 | `mediaTypes` | What are the different media type shapes that your API operations support? |
 | `operationTotal` | The total amount of operations in your definition. |
 | `securityTypes`  | The different types of security that your API contains. |
+| `rawFileSize`  | Size of the definition in its raw form. |
+| `dereferencedFileSize`  | Size of the definition after resolving all references. |
 <!-- prettier-ignore-end -->
 
 ##### OpenAPI Features

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -47,6 +47,14 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
         name: 'Security Type',
         found: OPENAPI_QUERIES.securityTypes(definition),
       },
+      rawFileSize: {
+        name: 'Raw File Size',
+        found: OPENAPI_QUERIES.fileSize(definition),
+      },
+      dereferencedFileSize: {
+        name: 'Dereferenced File Size',
+        found: await OPENAPI_QUERIES.fileSizeDereferenced(definition),
+      },
     },
     openapi: {
       additionalProperties: {

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -33,8 +33,14 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
   const rawBody = README_QUERIES.rawBody(definition);
   const refNames = README_QUERIES.refNames(definition);
 
+  const { raw: rawFileSize, dereferenced: dereferencedFileSize } = await OPENAPI_QUERIES.fileSize(definition);
+
   const analysis: OASAnalysis = {
     general: {
+      dereferencedFileSize: {
+        name: 'Dereferenced File Size',
+        found: dereferencedFileSize,
+      },
       mediaTypes: {
         name: 'Media Type',
         found: OPENAPI_QUERIES.mediaTypes(definition),
@@ -43,17 +49,13 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
         name: 'Operation',
         found: OPENAPI_QUERIES.totalOperations(definition),
       },
+      rawFileSize: {
+        name: 'Raw File Size',
+        found: rawFileSize,
+      },
       securityTypes: {
         name: 'Security Type',
         found: OPENAPI_QUERIES.securityTypes(definition),
-      },
-      rawFileSize: {
-        name: 'Raw File Size',
-        found: OPENAPI_QUERIES.fileSize(definition),
-      },
-      dereferencedFileSize: {
-        name: 'Dereferenced File Size',
-        found: await OPENAPI_QUERIES.fileSizeDereferenced(definition),
       },
     },
     openapi: {

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -63,22 +63,21 @@ export function discriminators(definition: OASDocument): string[] {
 }
 
 /**
- * Calculate the size of the raw OAS file in MB.
+ * Calculate the size of the raw and dereferenced OpenAPI file in MB.
+ *
  */
-export function fileSize(definition: OASDocument): number {
-  const sizeInBytes = Buffer.from(JSON.stringify(definition)).length;
-  return +(sizeInBytes / (1024 * 1024)).toFixed(2);
-}
+export async function fileSize(definition: OASDocument): Promise<{ raw: number; dereferenced: number }> {
+  const oas = new Oas(structuredClone(definition));
 
-/**
- * Calculate the size of the dereferenced OAS file in MB.
- */
-export async function fileSizeDereferenced(definition: OASDocument): Promise<number> {
-  const oas = new Oas(definition);
+  const originalSizeInBytes = Buffer.from(JSON.stringify(oas.api)).length;
+  const raw = Number((originalSizeInBytes / (1024 * 1024)).toFixed(2));
+
   await oas.dereference();
 
-  const sizeInBytes = Buffer.from(JSON.stringify(oas)).length;
-  return +(sizeInBytes / (1024 * 1024)).toFixed(2);
+  const dereferencedSizeInBytes = Buffer.from(JSON.stringify(oas)).length;
+  const dereferenced = Number((dereferencedSizeInBytes / (1024 * 1024)).toFixed(2));
+
+  return { raw, dereferenced };
 }
 
 /**

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -63,6 +63,25 @@ export function discriminators(definition: OASDocument): string[] {
 }
 
 /**
+ * Calculate the size of the raw OAS file in MB.
+ */
+export function fileSize(definition: OASDocument): number {
+  const sizeInBytes = Buffer.from(JSON.stringify(definition)).length;
+  return +(sizeInBytes / (1024 * 1024)).toFixed(2);
+}
+
+/**
+ * Calculate the size of the dereferenced OAS file in MB.
+ */
+export async function fileSizeDereferenced(definition: OASDocument): Promise<number> {
+  const oas = new Oas(definition);
+  await oas.dereference();
+
+  const sizeInBytes = Buffer.from(JSON.stringify(oas)).length;
+  return +(sizeInBytes / (1024 * 1024)).toFixed(2);
+}
+
+/**
  * Determine if a given API definition utilizes `links`.
  *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object}

--- a/packages/oas/src/analyzer/types.ts
+++ b/packages/oas/src/analyzer/types.ts
@@ -13,6 +13,8 @@ export interface OASAnalysis {
     mediaTypes: OASAnalysisGeneral;
     operationTotal: OASAnalysisGeneral;
     securityTypes: OASAnalysisGeneral;
+    rawFileSize: OASAnalysisGeneral;
+    dereferencedFileSize: OASAnalysisGeneral;
   };
   openapi: {
     additionalProperties: OASAnalysisFeature;

--- a/packages/oas/src/analyzer/types.ts
+++ b/packages/oas/src/analyzer/types.ts
@@ -10,11 +10,11 @@ export interface OASAnalysisGeneral {
 
 export interface OASAnalysis {
   general: {
+    dereferencedFileSize: OASAnalysisGeneral;
     mediaTypes: OASAnalysisGeneral;
     operationTotal: OASAnalysisGeneral;
-    securityTypes: OASAnalysisGeneral;
     rawFileSize: OASAnalysisGeneral;
-    dereferencedFileSize: OASAnalysisGeneral;
+    securityTypes: OASAnalysisGeneral;
   };
   openapi: {
     additionalProperties: OASAnalysisFeature;

--- a/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`analyzer > should should analyzer an OpenAPI definition 1`] = `
 {
   "general": {
+    "dereferencedFileSize": {
+      "found": 0.03,
+      "name": "Dereferenced File Size",
+    },
     "mediaTypes": {
       "found": [
         "application/json",
@@ -15,6 +19,10 @@ exports[`analyzer > should should analyzer an OpenAPI definition 1`] = `
     "operationTotal": {
       "found": 20,
       "name": "Operation",
+    },
+    "rawFileSize": {
+      "found": 0.01,
+      "name": "Raw File Size",
     },
     "securityTypes": {
       "found": [

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -134,6 +134,15 @@ describe('analyzer queries (OpenAPI)', () => {
     });
   });
 
+  describe('fileSize', () => {
+    it('should calculate the size of the definition in its raw form', async () => {
+      await expect(QUERIES.fileSize(readme)).resolves.toStrictEqual({
+        raw: 0.05,
+        dereferenced: 0.32,
+      });
+    });
+  });
+
   describe('links', () => {
     it('should discover `links` usage within a definition that has it', () => {
       expect(QUERIES.links(links)).toStrictEqual([
@@ -298,18 +307,6 @@ describe('analyzer queries (OpenAPI)', () => {
   describe('totalOperations', () => {
     it('should count the total operations used within a definition', () => {
       expect(QUERIES.totalOperations(readme)).toBe(39);
-    });
-  });
-
-  describe('rawFileSize', () => {
-    it('should calculate the size of the definition in its raw form', () => {
-      expect(QUERIES.fileSize(readme)).toBe(0.05);
-    });
-  });
-
-  describe('dereferencedFileSize', () => {
-    it('should calculate the size of the definition after resolving all references', async () => {
-      await expect(QUERIES.fileSizeDereferenced(readme)).resolves.toBe(0.32);
     });
   });
 

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -301,6 +301,18 @@ describe('analyzer queries (OpenAPI)', () => {
     });
   });
 
+  describe('rawFileSize', () => {
+    it('should calculate the size of the definition in its raw form', () => {
+      expect(QUERIES.fileSize(readme)).toBe(0.05);
+    });
+  });
+
+  describe('dereferencedFileSize', () => {
+    it('should calculate the size of the definition after resolving all references', async () => {
+      await expect(QUERIES.fileSizeDereferenced(readme)).resolves.toBe(0.32);
+    });
+  });
+
   describe('webhooks', () => {
     it('should determine if a definition uses webhooks when it does', () => {
       expect(QUERIES.webhooks(webhooks)).toStrictEqual(['#/webhooks/newPet']);


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

This pull request enhances the OpenAPI analyzer by adding functionality to calculate and report the raw and dereferenced file sizes of an API definition.

### Enhancements to Analyzer Functionality:
* Added support for calculating the size of the raw OpenAPI file (`rawFileSize`) and the dereferenced OpenAPI file (`dereferencedFileSize`) in MB. These values are now included in the general analysis results. 

### Documentation Updates:
* Updated the `README.md` to include descriptions of the new `rawFileSize` and `dereferencedFileSize` metrics in the analyzer output.

### Test Coverage:
* Added snapshot tests to validate the inclusion of `rawFileSize` and `dereferencedFileSize` in the analyzer output. 
* Introduced unit tests for `fileSize` and `fileSizeDereferenced` to verify their correctness. 

