### PR TITLE
feat(oas): splitting apart our `xml` analyzer query into more specific queries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit"
   },
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+
+  "biome.enabled": false
 }

--- a/packages/oas-examples/test/.eslintrc
+++ b/packages/oas-examples/test/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@readme/eslint-config/testing/vitest",
+}

--- a/packages/oas-examples/test/index.test.ts
+++ b/packages/oas-examples/test/index.test.ts
@@ -1,9 +1,9 @@
 import path from 'node:path';
 
-import toBeAValidOpenAPIDefinition from 'jest-expect-openapi';
-import fg from 'fast-glob';
-import { describe, it, expect } from 'vitest';
 import { parse } from '@readme/openapi-parser';
+import fg from 'fast-glob';
+import toBeAValidOpenAPIDefinition from 'jest-expect-openapi';
+import { describe, it, expect } from 'vitest';
 
 expect.extend({ toBeAValidOpenAPIDefinition });
 
@@ -13,37 +13,35 @@ describe.each([
   ['OpenAPI 3.1', 'openapi', '3.1'],
 ])('%s', (_, specification, version) => {
   it('should have parity between JSON and YAML petstores', async () => {
-    const json = await parse(path.join(__dirname, `../${version}/json/petstore.json`));
-    const yaml = await parse(path.join(__dirname, `../${version}/yaml/petstore.yaml`));
+    const json = await parse(path.join(import.meta.dirname, `../${version}/json/petstore.json`));
+    const yaml = await parse(path.join(import.meta.dirname, `../${version}/yaml/petstore.yaml`));
 
     expect(json).toStrictEqual(yaml);
   });
 
   describe('JSON', () => {
-    it.each(fg.sync([path.join(__dirname, `../${version}/json/*.json`)]).map(file => [path.basename(file), file]))(
-      'should validate `%s` as valid',
-      async (__, file) => {
-        await expect(file).toBeAValidOpenAPIDefinition();
-        await expect(parse(file)).resolves.toStrictEqual(
-          expect.objectContaining({
-            [specification]: expect.stringContaining(version),
-          }),
-        );
-      },
-    );
+    it.each(
+      fg.sync([path.join(import.meta.dirname, `../${version}/json/*.json`)]).map(file => [path.basename(file), file]),
+    )('should validate `%s` as valid', async (__, file) => {
+      await expect(file).toBeAValidOpenAPIDefinition();
+      await expect(parse(file)).resolves.toStrictEqual(
+        expect.objectContaining({
+          [specification]: expect.stringContaining(version),
+        }),
+      );
+    });
   });
 
   describe('YAML', () => {
-    it.each(fg.sync([path.join(__dirname, `../${version}/yaml/*.yaml`)]).map(file => [path.basename(file), file]))(
-      'should validate `%s` as valid',
-      async (__, file) => {
-        await expect(file).toBeAValidOpenAPIDefinition();
-        await expect(parse(file)).resolves.toStrictEqual(
-          expect.objectContaining({
-            [specification]: expect.stringContaining(version),
-          }),
-        );
-      },
-    );
+    it.each(
+      fg.sync([path.join(import.meta.dirname, `../${version}/yaml/*.yaml`)]).map(file => [path.basename(file), file]),
+    )('should validate `%s` as valid', async (__, file) => {
+      await expect(file).toBeAValidOpenAPIDefinition();
+      await expect(parse(file)).resolves.toStrictEqual(
+        expect.objectContaining({
+          [specification]: expect.stringContaining(version),
+        }),
+      );
+    });
   });
 });

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -8,7 +8,6 @@ import * as README_QUERIES from './queries/readme.js'; // eslint-disable-line re
  * Analyze a given OpenAPI or Swagger definition for any OpenAPI, JSON Schema, and ReadMe-specific
  * feature uses it may contain.
  *
- * @todo this might be worth moving into the `oas` package at some point
  */
 export default async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
   const additionalProperties = OPENAPI_QUERIES.additionalProperties(definition);
@@ -22,6 +21,9 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
   const serverVariables = OPENAPI_QUERIES.serverVariables(definition);
   const webhooks = OPENAPI_QUERIES.webhooks(definition);
   const xml = OPENAPI_QUERIES.xml(definition);
+  const xmlSchemas = OPENAPI_QUERIES.xmlSchemas(definition);
+  const xmlRequests = OPENAPI_QUERIES.xmlRequests(definition);
+  const xmlResponses = OPENAPI_QUERIES.xmlResponses(definition);
 
   const authDefaults = README_QUERIES.authDefaults(definition);
   const codeSampleLanguages = README_QUERIES.codeSampleLanguages(definition);
@@ -102,6 +104,18 @@ export default async function analyzer(definition: OASDocument): Promise<OASAnal
       xml: {
         present: !!xml.length,
         locations: xml,
+      },
+      xmlSchemas: {
+        present: !!xmlSchemas.length,
+        locations: xmlSchemas,
+      },
+      xmlRequests: {
+        present: !!xmlRequests.length,
+        locations: xmlRequests,
+      },
+      xmlResponses: {
+        present: !!xmlResponses.length,
+        locations: xmlResponses,
       },
     },
     readme: {

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -183,7 +183,10 @@ export function webhooks(definition: OASDocument): string[] {
 /**
  * Determine if a given API definition has XML schemas, payloads, or responses.
  *
- * @todo detect `+xml` media types
+ * @deprecated The data contained within this has been split apart into `xmlSchemas`, `xmlRequests`, and `xmlResponses`. This property will be removed in a future release.
+ * @see xmlSchemas
+ * @see xmlRequests
+ * @see xmlResponses
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xml-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object}
  */
@@ -200,6 +203,101 @@ export function xml(definition: OASDocument): string[] {
       "$..requestBody..['text/xml']",
       "$..requestBody..['text/xml-external-parsed-entity']",
       '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
+
+      "$..responses..['application/xml']",
+      "$..responses..['application/xml-external-parsed-entity']",
+      "$..responses..['application/xml-dtd']",
+      "$..responses..['text/xml']",
+      "$..responses..['text/xml-external-parsed-entity']",
+      '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
+    ],
+    definition,
+  ).map(res => refizePointer(res.pointer));
+}
+
+/**
+ * Determine if a given API definition utilises the XML object for defining XML schemas.
+ *
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xml-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object}
+ */
+export function xmlSchemas(definition: OASDocument): string[] {
+  return query(
+    [
+      '$.components.schemas..xml^',
+      '$..parameters..xml^',
+      '$..requestBody..xml^',
+
+      // "$..requestBody..['application/xml']",
+      // "$..requestBody..['application/xml-external-parsed-entity']",
+      // "$..requestBody..['application/xml-dtd']",
+      // "$..requestBody..['text/xml']",
+      // "$..requestBody..['text/xml-external-parsed-entity']",
+      // '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
+
+      // "$..responses..['application/xml']",
+      // "$..responses..['application/xml-external-parsed-entity']",
+      // "$..responses..['application/xml-dtd']",
+      // "$..responses..['text/xml']",
+      // "$..responses..['text/xml-external-parsed-entity']",
+      // '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
+    ],
+    definition,
+  ).map(res => refizePointer(res.pointer));
+}
+
+/**
+ * Determine if a given API definition uses XML in a request body payload.
+ *
+ * @todo detect `+xml` media types
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
+ */
+export function xmlRequests(definition: OASDocument): string[] {
+  return query(
+    [
+      // '$.components.schemas..xml^',
+      // '$..parameters..xml^',
+      // '$..requestBody..xml^',
+
+      "$..requestBody..['application/xml']",
+      "$..requestBody..['application/xml-external-parsed-entity']",
+      "$..requestBody..['application/xml-dtd']",
+      "$..requestBody..['text/xml']",
+      "$..requestBody..['text/xml-external-parsed-entity']",
+      '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
+
+      // "$..responses..['application/xml']",
+      // "$..responses..['application/xml-external-parsed-entity']",
+      // "$..responses..['application/xml-dtd']",
+      // "$..responses..['text/xml']",
+      // "$..responses..['text/xml-external-parsed-entity']",
+      // '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
+    ],
+    definition,
+  ).map(res => refizePointer(res.pointer));
+}
+
+/**
+ * Determine if a given API definition uses XML in a response body.
+ *
+ * @todo detect `+xml` media types
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
+ */
+export function xmlResponses(definition: OASDocument): string[] {
+  return query(
+    [
+      // '$.components.schemas..xml^',
+      // '$..parameters..xml^',
+      // '$..requestBody..xml^',
+
+      // "$..requestBody..['application/xml']",
+      // "$..requestBody..['application/xml-external-parsed-entity']",
+      // "$..requestBody..['application/xml-dtd']",
+      // "$..requestBody..['text/xml']",
+      // "$..requestBody..['text/xml-external-parsed-entity']",
+      // '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
 
       "$..responses..['application/xml']",
       "$..responses..['application/xml-external-parsed-entity']",

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -222,28 +222,9 @@ export function xml(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object}
  */
 export function xmlSchemas(definition: OASDocument): string[] {
-  return query(
-    [
-      '$.components.schemas..xml^',
-      '$..parameters..xml^',
-      '$..requestBody..xml^',
-
-      // "$..requestBody..['application/xml']",
-      // "$..requestBody..['application/xml-external-parsed-entity']",
-      // "$..requestBody..['application/xml-dtd']",
-      // "$..requestBody..['text/xml']",
-      // "$..requestBody..['text/xml-external-parsed-entity']",
-      // '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
-
-      // "$..responses..['application/xml']",
-      // "$..responses..['application/xml-external-parsed-entity']",
-      // "$..responses..['application/xml-dtd']",
-      // "$..responses..['text/xml']",
-      // "$..responses..['text/xml-external-parsed-entity']",
-      // '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
-    ],
-    definition,
-  ).map(res => refizePointer(res.pointer));
+  return query(['$.components.schemas..xml^', '$..parameters..xml^', '$..requestBody..xml^'], definition).map(res =>
+    refizePointer(res.pointer),
+  );
 }
 
 /**
@@ -256,23 +237,12 @@ export function xmlSchemas(definition: OASDocument): string[] {
 export function xmlRequests(definition: OASDocument): string[] {
   return query(
     [
-      // '$.components.schemas..xml^',
-      // '$..parameters..xml^',
-      // '$..requestBody..xml^',
-
       "$..requestBody..['application/xml']",
       "$..requestBody..['application/xml-external-parsed-entity']",
       "$..requestBody..['application/xml-dtd']",
       "$..requestBody..['text/xml']",
       "$..requestBody..['text/xml-external-parsed-entity']",
       '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
-
-      // "$..responses..['application/xml']",
-      // "$..responses..['application/xml-external-parsed-entity']",
-      // "$..responses..['application/xml-dtd']",
-      // "$..responses..['text/xml']",
-      // "$..responses..['text/xml-external-parsed-entity']",
-      // '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
     ],
     definition,
   ).map(res => refizePointer(res.pointer));
@@ -288,17 +258,6 @@ export function xmlRequests(definition: OASDocument): string[] {
 export function xmlResponses(definition: OASDocument): string[] {
   return query(
     [
-      // '$.components.schemas..xml^',
-      // '$..parameters..xml^',
-      // '$..requestBody..xml^',
-
-      // "$..requestBody..['application/xml']",
-      // "$..requestBody..['application/xml-external-parsed-entity']",
-      // "$..requestBody..['application/xml-dtd']",
-      // "$..requestBody..['text/xml']",
-      // "$..requestBody..['text/xml-external-parsed-entity']",
-      // '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
-
       "$..responses..['application/xml']",
       "$..responses..['application/xml-external-parsed-entity']",
       "$..responses..['application/xml-dtd']",

--- a/packages/oas/src/analyzer/types.ts
+++ b/packages/oas/src/analyzer/types.ts
@@ -27,7 +27,13 @@ export interface OASAnalysis {
     serverVariables: OASAnalysisFeature;
     style: OASAnalysisFeature;
     webhooks: OASAnalysisFeature;
+    /**
+     * @deprecated The data contained within this has been split apart into `xmlSchemas`, `xmlRequests`, and `xmlResponses`. This property will be removed in a future release.
+     */
     xml: OASAnalysisFeature;
+    xmlSchemas: OASAnalysisFeature;
+    xmlRequests: OASAnalysisFeature;
+    xmlResponses: OASAnalysisFeature;
   };
   readme: {
     /**

--- a/packages/oas/test/__datasets__/responses.json
+++ b/packages/oas/test/__datasets__/responses.json
@@ -27,6 +27,26 @@
         }
       }
     },
+    "/vendored-xml-content-type-suffix": {
+      "get": {
+        "description": "We should be able to return a response schema on vendor-prefixed content type that's XML-compatible.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain+xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/multiple-responses-with-a-json-compatible": {
       "get": {
         "description": "We should always prefer a JSON-compatible content type when multiple content types are present in a response.",

--- a/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
@@ -94,6 +94,34 @@ exports[`analyzer > should should analyzer an OpenAPI definition 1`] = `
       ],
       "present": true,
     },
+    "xmlRequests": {
+      "locations": [],
+      "present": false,
+    },
+    "xmlResponses": {
+      "locations": [
+        "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1xml",
+        "#/paths/~1pet~1findByTags/get/responses/200/content/application~1xml",
+        "#/paths/~1pet~1{petId}/get/responses/200/content/application~1xml",
+        "#/paths/~1store~1order/post/responses/200/content/application~1xml",
+        "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1xml",
+        "#/paths/~1user~1login/get/responses/200/content/application~1xml",
+        "#/paths/~1user~1{username}/get/responses/200/content/application~1xml",
+      ],
+      "present": true,
+    },
+    "xmlSchemas": {
+      "locations": [
+        "#/components/schemas/Category",
+        "#/components/schemas/Order",
+        "#/components/schemas/Pet",
+        "#/components/schemas/Pet/properties/photoUrls",
+        "#/components/schemas/Pet/properties/tags",
+        "#/components/schemas/Tag",
+        "#/components/schemas/User",
+      ],
+      "present": true,
+    },
   },
   "readme": {
     "x-default": {

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -1,17 +1,12 @@
 import type { OASDocument } from '../../src/types.js';
 
-import { describe, beforeAll, it, expect } from 'vitest';
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import { describe, it, expect } from 'vitest';
 
 import analyzer from '../../src/analyzer/index.js';
 
-let petstore: OASDocument;
-
 describe('analyzer', () => {
-  beforeAll(async () => {
-    petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(r => r.default as OASDocument);
-  });
-
   it('should should analyzer an OpenAPI definition', async () => {
-    await expect(analyzer(petstore)).resolves.toMatchSnapshot();
+    await expect(analyzer(petstore as OASDocument)).resolves.toMatchSnapshot();
   });
 });

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -1,50 +1,28 @@
 import type { OASDocument } from '../../../src/types.js';
 
-import { describe, beforeAll, expect, it } from 'vitest';
+import callbacks from '@readme/oas-examples/3.0/json/callbacks.json' with { type: 'json' };
+import complexNesting from '@readme/oas-examples/3.0/json/complex-nesting.json' with { type: 'json' };
+import discriminators from '@readme/oas-examples/3.0/json/discriminators.json' with { type: 'json' };
+import links from '@readme/oas-examples/3.0/json/link-example.json' with { type: 'json' };
+import commonParameters from '@readme/oas-examples/3.0/json/parameters-common.json' with { type: 'json' };
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import readme from '@readme/oas-examples/3.0/json/readme.json' with { type: 'json' };
+import additionalProperties from '@readme/oas-examples/3.0/json/schema-additional-properties.json' with { type: 'json' };
+import circular from '@readme/oas-examples/3.0/json/schema-circular.json' with { type: 'json' };
+import security from '@readme/oas-examples/3.0/json/security.json' with { type: 'json' };
+import serverVariables from '@readme/oas-examples/3.0/json/server-variables.json' with { type: 'json' };
+import parameterStyles from '@readme/oas-examples/3.1/json/parameters-style.json' with { type: 'json' };
+import trainTravel from '@readme/oas-examples/3.1/json/train-travel.json' with { type: 'json' };
+import webhooks from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
+import { describe, expect, it } from 'vitest';
 
 import * as QUERIES from '../../../src/analyzer/queries/openapi.js'; // eslint-disable-line readme/no-wildcard-imports
-
-function loadSpec(r: any) {
-  return r.default as unknown as OASDocument;
-}
+import responses from '../../__datasets__/responses.json' with { type: 'json' };
 
 describe('analyzer queries (OpenAPI)', () => {
-  let additionalProperties: OASDocument;
-  let callbacks: OASDocument;
-  let circular: OASDocument;
-  let commonParameters: OASDocument;
-  let complexNesting: OASDocument;
-  let discriminators: OASDocument;
-  let links: OASDocument;
-  let parameterStyles: OASDocument;
-  let petstore: OASDocument;
-  let readme: OASDocument;
-  let security: OASDocument;
-  let serverVariables: OASDocument;
-  let webhooks: OASDocument;
-
-  beforeAll(async () => {
-    additionalProperties = await import('@readme/oas-examples/3.0/json/schema-additional-properties.json').then(
-      loadSpec,
-    );
-    complexNesting = await import('@readme/oas-examples/3.0/json/complex-nesting.json').then(loadSpec);
-    callbacks = await import('@readme/oas-examples/3.0/json/callbacks.json').then(loadSpec);
-    commonParameters = await import('@readme/oas-examples/3.0/json/parameters-common.json').then(loadSpec);
-    discriminators = await import('@readme/oas-examples/3.0/json/discriminators.json').then(loadSpec);
-    links = await import('@readme/oas-examples/3.0/json/link-example.json').then(loadSpec);
-    petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(loadSpec);
-    readme = await import('@readme/oas-examples/3.0/json/readme.json').then(loadSpec);
-    circular = await import('@readme/oas-examples/3.0/json/schema-circular.json').then(loadSpec);
-    security = await import('@readme/oas-examples/3.0/json/security.json').then(loadSpec);
-    serverVariables = await import('@readme/oas-examples/3.0/json/server-variables.json').then(loadSpec);
-
-    parameterStyles = await import('@readme/oas-examples/3.1/json/parameters-style.json').then(loadSpec);
-    webhooks = await import('@readme/oas-examples/3.1/json/webhooks.json').then(loadSpec);
-  });
-
   describe('additionalProperties', () => {
     it('should discover `additionalProperties` usage within a definition that has it', () => {
-      expect(QUERIES.additionalProperties(additionalProperties)).toStrictEqual([
+      expect(QUERIES.additionalProperties(additionalProperties as OASDocument)).toStrictEqual([
         '#/paths/~1post/post/requestBody/content/application~1json/schema/properties/object with `additionalProperties: $ref, simple`/additionalProperties',
         '#/paths/~1post/post/requestBody/content/application~1json/schema/properties/object with `additionalProperties: $ref, with $ref`/additionalProperties',
         '#/paths/~1post/post/requestBody/content/application~1json/schema/properties/object with `additionalProperties: false` and no other properties/additionalProperties',
@@ -66,42 +44,42 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it('should discover `additionalProperties` usage within `$ref` pointers', () => {
-      expect(QUERIES.additionalProperties(complexNesting)).toStrictEqual([
+      expect(QUERIES.additionalProperties(complexNesting as OASDocument)).toStrictEqual([
         '#/components/schemas/ObjectOfAdditionalPropertiesObjectPolymorphism/additionalProperties',
       ]);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.additionalProperties(security)).toHaveLength(0);
+      expect(QUERIES.additionalProperties(security as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('callbacks', () => {
     it('should discover `callbacks` usage within a definition that has it', () => {
-      expect(QUERIES.callbacks(callbacks)).toStrictEqual(['#/paths/~1streams/post/callbacks']);
+      expect(QUERIES.callbacks(callbacks as OASDocument)).toStrictEqual(['#/paths/~1streams/post/callbacks']);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.callbacks(readme)).toHaveLength(0);
+      expect(QUERIES.callbacks(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('circularRefs', () => {
     it('should determine if a definition has circular refs when it does', async () => {
-      await expect(QUERIES.circularRefs(circular)).resolves.toStrictEqual([
+      await expect(QUERIES.circularRefs(circular as OASDocument)).resolves.toStrictEqual([
         '#/components/schemas/MultiPart/properties/parent',
         '#/components/schemas/ZoneOffset/properties/rules',
       ]);
     });
 
     it("should not find where it doesn't exist", async () => {
-      await expect(QUERIES.circularRefs(readme)).resolves.toHaveLength(0);
+      await expect(QUERIES.circularRefs(readme as OASDocument)).resolves.toHaveLength(0);
     });
   });
 
   describe('commonParameters', () => {
     it('should discover common parameters usage within a definition that has it', () => {
-      expect(QUERIES.commonParameters(commonParameters)).toStrictEqual([
+      expect(QUERIES.commonParameters(commonParameters as OASDocument)).toStrictEqual([
         '#/paths/~1anything~1{id}/parameters',
         '#/paths/~1anything~1{id}~1override/parameters',
         '#/paths/~1anything~1{id}~1{action}/parameters',
@@ -110,13 +88,13 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.commonParameters(readme)).toHaveLength(0);
+      expect(QUERIES.commonParameters(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('discriminators', () => {
     it('should discover `discriminator` usage within a definition that has it', () => {
-      expect(QUERIES.discriminators(discriminators)).toStrictEqual([
+      expect(QUERIES.discriminators(discriminators as OASDocument)).toStrictEqual([
         '#/components/schemas/BaseVehicle/discriminator',
         '#/components/schemas/Pet/discriminator',
         '#/paths/~1discriminator-with-mapping/patch/requestBody/content/application~1json/schema/discriminator',
@@ -130,13 +108,13 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.discriminators(readme)).toHaveLength(0);
+      expect(QUERIES.discriminators(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('fileSize', () => {
     it('should calculate the size of the definition in its raw form', async () => {
-      await expect(QUERIES.fileSize(readme)).resolves.toStrictEqual({
+      await expect(QUERIES.fileSize(readme as OASDocument)).resolves.toStrictEqual({
         raw: 0.05,
         dereferenced: 0.32,
       });
@@ -145,7 +123,7 @@ describe('analyzer queries (OpenAPI)', () => {
 
   describe('links', () => {
     it('should discover `links` usage within a definition that has it', () => {
-      expect(QUERIES.links(links)).toStrictEqual([
+      expect(QUERIES.links(links as OASDocument)).toStrictEqual([
         '#/components/links',
         '#/paths/~12.0~1repositories~1{username}/get/responses/200/links',
         '#/paths/~12.0~1repositories~1{username}~1{slug}/get/responses/200/links',
@@ -155,13 +133,13 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.links(readme)).toHaveLength(0);
+      expect(QUERIES.links(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('mediaTypes', () => {
     it('should tally all of the media types used within a definition', () => {
-      expect(QUERIES.mediaTypes(petstore)).toStrictEqual([
+      expect(QUERIES.mediaTypes(petstore as OASDocument)).toStrictEqual([
         'application/json',
         'application/x-www-form-urlencoded',
         'application/xml',
@@ -172,7 +150,7 @@ describe('analyzer queries (OpenAPI)', () => {
 
   describe('parameter serialization', () => {
     it('should discover parameter serialization usage within a definition that has it', () => {
-      expect(QUERIES.parameterSerialization(parameterStyles)).toStrictEqual([
+      expect(QUERIES.parameterSerialization(parameterStyles as unknown as OASDocument)).toStrictEqual([
         '#/paths/~1anything~1headers~1simple/get/parameters/0',
         '#/paths/~1anything~1headers~1simple/get/parameters/1',
         '#/paths/~1anything~1headers~1simple/get/parameters/2',
@@ -218,13 +196,13 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.parameterSerialization(readme)).toHaveLength(0);
+      expect(QUERIES.parameterSerialization(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('polymorphism', () => {
     it('should determine if a definition uses schema polymorphism', () => {
-      expect(QUERIES.polymorphism(readme)).toStrictEqual([
+      expect(QUERIES.polymorphism(readme as OASDocument)).toStrictEqual([
         '#/components/responses/authForbidden/content/application~1json/schema',
         '#/components/responses/authUnauthorized/content/application~1json/schema',
         '#/components/schemas/docSchemaPost',
@@ -284,13 +262,18 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.polymorphism(petstore)).toHaveLength(0);
+      expect(QUERIES.polymorphism(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('securityTypes', () => {
     it('should tally all of the security types used within a definition', () => {
-      expect(QUERIES.securityTypes(security)).toStrictEqual(['apiKey', 'http', 'oauth2', 'openIdConnect']);
+      expect(QUERIES.securityTypes(security as OASDocument)).toStrictEqual([
+        'apiKey',
+        'http',
+        'oauth2',
+        'openIdConnect',
+      ]);
     });
   });
 
@@ -300,29 +283,29 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.serverVariables(readme)).toHaveLength(0);
+      expect(QUERIES.serverVariables(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('totalOperations', () => {
     it('should count the total operations used within a definition', () => {
-      expect(QUERIES.totalOperations(readme)).toBe(39);
+      expect(QUERIES.totalOperations(readme as OASDocument)).toBe(39);
     });
   });
 
   describe('webhooks', () => {
     it('should determine if a definition uses webhooks when it does', () => {
-      expect(QUERIES.webhooks(webhooks)).toStrictEqual(['#/webhooks/newPet']);
+      expect(QUERIES.webhooks(webhooks as OASDocument)).toStrictEqual(['#/webhooks/newPet']);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.webhooks(readme)).toHaveLength(0);
+      expect(QUERIES.webhooks(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('xml', () => {
-    it('should determine if a definition has xml', () => {
-      expect(QUERIES.xml(petstore)).toStrictEqual([
+    it('should determine if a definition has XML', () => {
+      expect(QUERIES.xml(petstore as OASDocument)).toStrictEqual([
         '#/components/schemas/Category',
         '#/components/schemas/Order',
         '#/components/schemas/Pet',
@@ -369,7 +352,111 @@ describe('analyzer queries (OpenAPI)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.xml(readme)).toHaveLength(0);
+      expect(QUERIES.xml(readme as OASDocument)).toHaveLength(0);
+    });
+  });
+
+  describe('xmlSchemas', () => {
+    it('should determine if a definition uses the XML object', () => {
+      expect(QUERIES.xmlSchemas(trainTravel as OASDocument)).toStrictEqual([
+        '#/components/schemas/Booking',
+        '#/components/schemas/Problem',
+        '#/components/schemas/Station',
+        '#/components/schemas/Trip',
+        '#/components/schemas/Wrapper-Collection',
+      ]);
+    });
+
+    it('should not detect the `+xml` vendor suffix as an XML object', () => {
+      expect(QUERIES.xmlSchemas(responses as unknown as OASDocument)).toHaveLength(0);
+    });
+
+    it("should not find where it doesn't exist", () => {
+      expect(QUERIES.xmlSchemas(readme as OASDocument)).toHaveLength(0);
+    });
+  });
+
+  describe('xmlRequests', () => {
+    it('should determine if a definition has XML payloads', () => {
+      expect(QUERIES.xmlRequests(trainTravel as OASDocument)).toStrictEqual([
+        '#/paths/~1bookings/post/requestBody/content/application~1xml',
+      ]);
+    });
+
+    it('should discover `+xml` vendor suffixes', () => {
+      expect(
+        QUERIES.xmlRequests({
+          paths: {
+            '/anything': {
+              post: {
+                requestBody: {
+                  required: true,
+                  content: {
+                    'text/plain+xml': {
+                      schema: {
+                        type: 'array',
+                        items: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as any),
+      ).toStrictEqual(['#/paths/~1anything/post/requestBody/content/text~1plain+xml']);
+    });
+
+    it("should not find where it doesn't exist", () => {
+      expect(QUERIES.xmlRequests(readme as OASDocument)).toHaveLength(0);
+    });
+  });
+
+  describe('xmlResponses', () => {
+    it('should determine if a definition has XML responses', () => {
+      expect(QUERIES.xmlResponses(petstore as OASDocument)).toStrictEqual([
+        '#/paths/~1pet~1findByStatus/get/responses/200/content/application~1xml',
+        '#/paths/~1pet~1findByTags/get/responses/200/content/application~1xml',
+        '#/paths/~1pet~1{petId}/get/responses/200/content/application~1xml',
+        '#/paths/~1store~1order/post/responses/200/content/application~1xml',
+        '#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1xml',
+        '#/paths/~1user~1login/get/responses/200/content/application~1xml',
+        '#/paths/~1user~1{username}/get/responses/200/content/application~1xml',
+      ]);
+    });
+
+    it('should discover `+xml` vendor suffixes', () => {
+      expect(
+        QUERIES.xmlResponses({
+          paths: {
+            '/anything': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'successful operation',
+                    content: {
+                      'text/plain+xml': {
+                        schema: {
+                          type: 'array',
+                          items: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as any),
+      ).toStrictEqual(['#/paths/~1anything/get/responses/200/content/text~1plain+xml']);
+    });
+
+    it("should not find where it doesn't exist", () => {
+      expect(QUERIES.xmlResponses(readme as OASDocument)).toHaveLength(0);
     });
   });
 });

--- a/packages/oas/test/analyzer/queries/readme.test.ts
+++ b/packages/oas/test/analyzer/queries/readme.test.ts
@@ -1,48 +1,35 @@
 import type { OASDocument } from '../../../src/types.js';
 
-import { describe, beforeAll, expect, it } from 'vitest';
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import readme from '@readme/oas-examples/3.0/json/readme.json' with { type: 'json' };
+import extensions from '@readme/oas-examples/3.1/json/readme-extensions.json' with { type: 'json' };
+import schemaTypes from '@readme/oas-examples/3.1/json/schema-types.json' with { type: 'json' };
+import { describe, expect, it } from 'vitest';
 
 import * as QUERIES from '../../../src/analyzer/queries/readme.js'; // eslint-disable-line readme/no-wildcard-imports
 import Oas from '../../../src/index.js';
 
-function loadSpec(r: any) {
-  return r.default as unknown as OASDocument;
-}
-
 describe('analyzer queries (ReadMe)', () => {
-  let extensions: OASDocument;
-  let petstore: OASDocument;
-  let readme: OASDocument;
-  let schemaTypes: OASDocument;
-
-  beforeAll(async () => {
-    petstore = await import('@readme/oas-examples/3.0/json/petstore.json').then(loadSpec);
-    readme = await import('@readme/oas-examples/3.0/json/readme.json').then(loadSpec);
-
-    extensions = await import('@readme/oas-examples/3.1/json/readme-extensions.json').then(loadSpec);
-    schemaTypes = await import('@readme/oas-examples/3.1/json/schema-types.json').then(loadSpec);
-  });
-
   describe('`RAW_BODY`', () => {
     it('should deterine if a definition is utilizing `RAW_BODY`', () => {
-      expect(QUERIES.rawBody(schemaTypes)).toStrictEqual([
+      expect(QUERIES.rawBody(schemaTypes as unknown as OASDocument)).toStrictEqual([
         '#/paths/~1anything~1raw_body~1top-level-payloads/patch/requestBody/content/application~1json/schema',
         '#/paths/~1anything~1raw_body~1top-level-payloads/post/requestBody/content/application~1json/schema',
       ]);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.rawBody(readme)).toHaveLength(0);
+      expect(QUERIES.rawBody(readme as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('`x-readme.samples-languages` extension', () => {
     it('should detect usage of `x-samples-languages` for setting code sample languages', () => {
-      expect(QUERIES.codeSampleLanguages(extensions)).toStrictEqual(['swift']);
+      expect(QUERIES.codeSampleLanguages(extensions as unknown as OASDocument)).toStrictEqual(['swift']);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.codeSampleLanguages(petstore)).toHaveLength(0);
+      expect(QUERIES.codeSampleLanguages(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
@@ -63,26 +50,26 @@ describe('analyzer queries (ReadMe)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.codeSamplesDisabled(petstore)).toHaveLength(0);
+      expect(QUERIES.codeSamplesDisabled(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('`x-readme.proxy-enabled` extension', () => {
     it('should detect usage of `x-proxy-enabled` for disabling our CORS proxy', () => {
-      expect(QUERIES.corsProxyDisabled(extensions)).toStrictEqual([
+      expect(QUERIES.corsProxyDisabled(extensions as unknown as OASDocument)).toStrictEqual([
         '#/paths/~1x-proxy-enabled/patch',
         '#/paths/~1x-proxy-enabled/post',
       ]);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.corsProxyDisabled(petstore)).toHaveLength(0);
+      expect(QUERIES.corsProxyDisabled(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('`x-readme.code-samples` extension', () => {
     it('should detect usage of `x-code-samples` for defining custom code samples', () => {
-      expect(QUERIES.customCodeSamples(extensions)).toStrictEqual([
+      expect(QUERIES.customCodeSamples(extensions as unknown as OASDocument)).toStrictEqual([
         '#/paths/~1x-code-samples/get/x-code-samples',
         '#/paths/~1x-code-samples/post/x-readme/code-samples',
       ]);
@@ -109,20 +96,20 @@ describe('analyzer queries (ReadMe)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.customCodeSamples(petstore)).toHaveLength(0);
+      expect(QUERIES.customCodeSamples(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
   describe('`x-readme.explorer-enabled` extension', () => {
     it('should detect usage of `x-explorer-enabled` for disabling the API explorer "try it now" functionality', () => {
-      expect(QUERIES.explorerDisabled(extensions)).toStrictEqual([
+      expect(QUERIES.explorerDisabled(extensions as unknown as OASDocument)).toStrictEqual([
         '#/paths/~1x-explorer-enabled/patch',
         '#/paths/~1x-explorer-enabled/post',
       ]);
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.explorerDisabled(petstore)).toHaveLength(0);
+      expect(QUERIES.explorerDisabled(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
@@ -159,7 +146,7 @@ describe('analyzer queries (ReadMe)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.staticHeaders(petstore)).toHaveLength(0);
+      expect(QUERIES.staticHeaders(petstore as OASDocument)).toHaveLength(0);
     });
   });
 
@@ -187,7 +174,7 @@ describe('analyzer queries (ReadMe)', () => {
     });
 
     it("should not find where it doesn't exist", () => {
-      expect(QUERIES.authDefaults(petstore)).toHaveLength(0);
+      expect(QUERIES.authDefaults(petstore as OASDocument)).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## 🧰 Changes

Our `xml` query within the `oas/analyzer` library is far too encompassing for all things XML and we need ways to know if an OpenAPI definition uses XML schemas or request bodies but not responses. In order to support I have split apart this query into three new datasets: `xmlSchemas`, `xmlRequests`, and `xmlResponses`. 

The prior `xml` query remains intact and continues to query across all three of these datasets however I am marking it as deprecated and will remove it in a future release.