### PR TITLE
feat(oas): exposing utilities for operationId management

### DIFF
--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -21,6 +21,7 @@ import type { CallbackExamples } from './lib/get-callback-examples.js';
 import type { getParametersAsJSONSchemaOptions, SchemaWrapper } from './lib/get-parameters-as-json-schema.js';
 import type { RequestBodyExamples } from './lib/get-requestbody-examples.js';
 import type { ResponseExamples } from './lib/get-response-examples.js';
+import type { OperationIDGeneratorOptions } from './lib/operationId.js';
 
 import findSchemaDefinition from '../lib/find-schema-definition.js';
 import matchesMimeType from '../lib/matches-mimetype.js';
@@ -372,38 +373,35 @@ export class Operation {
   }
 
   /**
+   * Determine if an operation has an `operationId` present in its schema. Note that if one is
+   * present in the schema but is an empty string then this will return false.
+   *
+   */
+  static hasOperationId(schema: OperationObject): boolean {
+    return hasOperationId(schema);
+  }
+
+  /**
    * Get an `operationId` for this operation. If one is not present (it's not required by the spec!)
    * a hash of the path and method will be returned instead.
    *
    */
-  getOperationId(
-    opts: {
-      /**
-       * Generate a JS method-friendly operation ID when one isn't present.
-       *
-       * For backwards compatiblity reasons this option will be indefinitely supported however we
-       * recommend using `friendlyCase` instead as it's a heavily improved version of this option.
-       *
-       * @see {opts.friendlyCase}
-       * @deprecated
-       */
-      camelCase?: boolean;
-
-      /**
-       * Generate a human-friendly, but still camelCase, operation ID when one isn't present. The
-       * difference between this and `camelCase` is that this also ensure that consecutive words are
-       * not present in the resulting ID. For example, for the endpoint `/candidate/{candidate}` will
-       * return `getCandidateCandidate` for `camelCase` however `friendlyCase` will return
-       * `getCandidate`.
-       *
-       * The reason this friendliness is just not a part of the `camelCase` option is because we have
-       * a number of consumers of the old operation ID style and making that change there would a
-       * breaking change that we don't have any easy way to resolve.
-       */
-      friendlyCase?: boolean;
-    } = {},
-  ): string {
+  getOperationId(opts: OperationIDGeneratorOptions = {}): string {
     return getOperationId(this.path, this.method, this.schema, opts);
+  }
+
+  /**
+   * Get an `operationId` for an operation. If one is not present (it's not required by the spec!)
+   * a hash of the path and method will be returned instead.
+   *
+   */
+  static getOperationId(
+    path: string,
+    method: string,
+    schema: OperationObject,
+    opts: OperationIDGeneratorOptions = {},
+  ): string {
+    return getOperationId(path, method, schema, opts);
   }
 
   /**

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -33,6 +33,7 @@ import { getParametersAsJSONSchema } from './lib/get-parameters-as-json-schema.j
 import { getRequestBodyExamples } from './lib/get-requestbody-examples.js';
 import { getResponseAsJSONSchema } from './lib/get-response-as-json-schema.js';
 import { getResponseExamples } from './lib/get-response-examples.js';
+import { getOperationId, hasOperationId } from './lib/operationId.js';
 
 export class Operation {
   /**
@@ -362,12 +363,12 @@ export class Operation {
   }
 
   /**
-   * Determine if the operation has an operation present in its schema. Note that if one is present
-   * in the schema but is an empty string then this will return false.
+   * Determine if the operation has an `operationId` present in its schema. Note that if one is
+   * present in the schema but is an empty string then this will return false.
    *
    */
   hasOperationId(): boolean {
-    return Boolean('operationId' in this.schema && this.schema.operationId.length);
+    return hasOperationId(this.schema);
   }
 
   /**
@@ -402,75 +403,7 @@ export class Operation {
       friendlyCase?: boolean;
     } = {},
   ): string {
-    function sanitize(id: string) {
-      // We aren't sanitizing underscores here by default in order to preserve operation IDs that
-      // were already generated with this method in the past.
-      return id
-        .replace(opts?.camelCase || opts?.friendlyCase ? /[^a-zA-Z0-9_]/g : /[^a-zA-Z0-9]/g, '-') // Remove weird characters
-        .replace(/--+/g, '-') // Remove double --'s
-        .replace(/^-|-$/g, ''); // Don't start or end with -
-    }
-
-    let operationId: string;
-    if (this.hasOperationId()) {
-      operationId = this.schema.operationId;
-    } else {
-      operationId = sanitize(this.path).toLowerCase();
-    }
-
-    const method = this.method.toLowerCase();
-    if (opts?.camelCase || opts?.friendlyCase) {
-      if (opts?.friendlyCase) {
-        // In order to generate friendlier operation IDs we should swap out underscores with spaces
-        // so the end result will be _slightly_ more camelCase.
-        operationId = operationId.replaceAll('_', ' ');
-
-        if (!this.hasOperationId()) {
-          // In another effort to generate friendly operation IDs we should prevent words from
-          // appearing in consecutive order (eg. `/candidate/{candidate}` should generate
-          // `getCandidate` not `getCandidateCandidate`). However we only want to do this if we're
-          // generating the operation ID as if they intentionally added a consecutive word into the
-          // operation ID then we should respect that.
-          operationId = operationId
-            .replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => ` ${chr}`)
-            .split(' ')
-            .filter((word, i, arr) => word !== arr[i - 1])
-            .join(' ');
-        }
-      }
-
-      operationId = operationId.replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => chr.toUpperCase());
-      if (this.hasOperationId()) {
-        operationId = sanitize(operationId);
-      }
-
-      // Never start with a number.
-      operationId = operationId.replace(/^[0-9]/g, match => `_${match}`);
-
-      // Ensure that the first character of an `operationId` is always lowercase.
-      operationId = operationId.charAt(0).toLowerCase() + operationId.slice(1);
-
-      // If the generated `operationId` already starts with the method (eg. `getPets`) we don't want
-      // to double it up into `getGetPets`.
-      if (operationId.startsWith(method)) {
-        return operationId;
-      }
-
-      // If this operation already has an `operationId` and we just cleaned it up then we shouldn't
-      // prefix it with an HTTP method.
-      if (this.hasOperationId()) {
-        return operationId;
-      }
-
-      // Because we're merging the `operationId` into an HTTP method we need to reset the first
-      // character of it back to lowercase so we end up with `getBuster`, not `getbuster`.
-      operationId = operationId.charAt(0).toUpperCase() + operationId.slice(1);
-      return `${method}${operationId}`;
-    } else if (this.hasOperationId()) {
-      return operationId;
-    }
-
-    return `${method}_${operationId}`;
+    return getOperationId(this.path, this.method, this.schema, opts);
   }
 
   /**

--- a/packages/oas/src/operation/lib/operationId.ts
+++ b/packages/oas/src/operation/lib/operationId.ts
@@ -1,4 +1,30 @@
-import type { OperationObject } from '../../types';
+import type { OperationObject } from '../../types.ts';
+
+export interface OperationIDGeneratorOptions {
+  /**
+   * Generate a JS method-friendly operation ID when one isn't present.
+   *
+   * For backwards compatiblity reasons this option will be indefinitely supported however we
+   * recommend using `friendlyCase` instead as it's a heavily improved version of this option.
+   *
+   * @see {friendlyCase}
+   * @deprecated
+   */
+  camelCase?: boolean;
+
+  /**
+   * Generate a human-friendly, but still camelCase, operation ID when one isn't present. The
+   * difference between this and `camelCase` is that this also ensure that consecutive words are
+   * not present in the resulting ID. For example, for the endpoint `/candidate/{candidate}` will
+   * return `getCandidateCandidate` for `camelCase` however `friendlyCase` will return
+   * `getCandidate`.
+   *
+   * The reason this friendliness is just not a part of the `camelCase` option is because we have
+   * a number of consumers of the old operation ID style and making that change there would a
+   * breaking change that we don't have any easy way to resolve.
+   */
+  friendlyCase?: boolean;
+}
 
 /**
  * Determine if an operation has an `operationId` present in its schema. Note that if one is
@@ -18,31 +44,7 @@ export function getOperationId(
   path: string,
   method: string,
   operation: OperationObject,
-  opts: {
-    /**
-     * Generate a JS method-friendly operation ID when one isn't present.
-     *
-     * For backwards compatiblity reasons this option will be indefinitely supported however we
-     * recommend using `friendlyCase` instead as it's a heavily improved version of this option.
-     *
-     * @see {opts.friendlyCase}
-     * @deprecated
-     */
-    camelCase?: boolean;
-
-    /**
-     * Generate a human-friendly, but still camelCase, operation ID when one isn't present. The
-     * difference between this and `camelCase` is that this also ensure that consecutive words are
-     * not present in the resulting ID. For example, for the endpoint `/candidate/{candidate}` will
-     * return `getCandidateCandidate` for `camelCase` however `friendlyCase` will return
-     * `getCandidate`.
-     *
-     * The reason this friendliness is just not a part of the `camelCase` option is because we have
-     * a number of consumers of the old operation ID style and making that change there would a
-     * breaking change that we don't have any easy way to resolve.
-     */
-    friendlyCase?: boolean;
-  } = {},
+  opts: OperationIDGeneratorOptions = {},
 ): string {
   function sanitize(id: string) {
     // We aren't sanitizing underscores here by default in order to preserve operation IDs that

--- a/packages/oas/src/operation/lib/operationId.ts
+++ b/packages/oas/src/operation/lib/operationId.ts
@@ -1,0 +1,117 @@
+import type { OperationObject } from '../../types';
+
+/**
+ * Determine if an operation has an `operationId` present in its schema. Note that if one is
+ * present in the schema but is an empty string then this will return false.
+ *
+ */
+export function hasOperationId(operation: OperationObject): boolean {
+  return Boolean('operationId' in operation && operation.operationId.length);
+}
+
+/**
+ * Get an `operationId` for an operation. If one is not present (it's not required by the spec!)
+ * a hash of the path and method will be returned instead.
+ *
+ */
+export function getOperationId(
+  path: string,
+  method: string,
+  operation: OperationObject,
+  opts: {
+    /**
+     * Generate a JS method-friendly operation ID when one isn't present.
+     *
+     * For backwards compatiblity reasons this option will be indefinitely supported however we
+     * recommend using `friendlyCase` instead as it's a heavily improved version of this option.
+     *
+     * @see {opts.friendlyCase}
+     * @deprecated
+     */
+    camelCase?: boolean;
+
+    /**
+     * Generate a human-friendly, but still camelCase, operation ID when one isn't present. The
+     * difference between this and `camelCase` is that this also ensure that consecutive words are
+     * not present in the resulting ID. For example, for the endpoint `/candidate/{candidate}` will
+     * return `getCandidateCandidate` for `camelCase` however `friendlyCase` will return
+     * `getCandidate`.
+     *
+     * The reason this friendliness is just not a part of the `camelCase` option is because we have
+     * a number of consumers of the old operation ID style and making that change there would a
+     * breaking change that we don't have any easy way to resolve.
+     */
+    friendlyCase?: boolean;
+  } = {},
+): string {
+  function sanitize(id: string) {
+    // We aren't sanitizing underscores here by default in order to preserve operation IDs that
+    // were already generated with this method in the past.
+    return id
+      .replace(opts?.camelCase || opts?.friendlyCase ? /[^a-zA-Z0-9_]/g : /[^a-zA-Z0-9]/g, '-') // Remove weird characters
+      .replace(/--+/g, '-') // Remove double --'s
+      .replace(/^-|-$/g, ''); // Don't start or end with -
+  }
+
+  const operationIdExists = hasOperationId(operation);
+  let operationId: string;
+  if (operationIdExists) {
+    operationId = operation.operationId;
+  } else {
+    operationId = sanitize(path).toLowerCase();
+  }
+
+  const currMethod = method.toLowerCase();
+  if (opts?.camelCase || opts?.friendlyCase) {
+    if (opts?.friendlyCase) {
+      // In order to generate friendlier operation IDs we should swap out underscores with spaces
+      // so the end result will be _slightly_ more camelCase.
+      operationId = operationId.replaceAll('_', ' ');
+
+      if (!operationIdExists) {
+        // In another effort to generate friendly operation IDs we should prevent words from
+        // appearing in consecutive order (eg. `/candidate/{candidate}` should generate
+        // `getCandidate` not `getCandidateCandidate`). However we only want to do this if we're
+        // generating the operation ID as if they intentionally added a consecutive word into the
+        // operation ID then we should respect that.
+        operationId = operationId
+          .replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => ` ${chr}`)
+          .split(' ')
+          .filter((word, i, arr) => word !== arr[i - 1])
+          .join(' ');
+      }
+    }
+
+    operationId = operationId.replace(/[^a-zA-Z0-9_]+(.)/g, (_, chr) => chr.toUpperCase());
+    if (operationIdExists) {
+      operationId = sanitize(operationId);
+    }
+
+    // Never start with a number.
+    operationId = operationId.replace(/^[0-9]/g, match => `_${match}`);
+
+    // Ensure that the first character of an `operationId` is always lowercase.
+    operationId = operationId.charAt(0).toLowerCase() + operationId.slice(1);
+
+    // If the generated `operationId` already starts with the method (eg. `getPets`) we don't want
+    // to double it up into `getGetPets`.
+    if (operationId.startsWith(currMethod)) {
+      return operationId;
+    }
+
+    // If this operation already has an `operationId` and we just cleaned it up then we shouldn't
+    // prefix it with an HTTP method.
+    if (operationIdExists) {
+      return operationId;
+    }
+
+    // Because we're merging the `operationId` into an HTTP method we need to reset the first
+    // character of it back to lowercase so we end up with `getBuster`, not `getbuster`.
+    operationId = operationId.charAt(0).toUpperCase() + operationId.slice(1);
+    return `${currMethod}${operationId}`;
+  } else if (operationIdExists) {
+    return operationId;
+  }
+
+  return `${currMethod}_${operationId}`;
+}

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -1,8 +1,7 @@
 import findSchemaDefinition from './lib/find-schema-definition.js';
 import matchesMimeType from './lib/matches-mimetype.js';
 import { types as jsonSchemaTypes } from './operation/lib/get-parameters-as-json-schema.js';
-import { getOperationId, hasOperationId } from './operation/lib/operationId.js';
 
 const supportedMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
-export { findSchemaDefinition, getOperationId, hasOperationId, jsonSchemaTypes, matchesMimeType, supportedMethods };
+export { findSchemaDefinition, jsonSchemaTypes, matchesMimeType, supportedMethods };

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -1,7 +1,8 @@
 import findSchemaDefinition from './lib/find-schema-definition.js';
 import matchesMimeType from './lib/matches-mimetype.js';
 import { types as jsonSchemaTypes } from './operation/lib/get-parameters-as-json-schema.js';
+import { getOperationId, hasOperationId } from './operation/lib/operationId.js';
 
 const supportedMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
-export { findSchemaDefinition, jsonSchemaTypes, matchesMimeType, supportedMethods };
+export { findSchemaDefinition, getOperationId, hasOperationId, jsonSchemaTypes, matchesMimeType, supportedMethods };

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -1049,6 +1049,14 @@ describe('#hasOperationId()', () => {
 
     expect(operation.hasOperationId()).toBe(false);
   });
+
+  describe('and we are using the static method instead of the instance', () => {
+    it('should return true if one exists', () => {
+      const operation = petstore.operation('/pet/{petId}', 'delete');
+
+      expect(Operation.hasOperationId(operation.schema)).toBe(true);
+    });
+  });
 });
 
 describe('#getOperationId()', () => {
@@ -1271,6 +1279,14 @@ describe('#getOperationId()', () => {
 
         expect(operation.getOperationId({ friendlyCase: true })).toBe('postPetAdoption');
       });
+    });
+  });
+
+  describe('and we are using the static method instead of the instance', () => {
+    it('should return an operation id if one exists', () => {
+      const operation = petstore.operation('/pet/{petId}', 'delete');
+
+      expect(Operation.getOperationId(operation.path, operation.method, operation.schema)).toBe('deletePet');
     });
   });
 });


### PR DESCRIPTION
## 🧰 Changes

This exposes our `getOperationId` and `hasOperationID` methods that are a core part of `oas` `Operation` class to be usable outside of the class. I'm doing this because I would like to be able to invoke `getOperationId` without the memory overhead of instantiating new instances of `Oas` and `Operation` to do so.