### PR TITLE
fix(parser): rolling back our `json-schema-ref-parser` upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,21 +43,6 @@
       "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
       "dev": true
     },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.3.tgz",
-      "integrity": "sha512-XtI3vr6mq5ySDV7j+/ya7m9UDkRYN91NeSM5CBjGE8EZHXTuu5duHMm5emG+X8tmjRCYpEkWpHfxHpVR91owVg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
     "node_modules/@arethetypeswrong/cli": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.1.tgz",
@@ -7079,7 +7064,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7090,7 +7074,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17747,7 +17730,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -21388,7 +21371,7 @@
       "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^14.0.3",
+        "@apidevtools/json-schema-ref-parser": "^13.0.5",
         "@readme/better-ajv-errors": "^2.3.2",
         "@readme/openapi-schemas": "^3.1.0",
         "@types/json-schema": "^7.0.15",
@@ -21407,6 +21390,22 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "packages/parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-13.0.5.tgz",
+      "integrity": "sha512-xfh4xVJD62gG6spIc7lwxoWT+l16nZu1ELyU8FkjaP/oD2yP09EvLAU6KhtudN9aML2Khhs9pY6Slr7KGTES3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "packages/parser/node_modules/ajv": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -58,7 +58,7 @@
     "test": "echo 'Please run tests from the root!' && exit 1"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^14.0.3",
+    "@apidevtools/json-schema-ref-parser": "^13.0.5",
     "@readme/better-ajv-errors": "^2.3.2",
     "@readme/openapi-schemas": "^3.1.0",
     "@types/json-schema": "^7.0.15",


### PR DESCRIPTION
## 🧰 Changes

Some [rdme](https://npm.im/rdme) users are reporting issues with `$ref` parsing failing suddenly after I published a new release of `@readme/openapi-parser` yesterday that included a major version bump of `@apidevtools/json-schema-ref-parser`. Rolling that back to see if it's the cause.

https://github.com/readmeio/rdme/issues/1306
