### PR TITLE
chore(deps): upgrading `@apidevtools/json-scheam-ref-parser`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,22 @@
       "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
       "dev": true
     },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.1.1.tgz",
+      "integrity": "sha512-uGF1YGOzzD50L7HLNWclXmsEhQflw8/zZHIz0/AzkJrKL5r9PceUipZxR/cp/8veTk4TVfdDJLyIwXLjaP5ePg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
     "node_modules/@arethetypeswrong/cli": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.1.tgz",
@@ -7064,7 +7080,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7075,7 +7090,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17732,7 +17746,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -21373,7 +21387,7 @@
       "version": "4.1.2",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^13.0.5",
+        "@apidevtools/json-schema-ref-parser": "^14.1.1",
         "@readme/better-ajv-errors": "^2.3.2",
         "@readme/openapi-schemas": "^3.1.0",
         "@types/json-schema": "^7.0.15",
@@ -21392,22 +21406,6 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
-      }
-    },
-    "packages/parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-13.0.5.tgz",
-      "integrity": "sha512-xfh4xVJD62gG6spIc7lwxoWT+l16nZu1ELyU8FkjaP/oD2yP09EvLAU6KhtudN9aML2Khhs9pY6Slr7KGTES3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "packages/parser/node_modules/ajv": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -58,7 +58,7 @@
     "test": "echo 'Please run tests from the root!' && exit 1"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^13.0.5",
+    "@apidevtools/json-schema-ref-parser": "^14.1.1",
     "@readme/better-ajv-errors": "^2.3.2",
     "@readme/openapi-schemas": "^3.1.0",
     "@types/json-schema": "^7.0.15",

--- a/packages/parser/test/specs/bundling/bundling.test.ts
+++ b/packages/parser/test/specs/bundling/bundling.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { bundle } from '../../../src/index.js';
+import { relativePath } from '../../utils.js';
+
+describe('bundle', () => {
+  it('should bundle successfully', async () => {
+    const api = await bundle(relativePath('specs/bundling/nullish-example.yaml'));
+
+    expect(api).toStrictEqual({
+      openapi: '3.0.3',
+      info: {
+        version: '1.0',
+        title: 'API definition with a nullish example property',
+      },
+      paths: {
+        '/anything': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/User-Information' },
+                    },
+                    example: { data: { first: null, last: 'lastname' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          'User-Information': {
+            type: 'object',
+            properties: { first: { type: 'boolean' }, last: { type: 'boolean' } },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/parser/test/specs/bundling/nullish-example.yaml
+++ b/packages/parser/test/specs/bundling/nullish-example.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  version: '1.0'
+  title: API definition with a nullish example property
+paths:
+  /anything:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  '$ref': '#/components/schemas/User-Information'
+              example:
+                data:
+                  first:
+                  last: lastname
+components:
+  schemas:
+    User-Information:
+      type: object
+      properties:
+        first:
+          type: boolean
+        last:
+          type: boolean


### PR DESCRIPTION
## 🧰 Changes

This upgrade `@apidevtools/json-schema-ref-parser` to the latest release and also adds a test for the problem that was surfaced in https://github.com/readmeio/rdme/issues/1306 and fixed in https://github.com/APIDevTools/json-schema-ref-parser/pull/393.

Since this upgrade had to be reverted earlier today due to it being released in a patch release, which was automatically pulled down to all existing rdme versions, since this is a major version bump of `json-schema-ref-parser` I'll do a major version bump of our parser library too. Better safe than sorry.
