### PR TITLE
Revert "chore(deps): bump @apidevtools/json-schema-ref-parser from 14.2.1 to 15.1.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,15 +30,18 @@
       "dev": true
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.1.3.tgz",
-      "integrity": "sha512-XvEitlOaU8S+hOrMPuGyCjp6vC51K+syUN4HHrSUdSDLLWRWQJYjInU6xlSoRGCVBCfcoHxbRm+yiaYq2yFR5w==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.1.tgz",
+      "integrity": "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">= 20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       },
       "peerDependencies": {
         "@types/json-schema": "^7.0.15"
@@ -17596,7 +17599,7 @@
       "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^15.1.3",
+        "@apidevtools/json-schema-ref-parser": "^14.1.1",
         "@readme/better-ajv-errors": "^2.3.2",
         "@readme/openapi-schemas": "^3.1.0",
         "@types/json-schema": "^7.0.15",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -61,7 +61,7 @@
     "test": "echo 'Please run tests from the root!' && exit 1"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^15.1.3",
+    "@apidevtools/json-schema-ref-parser": "^14.1.1",
     "@readme/better-ajv-errors": "^2.3.2",
     "@readme/openapi-schemas": "^3.1.0",
     "@types/json-schema": "^7.0.15",


### PR DESCRIPTION
Reverts readmeio/oas#1025

`@apidevtools/json-schema-ref-parser` went ESM-only and we aren't ready for that.