### PR TITLE
fix(oas): improved support for response examples with `$ref` pointers

### DIFF
--- a/packages/oas/src/lib/refs.ts
+++ b/packages/oas/src/lib/refs.ts
@@ -145,6 +145,42 @@ export function dereferenceRef<T>(
 }
 
 /**
+ * Recursively resolve `$ref` pointers inside a given schema.
+ *
+ * Uses the same `seenRefs` logic as `dereferenceRef` for protection against circular references.
+ *
+ * @see {@link dereferenceRef}
+ */
+export function dereferenceRefDeep<T>(
+  value: T,
+  definition?: OASDocument | SchemaObject,
+  seenRefs: Set<string> = new Set<string>(),
+): T {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+
+  if (isRef(value)) {
+    if (!definition) return value;
+
+    const resolved = dereferenceRef(value, definition, seenRefs);
+    if (isRef(resolved)) return resolved as T;
+
+    return dereferenceRefDeep(resolved, definition, seenRefs) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(entry => dereferenceRefDeep(entry, definition, seenRefs)) as T;
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    out[key] = dereferenceRefDeep((value as Record<string, unknown>)[key], definition, seenRefs);
+  }
+
+  return out as T;
+}
+
+/**
  * Retrive our dereferencing configuration for `@readme/openapi-parser`.
  *
  */

--- a/packages/oas/src/operation/lib/get-mediatype-examples.ts
+++ b/packages/oas/src/operation/lib/get-mediatype-examples.ts
@@ -1,9 +1,9 @@
 import type { MediaTypeObject, OASDocument } from '../../types.js';
 
 import matchesMimeType from '../../lib/matches-mimetype.js';
+import { collectRefsInSchema, dereferenceRef, dereferenceRefDeep } from '../../lib/refs.js';
 import sampleFromSchema from '../../samples/index.js';
 import { isRef } from '../../types.js';
-import { dereferenceRef } from '../../utils.js';
 
 export interface MediaTypeExample {
   description?: string;
@@ -39,11 +39,13 @@ export function getMediaTypeExamples(
   } = {},
 ): MediaTypeExample[] {
   if (mediaTypeObject.example) {
-    if (isRef(mediaTypeObject.example)) {
-      mediaTypeObject.example = dereferenceRef(mediaTypeObject.example, definition);
-      if (!mediaTypeObject.example || isRef(mediaTypeObject.example)) {
-        return [];
-      }
+    mediaTypeObject.example = dereferenceRefDeep(mediaTypeObject.example, definition);
+
+    // If there is no example or if it contains any `$ref` pointers that we couldn't resolve then
+    // we shouldn't return anything because to the user it'll look like we generated an invalid
+    // example.
+    if (mediaTypeObject.example === undefined || collectRefsInSchema(mediaTypeObject.example).size > 0) {
+      return [];
     }
 
     return [
@@ -60,6 +62,13 @@ export function getMediaTypeExamples(
 
         let example = examples[key];
         if (example !== null && typeof example === 'object') {
+          if (isRef(example)) {
+            example = dereferenceRef(example, definition);
+            if (!example || isRef(example)) {
+              return false;
+            }
+          }
+
           if ('summary' in example) {
             summary = example.summary;
           }
@@ -68,19 +77,14 @@ export function getMediaTypeExamples(
             description = example.description;
           }
 
-          if (isRef(example)) {
-            example = dereferenceRef(example, definition);
-            if (!example || isRef(example)) {
-              return false;
-            }
-          }
-
           if ('value' in example) {
-            if (isRef(example.value)) {
-              example.value = dereferenceRef(example.value, definition);
-              if (!example.value || isRef(example.value)) {
-                return false;
-              }
+            example.value = dereferenceRefDeep(example.value, definition);
+
+            // If there is no example value or if it contains any `$ref` pointers that we couldn't
+            // resolve then we shouldn't return anything because to the user it'll look like we
+            // generated an invalid example.
+            if (example.value === undefined || collectRefsInSchema(example.value).size > 0) {
+              return false;
             }
 
             example = example.value;

--- a/packages/oas/test/__datasets__/issues/CX-3172.json
+++ b/packages/oas/test/__datasets__/issues/CX-3172.json
@@ -1,0 +1,167 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Response Example $ref Repro",
+    "version": "1.0.0",
+    "description": "Minimal repros for renderer issues where response examples are authored with refs but end up de-referenced. Includes both a standard components/examples ref and a schema x-examples-style ref embedded inside an example value."
+  },
+  "paths": {
+    "/widgets/{widgetId}": {
+      "get": {
+        "summary": "Get widget",
+        "operationId": "getWidget",
+        "parameters": [
+          {
+            "name": "widgetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WidgetResponse"
+                },
+                "examples": {
+                  "default": {
+                    "$ref": "#/components/examples/WidgetResponseExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/companies/{company_id}/admins": {
+      "get": {
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Example": {
+                    "value": [
+                      {
+                        "$ref": "#/components/schemas/Admin/x-examples/Example"
+                      }
+                    ]
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Admin"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "WidgetResponse": {
+        "type": "object",
+        "required": ["id", "name", "status", "owner"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "w_123"
+          },
+          "name": {
+            "type": "string",
+            "example": "Payroll Widget"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive"],
+            "example": "active"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/Owner"
+          }
+        }
+      },
+      "Owner": {
+        "type": "object",
+        "required": ["id", "email"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "u_456"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "owner@example.com"
+          }
+        }
+      },
+      "Admin": {
+        "type": "object",
+        "required": ["uuid", "email", "first_name", "last_name"],
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "example": "admin_123"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "example": "admin@example.com"
+          },
+          "first_name": {
+            "type": "string",
+            "example": "Ada"
+          },
+          "last_name": {
+            "type": "string",
+            "example": "Lovelace"
+          }
+        },
+        "x-examples": {
+          "Example": {
+            "uuid": "admin_123",
+            "email": "admin@example.com",
+            "first_name": "Ada",
+            "last_name": "Lovelace"
+          }
+        }
+      }
+    },
+    "examples": {
+      "WidgetResponseExample": {
+        "summary": "Referenced response example",
+        "value": {
+          "id": "w_123",
+          "name": "Payroll Widget",
+          "status": "active",
+          "owner": {
+            "id": "u_456",
+            "email": "owner@example.com"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/lib/refs.test.ts
+++ b/packages/oas/test/lib/refs.test.ts
@@ -3,7 +3,13 @@ import type { OASDocument, SchemaObject } from '../../src/types.js';
 import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
 import { describe, expect, it } from 'vitest';
 
-import { decodePointer, dereferenceRef, encodePointer, mergeReferencedSchemasIntoRoot } from '../../src/lib/refs.js';
+import {
+  decodePointer,
+  dereferenceRef,
+  dereferenceRefDeep,
+  encodePointer,
+  mergeReferencedSchemasIntoRoot,
+} from '../../src/lib/refs.js';
 
 describe('#encodePointer()', () => {
   it('should encode a string to a JSON pointer', () => {
@@ -130,6 +136,126 @@ describe('#dereferenceRef()', () => {
       expect(dereferenceRef(ref, definition, seenRefs)).toStrictEqual(ref);
       expect(seenRefs.has('#/components/schemas/SelfRef')).toBe(true);
     });
+  });
+});
+
+describe('#dereferenceRefDeep()', () => {
+  it('should return null and undefined as-is', () => {
+    expect(dereferenceRefDeep(null)).toBeNull();
+    expect(dereferenceRefDeep(undefined)).toBeUndefined();
+  });
+
+  it('should return primitives as-is', () => {
+    expect(dereferenceRefDeep('x')).toBe('x');
+    expect(dereferenceRefDeep(0)).toBe(0);
+    expect(dereferenceRefDeep(false)).toBe(false);
+  });
+
+  it('should dereference a root `$ref` and recurse into nested `$ref` inside the resolved value', () => {
+    const api = {
+      components: {
+        schemas: {
+          Inner: { type: 'string', const: 'x' },
+          Outer: { type: 'object', properties: { inner: { $ref: '#/components/schemas/Inner' } } },
+        },
+      },
+    } as unknown as OASDocument;
+
+    expect(dereferenceRefDeep({ $ref: '#/components/schemas/Outer' }, api)).toStrictEqual({
+      type: 'object',
+      properties: {
+        inner: { type: 'string', const: 'x' },
+      },
+    });
+  });
+
+  it('should dereference `$ref` entries inside an array', () => {
+    const rowSchema = {
+      type: 'object',
+      properties: {
+        uuid: { type: 'string', example: 'u1' },
+        email: { type: 'string', format: 'email', example: 'a@b.c' },
+      },
+      required: ['uuid', 'email'],
+    } as const;
+
+    const api = {
+      components: {
+        schemas: {
+          Row: rowSchema,
+        },
+      },
+    } as unknown as OASDocument;
+
+    expect(dereferenceRefDeep([{ $ref: '#/components/schemas/Row' }, { plain: true }], api)).toStrictEqual([
+      rowSchema,
+      { plain: true },
+    ]);
+  });
+
+  it('should dereference `$ref` values nested under object properties', () => {
+    const api = {
+      components: {
+        schemas: {
+          Payload: { type: 'object', properties: { id: { type: 'integer' } } },
+        },
+      },
+    } as unknown as OASDocument;
+
+    expect(
+      dereferenceRefDeep(
+        {
+          meta: { kind: 'row' },
+          data: { $ref: '#/components/schemas/Payload' },
+        },
+        api,
+      ),
+    ).toStrictEqual({
+      meta: { kind: 'row' },
+      data: { type: 'object', properties: { id: { type: 'integer' } } },
+    });
+  });
+
+  it('should leave `$ref` in place when a definition is not supplied', () => {
+    const ref = { $ref: '#/components/schemas/Pet' };
+    expect(dereferenceRefDeep({ outer: [ref] })).toStrictEqual({ outer: [ref] });
+  });
+
+  it('should leave `$ref` in place when nested resolution hits a circular reference', () => {
+    const circular = {
+      components: {
+        schemas: {
+          A: { items: [{ $ref: '#/components/schemas/B' }] },
+          B: { $ref: '#/components/schemas/A' },
+        },
+      },
+    } as unknown as OASDocument;
+
+    const out = dereferenceRefDeep({ $ref: '#/components/schemas/A' }, circular);
+    expect(out).toStrictEqual({
+      items: [{ $ref: '#/components/schemas/A' }],
+    });
+  });
+
+  it('should leave an invalid nested `$ref` unchanged when lookup fails', () => {
+    const ref = { $ref: '#/components/schemas/Nope' };
+    expect(dereferenceRefDeep({ x: ref }, petstore as OASDocument)).toStrictEqual({ x: ref });
+  });
+
+  it('should use a single instance of the `seenRefs` set across all recursive calls', () => {
+    const seen = new Set<string>();
+    const api = {
+      components: {
+        schemas: {
+          Leaf: { type: 'boolean' },
+          Root: { $ref: '#/components/schemas/Leaf' },
+        },
+      },
+    } as unknown as OASDocument;
+
+    dereferenceRefDeep({ $ref: '#/components/schemas/Root' }, api, seen);
+    expect(seen.has('#/components/schemas/Root')).toBe(true);
+    expect(seen.has('#/components/schemas/Leaf')).toBe(true);
   });
 });
 

--- a/packages/oas/test/operation/lib/__snapshots__/get-response-examples.test.ts.snap
+++ b/packages/oas/test/operation/lib/__snapshots__/get-response-examples.test.ts.snap
@@ -1,0 +1,88 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`.getResponseExamples() > defined within response \`content\` > \`examples\` > $ref support > should support media type example \`$ref\` pointers 1`] = `
+[
+  {
+    "mediaTypes": {
+      "application/json": [
+        {
+          "summary": "user",
+          "title": "user",
+          "value": {
+            "user": {
+              "email": "test@example.com",
+              "name": "Test user name",
+            },
+          },
+        },
+      ],
+    },
+    "status": "201",
+  },
+  {
+    "mediaTypes": {
+      "application/json": [
+        {
+          "summary": "An example of a cat",
+          "title": "cat",
+          "value": {
+            "breed": "Persian",
+            "color": "White",
+            "gender": "male",
+            "name": "Fluffy",
+            "petType": "Cat",
+          },
+        },
+        {
+          "summary": "An example of a dog with a cat's name",
+          "title": "dog",
+          "value": {
+            "breed": "Mixed",
+            "color": "Black",
+            "gender": "Female",
+            "name": "Puma",
+            "petType": "Dog",
+          },
+        },
+      ],
+    },
+    "status": "202",
+  },
+  {
+    "mediaTypes": {
+      "application/xml": [
+        {
+          "summary": "response",
+          "title": "response",
+          "value": "<?xml version="1.0" encoding="UTF-8"?><note><to>Tove</to><from>Jani</from><heading>Reminder</heading><body>Don't forget me this weekend!</body></note>",
+        },
+      ],
+    },
+    "status": "400",
+  },
+  {
+    "mediaTypes": {
+      "application/json": [
+        {
+          "summary": "response",
+          "title": "response",
+          "value": {
+            "user": {
+              "email": "test@example.com",
+              "name": "Test user name",
+            },
+          },
+        },
+      ],
+      "text/csv, text/comma-separated-values": [
+        {
+          "summary": "display_view=app",
+          "title": "display_view=app",
+          "value": "app1,app2,app3,app4,app5",
+        },
+      ],
+    },
+    "status": "default",
+  },
+]
+`;

--- a/packages/oas/test/operation/lib/get-mediatype-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-mediatype-examples.test.ts
@@ -1,0 +1,207 @@
+import type { MediaTypeObject, OASDocument } from '../../../src/types.js';
+
+import { describe, expect, it } from 'vitest';
+
+import { getMediaTypeExamples } from '../../../src/operation/lib/get-mediatype-examples.js';
+
+describe('getMediaTypeExamples()', () => {
+  describe('dereferencing `example`', () => {
+    it('should resolve a top-level `$ref` on `example`', () => {
+      const definition = {
+        components: {
+          examples: {
+            UserPayload: {
+              summary: 'User',
+              value: { id: '42', name: 'Ada' },
+            },
+          },
+        },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        example: { $ref: '#/components/examples/UserPayload' },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          value: {
+            summary: 'User',
+            value: { id: '42', name: 'Ada' },
+          },
+        },
+      ]);
+    });
+
+    it('should deeply resolve `$ref` values inside an array on `example`', () => {
+      const definition = {
+        components: {
+          examples: {
+            Row: {
+              value: { uuid: 'u1', email: 'row@example.com' },
+            },
+          },
+        },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        example: [{ $ref: '#/components/examples/Row/value' }, { local: true }],
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          value: [{ uuid: 'u1', email: 'row@example.com' }, { local: true }],
+        },
+      ]);
+    });
+
+    it('should return no examples when `example` stays a `$ref` after dereferencing fails', () => {
+      const definition = {
+        components: { examples: {} },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        example: { $ref: '#/components/examples/DoesNotExist' },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([]);
+    });
+
+    it('should return no examples when a nested value still contains an unresolved `$ref`', () => {
+      const definition = {
+        components: { examples: {} },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        example: {
+          items: [{ $ref: '#/components/examples/Missing' }],
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([]);
+    });
+
+    it('should leave a plain `example` value unchanged when it has no refs', () => {
+      const definition = {} as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        example: { count: 3, tags: ['a', 'b'] },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        { value: { count: 3, tags: ['a', 'b'] } },
+      ]);
+    });
+  });
+
+  describe('dereferencing `examples`', () => {
+    it('should resolve a `$ref` wrapper around an Example Object', () => {
+      const definition = {
+        components: {
+          examples: {
+            Shared: {
+              summary: 'Shared example',
+              value: { ok: true },
+            },
+          },
+        },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        examples: {
+          primary: { $ref: '#/components/examples/Shared' },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'Shared example',
+          title: 'primary',
+          value: { ok: true },
+        },
+      ]);
+    });
+
+    it('should deeply resolve `$ref` inside `examples[].value`', () => {
+      const definition = {
+        components: {
+          examples: {
+            Embedded: {
+              value: { id: 'emb-1' },
+            },
+          },
+        },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        examples: {
+          nested: {
+            summary: 'Nested ref',
+            value: [{ $ref: '#/components/examples/Embedded/value' }],
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'Nested ref',
+          title: 'nested',
+          value: [{ id: 'emb-1' }],
+        },
+      ]);
+    });
+
+    it('should drop an `examples` entry when `value` still contains a `$ref` after deep dereference', () => {
+      const definition = {
+        components: { examples: {} },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        examples: {
+          bad: {
+            value: { $ref: '#/components/examples/Nope' },
+          },
+          good: {
+            value: { x: 1 },
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'good',
+          title: 'good',
+          value: { x: 1 },
+        },
+      ]);
+    });
+
+    it('should pass through `description` on Example Objects after dereferencing `value`', () => {
+      const definition = {
+        components: {
+          examples: {
+            Part: { value: { n: 2 } },
+          },
+        },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        examples: {
+          withDesc: {
+            description: 'Desc text',
+            summary: 'Sum',
+            value: { $ref: '#/components/examples/Part/value' },
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          description: 'Desc text',
+          summary: 'Sum',
+          title: 'withDesc',
+          value: { n: 2 },
+        },
+      ]);
+    });
+  });
+});

--- a/packages/oas/test/operation/lib/get-response-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-response-examples.test.ts
@@ -1,11 +1,13 @@
 import type { HttpMethods } from '../../../src/types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import responseExamplesSpec from '@readme/oas-examples/3.0/json/response-examples.json' with { type: 'json' };
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import Oas from '../../../src/index.js';
 import circularSpec from '../../__datasets__/circular.json' with { type: 'json' };
 import deprecatedSpec from '../../__datasets__/deprecated.json' with { type: 'json' };
+import cx3172 from '../../__datasets__/issues/CX-3172.json' with { type: 'json' };
 import operationExamplesSpec from '../../__datasets__/operation-examples.json' with { type: 'json' };
 import readonlyWriteonlySpec from '../../__datasets__/readonly-writeonly.json' with { type: 'json' };
 import { jsonStringifyClean } from '../../__fixtures__/json-stringify-clean.js';
@@ -14,11 +16,13 @@ describe('.getResponseExamples()', () => {
   let operationExamples: Oas;
   let petstore: Oas;
   let readonlyWriteonly: Oas;
+  let responseExamples: Oas;
 
   beforeEach(async () => {
     operationExamples = Oas.init(structuredClone(operationExamplesSpec));
     petstore = Oas.init(structuredClone(petstoreSpec));
     readonlyWriteonly = Oas.init(structuredClone(readonlyWriteonlySpec));
+    responseExamples = Oas.init(structuredClone(responseExamplesSpec));
   });
 
   it('should handle if there are no responses', () => {
@@ -213,115 +217,6 @@ describe('.getResponseExamples()', () => {
         ]);
       });
 
-      it('should transform a `$ref` in a singular example', async () => {
-        const operation = operationExamples.operation(
-          '/single-media-type-single-example-in-example-prop-with-ref',
-          'post',
-        );
-
-        expect(operation.getResponseExamples()).toStrictEqual([
-          {
-            status: '200',
-            mediaTypes: {
-              'application/json': [
-                {
-                  value: {
-                    value: userExample,
-                  },
-                },
-              ],
-            },
-          },
-        ]);
-      });
-
-      it('should support media type example `$ref` pointers', () => {
-        const oas = Oas.init({
-          openapi: '3.1.0',
-          info: {
-            title: 'Example API with reusable examples',
-            version: '1.0.0',
-          },
-          paths: {
-            '/users': {
-              get: {
-                summary: 'Get all users',
-                responses: {
-                  '200': {
-                    description: 'List of users',
-                    content: {
-                      'application/json': {
-                        schema: {
-                          type: 'array',
-                          items: {
-                            $ref: '#/components/schemas/User',
-                          },
-                        },
-                        examples: {
-                          sampleUsers: {
-                            $ref: '#/components/examples/UsersExample',
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          components: {
-            schemas: {
-              User: {
-                type: 'object',
-                properties: {
-                  id: {
-                    type: 'string',
-                  },
-                  name: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-            examples: {
-              UsersExample: {
-                summary: 'Sample list of users',
-                value: [
-                  {
-                    id: '1',
-                    name: 'John Doe',
-                  },
-                  {
-                    id: '2',
-                    name: 'Jane Smith',
-                  },
-                ],
-              },
-            },
-          },
-        });
-
-        const operation = oas.operation('/users', 'get');
-
-        expect(operation.getResponseExamples()).toStrictEqual([
-          {
-            status: '200',
-            mediaTypes: {
-              'application/json': [
-                {
-                  summary: 'sampleUsers',
-                  title: 'sampleUsers',
-                  value: [
-                    { id: '1', name: 'John Doe' },
-                    { id: '2', name: 'Jane Smith' },
-                  ],
-                },
-              ],
-            },
-          },
-        ]);
-      });
-
       it('should not fail if the example is a string', () => {
         const operation = operationExamples.operation(
           '/single-media-type-single-example-in-example-prop-thats-a-string',
@@ -340,6 +235,30 @@ describe('.getResponseExamples()', () => {
             },
           },
         ]);
+      });
+
+      describe('$ref support', () => {
+        it('should transform a `$ref` in a singular example', async () => {
+          const operation = operationExamples.operation(
+            '/single-media-type-single-example-in-example-prop-with-ref',
+            'post',
+          );
+
+          expect(operation.getResponseExamples()).toStrictEqual([
+            {
+              status: '200',
+              mediaTypes: {
+                'application/json': [
+                  {
+                    value: {
+                      value: userExample,
+                    },
+                  },
+                ],
+              },
+            },
+          ]);
+        });
       });
     });
 
@@ -579,6 +498,75 @@ describe('.getResponseExamples()', () => {
             },
           },
         ]);
+      });
+
+      describe('$ref support', () => {
+        it('should support media type example `$ref` pointers', () => {
+          const operation = responseExamples.operation('/examples', 'get');
+
+          // Just a sanity check to ensure that the original schema has a `$ref` example.
+          expect(operation.schema.responses?.default).toHaveProperty('content', {
+            'application/json': {
+              examples: {
+                response: {
+                  value: {
+                    $ref: '#/components/schemas/UserResponse/example',
+                  },
+                },
+              },
+            },
+            'text/csv, text/comma-separated-values': expect.any(Object),
+          });
+
+          const examples = operation.getResponseExamples();
+          expect(examples.find(example => example.status === 'default')).toStrictEqual({
+            status: 'default',
+            mediaTypes: {
+              'application/json': [
+                {
+                  summary: 'response',
+                  title: 'response',
+                  value: {
+                    user: {
+                      email: 'test@example.com',
+                      name: 'Test user name',
+                    },
+                  },
+                },
+              ],
+              'text/csv, text/comma-separated-values': expect.any(Array),
+            },
+          });
+
+          expect(examples).toMatchSnapshot();
+        });
+
+        it('support deeply resolve nested `$ref` pointers', async () => {
+          const oas = Oas.init(structuredClone(cx3172));
+          const operation = oas.operation('/v1/companies/{company_id}/admins', 'get');
+
+          expect(operation.getResponseExamples()).toStrictEqual([
+            {
+              status: '200',
+              mediaTypes: {
+                'application/json': [
+                  {
+                    summary: 'Example',
+                    title: 'Example',
+                    value: [
+                      {
+                        uuid: 'admin_123',
+                        email: 'admin@example.com',
+                        first_name: 'Ada',
+                        last_name: 'Lovelace',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ]);
+        });
       });
     });
   });


### PR DESCRIPTION
| 🚥 Resolves CX-3172 |
| :------------------- |

## 🧰 Changes

This expands upon the work I did in https://github.com/readmeio/oas/pull/1106 to support `$ref` pointers in response examples to support them throughout the **entire** example, not just at the top-level. This'll resolve an issue we're seeing on some customer sites where because we aren't deeply resolving these `$ref` pointers the example they're seeing looks like the following:

```js
[
  {
    "$ref": "#/components/schemas/Admin/x-examples/Example"
  }
]
```

To address this I've created a new `dereferenceRefDeep` method that will deeply dereference a given value. The above example is now generated to the following:

```js
[
  {
    "uuid": "admin_123",
    "email": "admin@example.com",
    "first_name": "Ada",
    "last_name": "Lovelace"
  }
]
```