### PR TITLE
fix(oas): don’t drop `false`/`0`/`null` when appending enum to description

### DIFF
--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -830,7 +830,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts: toJSONSchemaOpt
     // will serve nobody any good.
     if (addEnumsToDescriptions) {
       const enums = schema.enum
-        .filter(Boolean)
+        .filter(v => v !== undefined && (typeof v !== 'string' || v.trim() !== ''))
         .map(str => `\`${str}\``)
         .join(' ');
 

--- a/packages/oas/test/__datasets__/response-enums.json
+++ b/packages/oas/test/__datasets__/response-enums.json
@@ -53,6 +53,10 @@
             "type": "string",
             "enum": ["available", "pending", "sold"]
           },
+          "enum (with boolean values)": {
+            "type": "boolean",
+            "enum": [true, false]
+          },
           "enum (with default)": {
             "type": "string",
             "description": "This enum has a `default` of `available`.",
@@ -74,6 +78,20 @@
             "description": "This enum has a an empty string (`\"\"`) as its only available option, and that same value is set as its `default`.",
             "enum": [""],
             "default": ""
+          },
+          "enum (with null value)": {
+            "type": "string",
+            "nullable": true,
+            "enum": ["available", "pending", "sold", null]
+          },
+          "enum (with value 0)": {
+            "type": "number",
+            "enum": [0, 1]
+          },
+          "enum (with value containing only a space)": {
+            "type": "string",
+            "nullable": true,
+            "enum": ["available", " "]
           }
         }
       }

--- a/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
@@ -164,6 +164,10 @@ describe('`enum` handling', () => {
               description:
                 'This enum has a an empty string (`""`) as one of its available options.\n\n`available` `pending` `sold`',
             }),
+            'enum (with empty option and empty default)': expect.objectContaining({
+              description:
+                'This enum has a an empty string (`""`) as its only available option, and that same value is set as its `default`.',
+            }),
             'enum (with null value)': expect.objectContaining({
               description: '`available` `pending` `sold` `null`',
             }),

--- a/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/lib/get-response-as-json-schema.test.ts
@@ -151,6 +151,9 @@ describe('`enum` handling', () => {
             'enum (no description)': expect.objectContaining({
               description: '`available` `pending` `sold`',
             }),
+            'enum (with boolean values)': expect.objectContaining({
+              description: '`true` `false`',
+            }),
             'enum (with default)': expect.objectContaining({
               description: 'This enum has a `default` of `available`.\n\n`available` `pending` `sold`',
             }),
@@ -161,9 +164,14 @@ describe('`enum` handling', () => {
               description:
                 'This enum has a an empty string (`""`) as one of its available options.\n\n`available` `pending` `sold`',
             }),
-            'enum (with empty option and empty default)': expect.objectContaining({
-              description:
-                'This enum has a an empty string (`""`) as its only available option, and that same value is set as its `default`.',
+            'enum (with null value)': expect.objectContaining({
+              description: '`available` `pending` `sold` `null`',
+            }),
+            'enum (with value 0)': expect.objectContaining({
+              description: '`0` `1`',
+            }),
+            'enum (with value containing only a space)': expect.objectContaining({
+              description: '`available`',
             }),
           }),
           'x-readme-ref-name': 'enum-request',


### PR DESCRIPTION
| 🚥 Resolves CX-989, RM-8112 |
| :------------------- |

## 🧰 Changes

- Replace `.filter(Boolean)` with a targeted predicate to exclude only undefined and blank strings, preserving `false`, `0`, and `null`.

- Update tests to cover boolean/number/null enums.

Impact: Descriptions now correctly include all valid enum values; previously dropped falsy values are retained.
