### PR TITLE
feat: Ability to get response schema by preferred header content type

### DIFF
--- a/packages/oas/src/operation/lib/get-response-as-json-schema.ts
+++ b/packages/oas/src/operation/lib/get-response-as-json-schema.ts
@@ -100,6 +100,7 @@ export function getResponseAsJSONSchema(
   statusCode: number | string,
   opts?: {
     includeDiscriminatorMappingRefs?: boolean;
+    preferContentType?: string;
     /**
      * With a transformer you can transform any data within a given schema, like say if you want
      * to rewrite a potentially unsafe `title` that might be eventually used as a JS variable
@@ -138,6 +139,14 @@ export function getResponseAsJSONSchema(
     const contentTypes = Object.keys(content);
     if (!contentTypes.length) {
       return null;
+    }
+
+    if (opts?.preferContentType && content[opts.preferContentType]) {
+      return toJSONSchema(cloneObject(content[opts.preferContentType].schema), {
+        addEnumsToDescriptions: true,
+        refLogger,
+        transformer: opts.transformer,
+      });
     }
 
     for (let i = 0; i < contentTypes.length; i++) {

--- a/packages/oas/test/operation/lib/get-response-as-json-schema-content-type.test.ts
+++ b/packages/oas/test/operation/lib/get-response-as-json-schema-content-type.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { createOasForOperation } from '../../__fixtures__/create-oas.js';
+
+describe('#getResponseAsJSONSchema() content type override', () => {
+  it('should respect the preferContentType option if provided', () => {
+    const oas = createOasForOperation({
+      responses: {
+        200: {
+          description: 'OK',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { json: { type: 'string' } },
+              },
+            },
+            'application/xml': {
+              schema: {
+                type: 'object',
+                properties: { xml: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    });
+    const operation = oas.operation('/', 'get');
+
+    // Default behavior (prefers JSON)
+    const defaultSchema = operation.getResponseAsJSONSchema('200');
+    expect(defaultSchema[0].schema.properties.json).toBeDefined();
+
+    // With override
+    const xmlSchema = operation.getResponseAsJSONSchema('200', { preferContentType: 'application/xml' });
+    expect(xmlSchema[0].schema.properties.xml).toBeDefined();
+  });
+
+  it('should fall back to default logic if provided preferContentType does not exist', () => {
+    const oas = createOasForOperation({
+      responses: {
+        200: {
+          description: 'OK',
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { json: { type: 'string' } },
+              },
+            },
+          },
+        },
+      },
+    });
+    const operation = oas.operation('/', 'get');
+
+    const schema = operation.getResponseAsJSONSchema('200', { preferContentType: 'application/xml' });
+    expect(schema[0].schema.properties.json).toBeDefined();
+  });
+});

--- a/packages/oas/test/operation/selected-content-type.test.ts
+++ b/packages/oas/test/operation/selected-content-type.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { createOasForOperation } from '../__fixtures__/create-oas.js';
+
+describe('Operation #selectedContentType', () => {
+  it('should allow setting and getting a selected content type', () => {
+    const oas = createOasForOperation({
+      requestBody: {
+        content: {
+          'application/json': { schema: { type: 'object' } },
+          'application/xml': { schema: { type: 'object' } },
+        },
+      },
+    });
+    const operation = oas.operation('/', 'get');
+
+    expect(operation.getContentType()).toBe('application/json');
+
+    operation.setContentType('application/xml');
+    expect(operation.getContentType()).toBe('application/xml');
+  });
+
+  it('should respect selected content type in getRequestBody()', () => {
+    const oas = createOasForOperation({
+      requestBody: {
+        description: 'Test Description',
+        content: {
+          'application/json': { schema: { type: 'object', properties: { json: { type: 'boolean' } } } },
+          'application/xml': { schema: { type: 'object', properties: { xml: { type: 'boolean' } } } },
+        },
+      },
+    });
+    const operation = oas.operation('/', 'get');
+
+    // Default (should be JSON)
+    const [defaultType] = operation.getRequestBody() as [string, any, string];
+    expect(defaultType).toBe('application/json');
+
+    // Select XML
+    operation.setContentType('application/xml');
+    const [selectedType, selectedSchema, description] = operation.getRequestBody() as [string, any, string];
+    expect(selectedType).toBe('application/xml');
+    expect(selectedSchema.schema.properties.xml).toBeDefined();
+    expect(description).toBe('Test Description');
+  });
+
+  it('should return false if selected content type does not exist in getRequestBody()', () => {
+    const oas = createOasForOperation({
+      requestBody: {
+        content: {
+          'application/json': { schema: { type: 'object' } },
+        },
+      },
+    });
+    const operation = oas.operation('/', 'get');
+
+    operation.setContentType('application/xml');
+    expect(operation.getRequestBody()).toBe(false);
+  });
+
+  it('should return available media types via getMediaTypes()', () => {
+    const oas = createOasForOperation({
+      requestBody: {
+        content: {
+          'application/json': { schema: { type: 'object' } },
+          'application/xml': { schema: { type: 'object' } },
+        },
+      },
+      responses: {
+        200: {
+          description: 'Success response',
+          content: {
+            'text/plain': { schema: { type: 'string' } },
+          },
+        },
+      },
+    });
+    const operation = oas.operation('/', 'get');
+
+    expect(operation.getMediaTypes()).toStrictEqual(['application/json', 'application/xml', 'text/plain']);
+  });
+
+  describe('no content type requirements', () => {
+    it('should return an empty array if no media types are defined anywhere', () => {
+      const oas = createOasForOperation({
+        responses: {
+          204: { description: 'No Content' },
+        },
+      });
+      const operation = oas.operation('/', 'get');
+
+      expect(operation.getMediaTypes()).toStrictEqual([]);
+    });
+
+    it('should not include Accept header if no response content exists', () => {
+      const oas = createOasForOperation({
+        requestBody: {
+          content: { 'application/json': {} },
+        },
+        responses: {
+          204: { description: 'No Content' },
+        },
+      });
+      const operation = oas.operation('/', 'get');
+
+      const headers = operation.getHeaders();
+      expect(headers.request).not.toContain('Accept');
+      expect(headers.request).toContain('Content-Type'); // Added because request body exists
+    });
+  });
+});


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

Added `preferContentType` to Operation so we can fetch response schema based on different header 'accept' content type

## 🧰 Changes

Describe in detail what this PR is for.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
