### PR TITLE
fix(oas-to-har): improved `format: json` encoding support

### DIFF
--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -30,7 +30,7 @@ import {
   getSafeRequestBody,
   getTypedFormatsInSchema,
   hasSchemaType,
-  parseJsonStringsInBody,
+  parseJSONStringsInBodyWithSchema,
 } from './lib/utils.js';
 
 function formatter(
@@ -598,7 +598,7 @@ export default function oasToHar(
                 // values that are valid JSON so `format: json` is still resolved for our
                 // `application/json` payload.
                 try {
-                  const parsed = parseJsonStringsInBody(cleanBody) as Record<string, unknown>;
+                  const parsed: any = parseJSONStringsInBodyWithSchema(cleanBody, requestBodySchema, operation.api);
                   if (typeof parsed?.RAW_BODY !== 'undefined') {
                     har.postData.text = isPrimitive(parsed.RAW_BODY)
                       ? String(parsed.RAW_BODY)

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -339,7 +339,7 @@ export function parseJSONStringsInBodyWithSchema(
   api: OASDocument,
   seenRefs: Set<string> = new Set(),
 ): unknown {
-  // If there's no chema then we should parse any strings that look like JSON.
+  // If there's no schema then we should parse any strings that look like JSON.
   if (schema === undefined) return parseJSONStrings(obj);
 
   let resolved: SchemaObject = schema;

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -394,7 +394,7 @@ export function parseJSONStringsInBodyWithSchema(
       items = derefItems && !isRef(derefItems) ? derefItems : undefined;
     }
 
-    return obj.map(item => parseJSONStringsInBodyWithSchema(item, items, api, seenRefs));
+    return obj.map(item => parseJSONStringsInBodyWithSchema(item, items, api, new Set(seenRefs)));
   }
 
   if (obj !== null && typeof obj === 'object') {
@@ -407,7 +407,7 @@ export function parseJSONStringsInBodyWithSchema(
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) {
       const propSchema = resolved.properties[k] as SchemaObject | undefined;
-      out[k] = parseJSONStringsInBodyWithSchema(v, propSchema, api, seenRefs);
+      out[k] = parseJSONStringsInBodyWithSchema(v, propSchema, api, new Set(seenRefs));
     }
 
     return out;

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -301,24 +301,113 @@ export function getParameterContentSchema(param: ParameterObject, contentType: s
  *
  * This is used when we're dealing with objects that have nested `format: json` descriptors.
  */
-export function parseJsonStringsInBody(obj: unknown): unknown {
+export function parseJSONStrings(obj: unknown): unknown {
   if (typeof obj === 'string') {
     try {
       const p = JSON.parse(obj);
-      return typeof p === 'object' && p !== null ? parseJsonStringsInBody(p) : p;
+      return typeof p === 'object' && p !== null ? parseJSONStrings(p) : p;
     } catch {
       return obj;
     }
   }
 
   if (Array.isArray(obj)) {
-    return obj.map(parseJsonStringsInBody);
+    return obj.map(parseJSONStrings);
   }
 
   if (obj !== null && typeof obj === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) {
-      out[k] = parseJsonStringsInBody(v);
+      out[k] = parseJSONStrings(v);
+    }
+
+    return out;
+  }
+
+  return obj;
+}
+
+/**
+ * Recursively runs through a schema, parsing any values that have `format: json` attached and
+ * deserializing them into their JSON representations.
+ *
+ * @see {@link parseJSONStrings}
+ */
+export function parseJSONStringsInBodyWithSchema(
+  obj: unknown,
+  schema: SchemaObject | undefined,
+  api: OASDocument,
+  seenRefs: Set<string> = new Set(),
+): unknown {
+  // If there's no chema then we should parse any strings that look like JSON.
+  if (schema === undefined) return parseJSONStrings(obj);
+
+  let resolved: SchemaObject = schema;
+  if (isRef(schema)) {
+    // If we have already processed this `$ref` before then we should stop all schema-guiding
+    // parsing behaviors so we don't infinitely recurse.
+    if (seenRefs.has(schema.$ref)) {
+      return parseJSONStrings(obj);
+    }
+
+    seenRefs.add(schema.$ref);
+    const deref = dereferenceRef(schema, api);
+    if (!deref || isRef(deref)) {
+      return parseJSONStrings(obj);
+    }
+
+    resolved = deref;
+  }
+
+  // If our resovled schema is a polymorphic `oneOf` or `anyOf` schema then we should use the first
+  // branch of the schema to guide our parsing behavior. If the schema is _not_ polymorphic then
+  // we'll use that schema as-is.
+  const safe = getSafeRequestBody(resolved);
+  if (isRef(safe)) {
+    return parseJSONStringsInBodyWithSchema(obj, safe, api, seenRefs);
+  }
+
+  resolved = safe;
+
+  if (typeof obj === 'string') {
+    // If the schema is a string but does **not** have `format: json` then it should be left alone.
+    if (hasSchemaType(resolved, 'string') && resolved.format !== 'json') {
+      return obj;
+    }
+
+    return parseJSONStrings(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    // @ts-expect-error -- `items` exists in schema objects, just the typing on `SchemaObject` is very messy.
+    let items = resolved.items as SchemaObject | undefined;
+    if (items && typeof items === 'object' && isRef(items)) {
+      // If we've already processed this `$ref` before then we should stop all schema-guided
+      // parsing behaviors so we don't infinitely recurse, instead treating what we have as it is
+      // and parsing anything that looks like JSON.
+      if (seenRefs.has(items.$ref)) {
+        return obj.map(item => parseJSONStrings(item));
+      }
+
+      seenRefs.add(items.$ref);
+      const derefItems = dereferenceRef(items, api);
+      items = derefItems && !isRef(derefItems) ? derefItems : undefined;
+    }
+
+    return obj.map(item => parseJSONStringsInBodyWithSchema(item, items, api, seenRefs));
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    // If we have an object schema that doesn't have any `properties` then we should just parse
+    // anything that looks like JSON within whatever we _do_ have here.
+    if (!resolved.properties || typeof resolved.properties !== 'object') {
+      return parseJSONStrings(obj);
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      const propSchema = resolved.properties[k] as SchemaObject | undefined;
+      out[k] = parseJSONStringsInBodyWithSchema(v, propSchema, api, seenRefs);
     }
 
     return out;

--- a/packages/oas-to-har/test/__datasets__/issues/CX-3182.json
+++ b/packages/oas-to-har/test/__datasets__/issues/CX-3182.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Try It String Coerced to Number — Reproduction",
+    "description": "Minimal spec: `tin` is OpenAPI `type: string` (9 chars). ReadMe Try it may still send a JSON number if the user enters digits only."
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything",
+      "description": "Echo endpoint: returns JSON so Try it does not show example.com HTML. Response includes request JSON under `json`."
+    }
+  ],
+  "paths": {
+    "/tin_verifications": {
+      "post": {
+        "summary": "Submit Tin Verification",
+        "operationId": "submit_tin_verification",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TINVerificationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TINVerificationRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "tin", "address"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "examples": ["Acme Corporation"]
+          },
+          "tin": {
+            "type": "string",
+            "minLength": 9,
+            "maxLength": 9,
+            "description": "The TIN/EIN to verify (must be a string in JSON).",
+            "examples": ["123456789"]
+          },
+          "address": {
+            "type": "string",
+            "maxLength": 500,
+            "examples": ["123 Main St, Anytown, USA"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas-to-har/test/lib/utils.test.ts
+++ b/packages/oas-to-har/test/lib/utils.test.ts
@@ -514,6 +514,38 @@ describe('#parseJSONStringsInBodyWithSchema()', () => {
     expect(parseJSONStringsInBodyWithSchema(payload, root, api)).toStrictEqual([{ a: 1 }, { b: 2 }]);
   });
 
+  it('should apply the same `$ref` schema independently to sibling properties', () => {
+    const api = createOASDocument({
+      Thing: {
+        type: 'object',
+        properties: {
+          label: {
+            type: 'string',
+          },
+        },
+      },
+    });
+
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        left: { $ref: '#/components/schemas/Thing' },
+        right: { $ref: '#/components/schemas/Thing' },
+      },
+    };
+
+    const payload = { left: { label: '[1,2,3]' }, right: { label: '[4,5,6]' } };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, api)).toStrictEqual({
+      left: {
+        label: '[1,2,3]',
+      },
+      right: {
+        label: '[4,5,6]',
+      },
+    });
+  });
+
   it('should return non-object primitives unchanged at leaves', () => {
     const schema: SchemaObject = { type: 'object', properties: { n: { type: 'number' } } };
     const payload = { n: 5 };

--- a/packages/oas-to-har/test/lib/utils.test.ts
+++ b/packages/oas-to-har/test/lib/utils.test.ts
@@ -3,21 +3,18 @@ import type { OASDocument, SchemaObject } from 'oas/types';
 import circularRequestBodies from '@readme/oas-examples/3.0/json/circular-request-bodies.json' with { type: 'json' };
 import { describe, expect, it } from 'vitest';
 
-import { getTypedFormatsInSchema, parseJsonStringsInBody } from '../../src/lib/utils.js';
+import { getTypedFormatsInSchema, parseJSONStrings, parseJSONStringsInBodyWithSchema } from '../../src/lib/utils.js';
 
-describe('getTypedFormatsInSchema', () => {
-  const api = circularRequestBodies as unknown as OASDocument;
-  const schemas = circularRequestBodies.components.schemas as Record<string, SchemaObject>;
+function createOASDocument(components: Record<string, SchemaObject> = {}): OASDocument {
+  return {
+    openapi: '3.0.0',
+    info: { title: 'test', version: '1.0.0' },
+    paths: {},
+    components: { schemas: components },
+  } as unknown as OASDocument;
+}
 
-  function createApi(components: Record<string, SchemaObject> = {}): OASDocument {
-    return {
-      openapi: '3.0.0',
-      info: { title: 'test', version: '1.0.0' },
-      paths: {},
-      components: { schemas: components },
-    } as unknown as OASDocument;
-  }
-
+describe('#getTypedFormatsInSchema()', () => {
   it('should return the key for a matching format in a nested property', () => {
     const schema: SchemaObject = {
       type: 'object',
@@ -26,7 +23,7 @@ describe('getTypedFormatsInSchema', () => {
       },
     };
 
-    const result = getTypedFormatsInSchema('binary', schema, createApi(), {
+    const result = getTypedFormatsInSchema('binary', schema, createOASDocument(), {
       payload: { file: 'data' },
     });
 
@@ -41,7 +38,7 @@ describe('getTypedFormatsInSchema', () => {
       },
     };
 
-    const result = getTypedFormatsInSchema('binary', schema, createApi(), {
+    const result = getTypedFormatsInSchema('binary', schema, createOASDocument(), {
       payload: { name: 'test' },
     });
 
@@ -51,7 +48,7 @@ describe('getTypedFormatsInSchema', () => {
   it('should handle direct schema with matching format and no parentKey', () => {
     const schema: SchemaObject = { type: 'string', format: 'binary' };
 
-    const result = getTypedFormatsInSchema('binary', schema, createApi(), {
+    const result = getTypedFormatsInSchema('binary', schema, createOASDocument(), {
       payload: 'data',
     });
 
@@ -61,7 +58,7 @@ describe('getTypedFormatsInSchema', () => {
   it('should handle direct schema with matching format and a parentKey', () => {
     const schema: SchemaObject = { type: 'string', format: 'json' };
 
-    const result = getTypedFormatsInSchema('json', schema, createApi(), {
+    const result = getTypedFormatsInSchema('json', schema, createOASDocument(), {
       payload: { field: '{}' },
       parentKey: 'field',
     });
@@ -70,6 +67,8 @@ describe('getTypedFormatsInSchema', () => {
   });
 
   it('should not infinite-loop on direct self-referencing $ref (TreeNode)', () => {
+    const api = circularRequestBodies as unknown as OASDocument;
+    const schemas = circularRequestBodies.components.schemas;
     const schema = schemas.TreeNode as SchemaObject;
 
     const result = getTypedFormatsInSchema('binary', schema, api, {
@@ -80,6 +79,8 @@ describe('getTypedFormatsInSchema', () => {
   });
 
   it('should not infinite-loop on indirect circular $ref (Person → Company → Person)', () => {
+    const api = circularRequestBodies as unknown as OASDocument;
+    const schemas = circularRequestBodies.components.schemas;
     const schema = schemas.Person as SchemaObject;
 
     const result = getTypedFormatsInSchema('binary', schema, api, {
@@ -90,6 +91,8 @@ describe('getTypedFormatsInSchema', () => {
   });
 
   it('should not infinite-loop on multiple self-referencing properties (LinkedNode)', () => {
+    const api = circularRequestBodies as unknown as OASDocument;
+    const schemas = circularRequestBodies.components.schemas;
     const schema = schemas.LinkedNode as SchemaObject;
 
     const result = getTypedFormatsInSchema('binary', schema, api, {
@@ -100,19 +103,19 @@ describe('getTypedFormatsInSchema', () => {
   });
 
   it('should not lose results due to stack overflow when many circular refs fan out', () => {
-    const schema: SchemaObject = {
+    const schema = {
       type: 'object',
       properties: {
-        a: { $ref: '#/components/schemas/S' } as unknown as SchemaObject,
-        b: { $ref: '#/components/schemas/S' } as unknown as SchemaObject,
-        c: { $ref: '#/components/schemas/S' } as unknown as SchemaObject,
-        d: { $ref: '#/components/schemas/S' } as unknown as SchemaObject,
-        e: { $ref: '#/components/schemas/S' } as unknown as SchemaObject,
+        a: { $ref: '#/components/schemas/S' },
+        b: { $ref: '#/components/schemas/S' },
+        c: { $ref: '#/components/schemas/S' },
+        d: { $ref: '#/components/schemas/S' },
+        e: { $ref: '#/components/schemas/S' },
         target: { type: 'string', format: 'binary' },
       },
-    };
+    } as SchemaObject;
 
-    const fanOutApi = createApi({ S: schema });
+    const fanOutApi = createOASDocument({ S: schema });
 
     const result = getTypedFormatsInSchema('binary', schema, fanOutApi, {
       payload: { a: {}, b: {}, c: {}, d: {}, e: {}, target: 'data' },
@@ -132,7 +135,7 @@ describe('getTypedFormatsInSchema', () => {
       },
     };
 
-    const result = getTypedFormatsInSchema('binary', schema, createApi(), {
+    const result = getTypedFormatsInSchema('binary', schema, createOASDocument(), {
       payload: { files: ['file1', 'file2'] },
     });
 
@@ -140,53 +143,53 @@ describe('getTypedFormatsInSchema', () => {
   });
 });
 
-describe('parseJsonStringsInBody', () => {
+describe('#parseJSONStrings()', () => {
   it('should return primitives unchanged', () => {
-    expect(parseJsonStringsInBody(42)).toBe(42);
-    expect(parseJsonStringsInBody(true)).toBe(true);
-    expect(parseJsonStringsInBody(false)).toBe(false);
-    expect(parseJsonStringsInBody(null)).toBe(null);
+    expect(parseJSONStrings(42)).toBe(42);
+    expect(parseJSONStrings(true)).toBe(true);
+    expect(parseJSONStrings(false)).toBe(false);
+    expect(parseJSONStrings(null)).toBe(null);
   });
 
   it('should return non-JSON strings unchanged', () => {
-    expect(parseJsonStringsInBody('hello')).toBe('hello');
-    expect(parseJsonStringsInBody('')).toBe('');
-    expect(parseJsonStringsInBody('not valid json')).toBe('not valid json');
+    expect(parseJSONStrings('hello')).toBe('hello');
+    expect(parseJSONStrings('')).toBe('');
+    expect(parseJSONStrings('not valid json')).toBe('not valid json');
   });
 
   it('should return invalid JSON strings unchanged', () => {
-    expect(parseJsonStringsInBody('{')).toBe('{');
-    expect(parseJsonStringsInBody('["unclosed')).toBe('["unclosed');
+    expect(parseJSONStrings('{')).toBe('{');
+    expect(parseJSONStrings('["unclosed')).toBe('["unclosed');
   });
 
   it('should parse a string that is valid JSON and return the parsed value', () => {
-    expect(parseJsonStringsInBody('42')).toBe(42);
-    expect(parseJsonStringsInBody('"quoted"')).toBe('quoted');
-    expect(parseJsonStringsInBody('true')).toBe(true);
-    expect(parseJsonStringsInBody('null')).toBe(null);
+    expect(parseJSONStrings('42')).toBe(42);
+    expect(parseJSONStrings('"quoted"')).toBe('quoted');
+    expect(parseJSONStrings('true')).toBe(true);
+    expect(parseJSONStrings('null')).toBe(null);
   });
 
   it('should parse a string that is a JSON object and recursively process it', () => {
-    expect(parseJsonStringsInBody('{"a":1}')).toStrictEqual({ a: 1 });
-    expect(parseJsonStringsInBody('{"a":1,"b":2}')).toStrictEqual({ a: 1, b: 2 });
+    expect(parseJSONStrings('{"a":1}')).toStrictEqual({ a: 1 });
+    expect(parseJSONStrings('{"a":1,"b":2}')).toStrictEqual({ a: 1, b: 2 });
   });
 
   it('should parse a string that is a JSON array and recursively process it', () => {
-    expect(parseJsonStringsInBody('[1,2,3]')).toStrictEqual([1, 2, 3]);
-    expect(parseJsonStringsInBody('[]')).toStrictEqual([]);
+    expect(parseJSONStrings('[1,2,3]')).toStrictEqual([1, 2, 3]);
+    expect(parseJSONStrings('[]')).toStrictEqual([]);
   });
 
   it('should recursively process plain objects', () => {
-    expect(parseJsonStringsInBody({ a: 1, b: 'x' })).toStrictEqual({ a: 1, b: 'x' });
+    expect(parseJSONStrings({ a: 1, b: 'x' })).toStrictEqual({ a: 1, b: 'x' });
   });
 
   it('should recursively process arrays', () => {
-    expect(parseJsonStringsInBody([1, 'x', true])).toStrictEqual([1, 'x', true]);
+    expect(parseJSONStrings([1, 'x', true])).toStrictEqual([1, 'x', true]);
   });
 
   it('should parse nested JSON strings inside objects', () => {
     expect(
-      parseJsonStringsInBody({
+      parseJSONStrings({
         a: 1,
         b: '{"nested": true}',
         c: 'plain',
@@ -199,11 +202,11 @@ describe('parseJsonStringsInBody', () => {
   });
 
   it('should parse nested JSON strings inside arrays', () => {
-    expect(parseJsonStringsInBody([1, '{"x": 10}', 'text'])).toStrictEqual([1, { x: 10 }, 'text']);
+    expect(parseJSONStrings([1, '{"x": 10}', 'text'])).toStrictEqual([1, { x: 10 }, 'text']);
   });
 
   it('should recursively parse JSON strings at any depth', () => {
-    const result = parseJsonStringsInBody({
+    const result = parseJSONStrings({
       level1: '{"level2": "{\\"level3\\": 42}"}',
     });
 
@@ -218,8 +221,347 @@ describe('parseJsonStringsInBody', () => {
 
   it('should parse object from string and then process nested JSON strings within it', () => {
     const input = '{"outer": "{\\"inner\\": 42}"}';
-    expect(parseJsonStringsInBody(input)).toStrictEqual({
+    expect(parseJSONStrings(input)).toStrictEqual({
       outer: { inner: 42 },
+    });
+  });
+});
+
+describe('#parseJSONStringsInBodyWithSchema()', () => {
+  const emptyAPIDefinition = createOASDocument();
+
+  it('should match `parseJSONStrings` when the schema is undefined', () => {
+    const payload = { a: 1, b: '{"x":2}', c: 'plain' };
+
+    const matched = parseJSONStrings(structuredClone(payload));
+    expect(matched).toStrictEqual({
+      a: 1,
+      b: {
+        x: 2,
+      },
+      c: 'plain',
+    });
+
+    expect(parseJSONStringsInBodyWithSchema(payload, undefined, emptyAPIDefinition)).toStrictEqual(matched);
+  });
+
+  it('should keep numerical values as strings when the property is `type: string` without `format: json`', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        tin: { type: 'string', minLength: 9, maxLength: 9 },
+        name: { type: 'string' },
+      },
+    };
+
+    const payload = { tin: '123456789', name: 'Acme' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      tin: '123456789',
+      name: 'Acme',
+    });
+  });
+
+  it('should parse string values when property has `format: json`', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        meta: { type: 'string', format: 'json' },
+        raw: { type: 'string' },
+      },
+    };
+
+    const payload = { meta: '{"ok":true,"n":1}', raw: '{"ignored":1}' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      meta: { ok: true, n: 1 },
+      raw: '{"ignored":1}',
+    });
+  });
+
+  it('should coerce numeric strings for number and integer properties', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        count: { type: 'integer' },
+        score: { type: 'number' },
+      },
+    };
+
+    const payload = { count: '42', score: '3.5' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      count: 42,
+      score: 3.5,
+    });
+  });
+
+  it('should apply rules per nested property independently', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        payload: { type: 'string', format: 'json' },
+        extra: { type: 'number' },
+      },
+    };
+
+    const payload = { id: '007', payload: '{"a":1}', extra: '99' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      id: '007',
+      payload: { a: 1 },
+      extra: 99,
+    });
+  });
+
+  it('should recurse into nested objects using property schemas', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        outer: {
+          type: 'object',
+          properties: {
+            inner: { type: 'string' },
+            data: { type: 'string', format: 'json' },
+          },
+        },
+      },
+    };
+
+    const payload = { outer: { inner: '001', data: '{"k":"v"}' } };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      outer: {
+        inner: '001',
+        data: { k: 'v' },
+      },
+    });
+  });
+
+  it('should use `items` schema for array elements', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        tags: { type: 'array', items: { type: 'string' } },
+        nums: { type: 'array', items: { type: 'integer' } },
+      },
+    };
+
+    const payload = { tags: ['01', '02'], nums: ['1', '2'] };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      tags: ['01', '02'],
+      nums: [1, 2],
+    });
+  });
+
+  it('should parse `format: json` on array items', () => {
+    const schema: SchemaObject = {
+      type: 'array',
+      items: { type: 'string', format: 'json' },
+    };
+
+    const payload = ['{"a":1}', '{"b":2}'];
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('should leave stringified JSON as plain strings when items are `type: string` only', () => {
+    const schema: SchemaObject = {
+      type: 'array',
+      items: { type: 'string' },
+    };
+
+    const payload = ['{"x":1}', 'plain'];
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual(['{"x":1}', 'plain']);
+  });
+
+  it('should resolve top-level and nested `$ref` to components.schemas', () => {
+    const api = createOASDocument({
+      Row: {
+        type: 'object',
+        properties: {
+          code: { type: 'string' },
+        },
+      },
+      Wrapper: {
+        type: 'object',
+        properties: {
+          row: { $ref: '#/components/schemas/Row' },
+        },
+      },
+    });
+
+    const schema: SchemaObject = { $ref: '#/components/schemas/Wrapper' };
+    const payload = { row: { code: '001' } };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, api)).toStrictEqual({
+      row: { code: '001' },
+    });
+  });
+
+  it('should resolve items `$ref`', () => {
+    const api = createOASDocument({
+      Item: { type: 'string' },
+      ListHolder: {
+        type: 'object',
+        properties: {
+          items: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Item' },
+          },
+        },
+      },
+    });
+
+    const root: SchemaObject = { $ref: '#/components/schemas/ListHolder' };
+    const payload = { items: ['01', '02'] };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, root, api)).toStrictEqual({
+      items: ['01', '02'],
+    });
+  });
+
+  it('should use `getSafeRequestBody` (first `oneOf` branch) when schema uses `oneOf`', () => {
+    const schema: SchemaObject = {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            mode: { type: 'string' },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            other: { type: 'number' },
+          },
+        },
+      ],
+    };
+
+    const payload = { mode: '001' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      mode: '001',
+    });
+  });
+
+  it('should fallback to `parseJSONStrings` when object schema has no properties', () => {
+    const schema: SchemaObject = { type: 'object' };
+    const payload = { loose: '{"parsed":true}' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      loose: { parsed: true },
+    });
+  });
+
+  it('should parse unknown object keys with full JSON-string rules (undefined prop schema)', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        known: { type: 'string' },
+      },
+    };
+
+    const payload = { known: 'keep', unknown: '{"z":3}' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      known: 'keep',
+      unknown: { z: 3 },
+    });
+  });
+
+  it('should fallback to `parseJSONStrings` when the same `$ref` is seen twice (cycle)', () => {
+    const api = createOASDocument({
+      Node: {
+        type: 'object',
+        properties: {
+          next: { $ref: '#/components/schemas/Node' },
+          label: { type: 'string' },
+        },
+      },
+    });
+
+    const root: SchemaObject = { $ref: '#/components/schemas/Node' };
+    const payload = {
+      label: 'a',
+      next: {
+        label: 'b',
+        next: { label: '001', next: { label: 'c', next: null } },
+      },
+    };
+
+    const result = parseJSONStringsInBodyWithSchema(payload, root, api) as typeof payload;
+    expect(result.label).toBe('a');
+    expect(result.next?.label).toBe('b');
+    expect(result.next?.next?.label).toBe('001');
+  });
+
+  it('should fallback for array elements when items `$ref` hits a cycle', () => {
+    const api = createOASDocument({
+      SelfList: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/SelfList' },
+      },
+    });
+
+    const root: SchemaObject = { $ref: '#/components/schemas/SelfList' };
+    const payload = ['{"a":1}', '{"b":2}'];
+
+    expect(parseJSONStringsInBodyWithSchema(payload, root, api)).toStrictEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('should return non-object primitives unchanged at leaves', () => {
+    const schema: SchemaObject = { type: 'object', properties: { n: { type: 'number' } } };
+    const payload = { n: 5 };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({ n: 5 });
+  });
+
+  it('should treat root string with schema `type: string` as opaque', () => {
+    const schema: SchemaObject = { type: 'string' };
+    const payload = '{"not":"parsed"}';
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toBe('{"not":"parsed"}');
+  });
+
+  it('should parse root string when schema is `format: json`', () => {
+    const schema: SchemaObject = { type: 'string', format: 'json' };
+    const payload = '{"x":1}';
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({ x: 1 });
+  });
+
+  it('should handle OpenAPI 3.1 style `string | null` type arrays on a property', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        code: { type: ['string', 'null'] },
+      },
+    };
+
+    const payload = { code: '00123' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      code: '00123',
+    });
+  });
+
+  it('should leave invalid JSON strings unchanged even for non-string schema branches', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        n: { type: 'integer' },
+      },
+    };
+
+    const payload = { n: 'not-a-number' };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      n: 'not-a-number',
     });
   });
 });

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import oasToHar from '../src/index.js';
 import deeplyNestedJsonFormats from './__datasets__/deeply-nested-json-formats.json' with { type: 'json' };
 import formdataNestedObject from './__datasets__/formData-nested-object.json' with { type: 'json' };
+import cx3182 from './__datasets__/issues/CX-3182.json' with { type: 'json' };
 import multipartFormDataArrayOfFiles from './__datasets__/multipart-form-data/array-of-files.json' with { type: 'json' };
 import multipartFormDataOneOfRequestBody from './__datasets__/multipart-form-data/oneOf-requestbody.json' with { type: 'json' };
 import multipartFormData from './__datasets__/multipart-form-data.json' with { type: 'json' };
@@ -1214,6 +1215,27 @@ describe('request body handling', () => {
         { name: 'id', value: '12345' },
         { name: 'Request', value: '{"MerchantId":"buster"}' },
       ]);
+    });
+
+    it('should not transform strings to numbers on a `string` input', async () => {
+      const spec = Oas.init(structuredClone(cx3182));
+      const operation = spec.operation('/tin_verifications', 'post');
+
+      const har = oasToHar(spec, operation, {
+        server: {
+          selected: 0,
+          variables: {},
+        },
+        body: {
+          tin: '11111',
+        },
+      });
+
+      await expect(har).toBeAValidHAR();
+      expect(har.log.entries[0].request.postData).toStrictEqual({
+        mimeType: 'application/json',
+        text: '{"tin":"11111"}',
+      });
     });
   });
 


### PR DESCRIPTION
| 🚥 Resolves CX-3182 |
| :------------------- |

## 🧰 Changes

This addresses a bug in `oas-to-har` where we were always decoding form data as if it were JSON even if the schema properties didn't have `format: json` set.