### PR TITLE
fix(oas): polymorphic merging can sometimes drop schema properties

### DIFF
--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -1,4 +1,5 @@
-import type { JSONSchema7TypeName } from 'json-schema';
+import type { JSONSchema4, JSONSchema7TypeName } from 'json-schema';
+import type { Options as JSONSchemaMergeAllOfOptions } from 'json-schema-merge-allof';
 import type {
   ExampleObject,
   JSONSchema,
@@ -29,6 +30,38 @@ const UNSUPPORTED_SCHEMA_PROPS = [
   'externalDocs',
   'xml',
 ] as const;
+
+const mergeAllOfSchemasOptions: JSONSchemaMergeAllOfOptions = {
+  ignoreAdditionalProperties: true,
+  resolvers: {
+    // `merge-json-schema-allof` by default takes the first `description` when you're merging an
+    // `allOf` but because generally when you're merging two schemas together with an `allOf` you
+    // want data in the subsequent schemas to be applied to the first and `description` should be a
+    // part of that.
+    description: (obj: string[]) => {
+      return obj.slice(-1)[0];
+    },
+
+    // `merge-json-schema-allof` doesn't support merging enum arrays but since that's a safe and
+    // simple operation as enums always contain primitives we can handle it ourselves with a custom
+    // resolver. We intersect the arrays so that child schemas can narrow a parent's broad enum
+    // (e.g. [1,2,20,50] ∩ [1] = [1]).
+    //
+    // We unfortunately need to cast our return value as `any[]` because the internal types of
+    // `merge-json-schema-allof`'s `enum` resolver are not portable.
+    enum: (obj: unknown[]) => {
+      const arrays = obj as any[][];
+      const intersection = arrays.reduce((acc, e) => acc.filter(v => e.includes(v)));
+      return intersection.length > 0 ? intersection : arrays.reduce((acc, e) => acc.concat(e), []);
+    },
+
+    // For any unknown keywords (e.g., `example`, `format`, `x-readme-ref-name`), we fallback to
+    // using the `title` resolver (which uses the first value found).
+    // https://github.com/mokkabonna/json-schema-merge-allof/blob/ea2e48ee34415022de5a50c236eb4793a943ad11/src/index.js#L292
+    // https://github.com/mokkabonna/json-schema-merge-allof/blob/ea2e48ee34415022de5a50c236eb4793a943ad11/README.md?plain=1#L147
+    defaultResolver: mergeJSONSchemaAllOf.options.resolvers.title,
+  },
+};
 
 export interface toJSONSchemaOptions {
   /**
@@ -579,8 +612,27 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
 
         allOfSchemas = schema.allOf.map(item => {
           if (isRef(item)) {
-            return resolveAndCacheRefSchema({
-              schema: item,
+            // `isRef` is true for any object with a `$ref` key. When other keywords (e.g. `title`,
+            // `properties`) sit alongside `$ref` in an `allOf` branch, which can be common after
+            // `json-schema-merge-allof` merges a polymorphic schema, resolving only the `$ref`
+            // drops those siblings.
+            //
+            // We should always try to merge the converted target with its converted siblings.
+            if (Object.keys(item).length === 1) {
+              return resolveAndCacheRefSchema({
+                schema: item,
+                definition,
+                usedSchemas,
+                seenRefs,
+                conversionOptions: allOfOptions,
+                returnMode: 'converted',
+                refLogger,
+              });
+            }
+
+            const { $ref, ...siblings } = item as SchemaObject & ReferenceObject;
+            const resolved = resolveAndCacheRefSchema({
+              schema: { $ref },
               definition,
               usedSchemas,
               seenRefs,
@@ -588,6 +640,21 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
               returnMode: 'converted',
               refLogger,
             });
+
+            // If all we had was a `$ref` schema then we should return whatever it resolved to.
+            if (!Object.keys(siblings).length) {
+              return resolved;
+            }
+
+            const siblingSchema = toJSONSchema(siblings as SchemaObject, allOfOptions);
+            try {
+              return mergeJSONSchemaAllOf(
+                { allOf: [resolved as JSONSchema4, siblingSchema as JSONSchema4] },
+                mergeAllOfSchemasOptions,
+              ) as SchemaObject;
+            } catch {
+              return resolved;
+            }
           }
 
           return toJSONSchema(item as SchemaObject, allOfOptions);
@@ -600,37 +667,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
       }
 
       try {
-        schema = mergeJSONSchemaAllOf(schema as JSONSchema, {
-          ignoreAdditionalProperties: true,
-          resolvers: {
-            // `merge-json-schema-allof` by default takes the first `description` when you're
-            // merging an `allOf` but because generally when you're merging two schemas together
-            // with an `allOf` you want data in the subsequent schemas to be applied to the first
-            // and `description` should be a part of that.
-            description: (obj: string[]) => {
-              return obj.slice(-1)[0];
-            },
-
-            // `merge-json-schema-allof` doesn't support merging enum arrays but since that's a
-            // safe and simple operation as enums always contain primitives we can handle it
-            // ourselves with a custom resolver. We intersect the arrays so that child schemas
-            // can narrow a parent's broad enum (e.g. [1,2,20,50] ∩ [1] = [1]).
-            //
-            // We unfortunately need to cast our return value as `any[]` because the internal types
-            // of `merge-json-schema-allof`'s `enum` resolver are not portable.
-            enum: (obj: unknown[]) => {
-              const arrays = obj as any[][];
-              const intersection = arrays.reduce((acc, e) => acc.filter(v => e.includes(v)));
-              return intersection.length > 0 ? intersection : arrays.reduce((acc, e) => acc.concat(e), []);
-            },
-
-            // for any unknown keywords (e.g., `example`, `format`, `x-readme-ref-name`),
-            // we fallback to using the title resolver (which uses the first value found).
-            // https://github.com/mokkabonna/json-schema-merge-allof/blob/ea2e48ee34415022de5a50c236eb4793a943ad11/src/index.js#L292
-            // https://github.com/mokkabonna/json-schema-merge-allof/blob/ea2e48ee34415022de5a50c236eb4793a943ad11/README.md?plain=1#L147
-            defaultResolver: mergeJSONSchemaAllOf.options.resolvers.title,
-          },
-        }) as SchemaObject;
+        schema = mergeJSONSchemaAllOf(schema as JSONSchema, mergeAllOfSchemasOptions) as SchemaObject;
       } catch {
         // If we can't merge the `allOf` for whatever reason (like if one item is a `string` and
         // the other is a `object`) then we should completely remove it from the schema and continue

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -623,8 +623,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
             preprocessed[prop] = val;
           }
         }
-
-        schema = { ...schema, properties: preprocessed as SchemaObject['properties'] } as SchemaObject;
+        schema = { ...schema, properties: preprocessed } as SchemaObject;
       }
 
       // If we have an API definition present then we should attempt to resolve each `$ref` in an
@@ -637,11 +636,9 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
         // unwrapping the schema, so `$ref` pointers _do_ appear in the output then we **should**
         // log those.
         const allOfOptions: toJSONSchemaOptions =
-          // biome-ignore lint/style/noNonNullAssertion: We've narrowed above to have an `allOf` array.
-          schema.allOf!.length > 1 ? { ...polyOptions, refLogger: () => {} } : polyOptions;
+          allOfSchemas.length > 1 ? { ...polyOptions, refLogger: () => {} } : polyOptions;
 
-        // biome-ignore lint/style/noNonNullAssertion: We've narrowed above to have an `allOf` array.
-        allOfSchemas = schema.allOf!.map(item => {
+        allOfSchemas = allOfSchemas.map(item => {
           if (isRef(item)) {
             // `isRef` is true for any object with a `$ref` key. When other keywords (e.g. `title`,
             // `properties`) sit alongside `$ref` in an `allOf` branch, which can be common after

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -598,6 +598,35 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
     // If this is an `allOf` schema we should make an attempt to merge so as to ease the burden on
     // the tooling that ingests these schemas.
     if ('allOf' in schema && Array.isArray(schema.allOf)) {
+      // `json-schema-merge-allof` does not resolve `$ref` pointers so if this schema has sibling
+      // `properties` whose internal schemas _also_ contain an `allOf` with multiple `$ref`
+      // pointers, merging the parent `allOf` first can drop those pointers. We should instead
+      // convert each individual property schema first.
+      if (
+        'properties' in schema &&
+        schema.properties !== undefined &&
+        typeof schema.properties === 'object' &&
+        schema.properties !== null &&
+        !Array.isArray(schema.properties)
+      ) {
+        const preprocessed: SchemaObject['properties'] = {};
+        for (const prop of Object.keys(schema.properties)) {
+          const val = schema.properties[prop];
+          if (Array.isArray(val) || (typeof val === 'object' && val !== null)) {
+            preprocessed[prop] = toJSONSchema(val as SchemaObject, {
+              ...polyOptions,
+              currentLocation: `${currentLocation}/${encodePointer(prop)}`,
+              prevDefaultSchemas,
+              prevExampleSchemas,
+            });
+          } else {
+            preprocessed[prop] = val;
+          }
+        }
+
+        schema = { ...schema, properties: preprocessed as SchemaObject['properties'] } as SchemaObject;
+      }
+
       // If we have an API definition present then we should attempt to resolve each `$ref` in an
       // `allOf` before merging them together with `json-schema-merge-allof` so that that has access
       // to the full and actual schemas.
@@ -608,9 +637,11 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
         // unwrapping the schema, so `$ref` pointers _do_ appear in the output then we **should**
         // log those.
         const allOfOptions: toJSONSchemaOptions =
-          schema.allOf.length > 1 ? { ...polyOptions, refLogger: () => {} } : polyOptions;
+          // biome-ignore lint/style/noNonNullAssertion: We've narrowed above to have an `allOf` array.
+          schema.allOf!.length > 1 ? { ...polyOptions, refLogger: () => {} } : polyOptions;
 
-        allOfSchemas = schema.allOf.map(item => {
+        // biome-ignore lint/style/noNonNullAssertion: We've narrowed above to have an `allOf` array.
+        allOfSchemas = schema.allOf!.map(item => {
           if (isRef(item)) {
             // `isRef` is true for any object with a `$ref` key. When other keywords (e.g. `title`,
             // `properties`) sit alongside `$ref` in an `allOf` branch, which can be common after

--- a/packages/oas/src/types.ts
+++ b/packages/oas/src/types.ts
@@ -249,6 +249,9 @@ export interface SchemaWrapper {
 }
 
 /**
+ * Determine if a given JSON Schema object is a valid JSON Schema object and either has a declared
+ * `type` or is polymorphic in one form or another.
+ *
  * @param check JSON Schema object to determine if it's a non-polymorphic schema.
  * @param isPolymorphicAllOfChild If this JSON Schema object is the child of a polymorphic `allOf`.
  * @returns If the JSON Schema object is a JSON Schema object.

--- a/packages/oas/test/__datasets__/issues/CX-3194.json
+++ b/packages/oas/test/__datasets__/issues/CX-3194.json
@@ -1,0 +1,145 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Example API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/first-endpoint/{test}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "test",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "test": {
+                    "allOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "testiks": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ],
+                    "oneOf": [
+                      {
+                        "title": "Test 1",
+                        "allOf": [
+                          {
+                            "properties": {
+                              "testik": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          {
+                            "$ref": "#/components/schemas/Testsasffqefeq"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/second-endpoint/{hm}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "hm",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "test2": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/third-endpoint/{hm}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "hm",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "testik": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Testsasffqefeq": {
+        "type": "object",
+        "properties": {
+          "test": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/__datasets__/issues/CX-3195.json
+++ b/packages/oas/test/__datasets__/issues/CX-3195.json
@@ -1,0 +1,81 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "CX-3195",
+    "version": "1.3.0"
+  },
+  "paths": {
+    "/v1/merchants/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Example"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Example": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {}
+            }
+          }
+        ],
+        "properties": {
+          "cardAcceptanceSettings": {
+            "allOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "second": {
+                    "type": "string",
+                    "example": "002"
+                  }
+                }
+              },
+              {
+                "$ref": "#/components/schemas/First"
+              },
+              {
+                "$ref": "#/components/schemas/Third"
+              }
+            ]
+          }
+        }
+      },
+      "First": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string",
+            "example": "001"
+          }
+        }
+      },
+      "Third": {
+        "type": "object",
+        "properties": {
+          "third": {
+            "type": "string",
+            "example": "003"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -25,6 +25,7 @@ import invalidComponentSchemaNamesSpec from '../../__datasets__/invalid-componen
 import cx3174 from '../../__datasets__/issues/CX-3174.json' with { type: 'json' };
 import cx3183 from '../../__datasets__/issues/CX-3183.json' with { type: 'json' };
 import cx3185 from '../../__datasets__/issues/CX-3185.json' with { type: 'json' };
+import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
 import polymorphismQuirksSpec from '../../__datasets__/polymorphism-quirks.json' with { type: 'json' };
@@ -494,6 +495,55 @@ describe('.getParametersAsJSONSchema()', () => {
 
       const schemas = oas.operation('/', 'get').getParametersAsJSONSchema();
       expect(schemas).toHaveLength(0);
+    });
+
+    describe('polymorphic quirks', () => {
+      it('should preserve schema `title` properties', async () => {
+        const oas = Oas.init(structuredClone(cx3194));
+        const operation = oas.operation('/first-endpoint/{test}', 'post');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas?.[1].schema).toStrictEqual({
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            test: {
+              type: 'object',
+              oneOf: [
+                {
+                  title: 'Test 1',
+                  type: 'object',
+                  properties: {
+                    test: {
+                      type: 'string',
+                    },
+                    testik: {
+                      type: 'string',
+                    },
+                    testiks: {
+                      type: 'string',
+                    },
+                  },
+                  'x-readme-ref-name': 'Testsasffqefeq',
+                },
+              ],
+            },
+          },
+          components: {
+            schemas: {
+              Testsasffqefeq: {
+                type: 'object',
+                properties: {
+                  test: {
+                    type: 'string',
+                  },
+                },
+                'x-readme-ref-name': 'Testsasffqefeq',
+              },
+            },
+          },
+        });
+      });
     });
   });
 

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -26,6 +26,7 @@ import cx3174 from '../../__datasets__/issues/CX-3174.json' with { type: 'json' 
 import cx3183 from '../../__datasets__/issues/CX-3183.json' with { type: 'json' };
 import cx3185 from '../../__datasets__/issues/CX-3185.json' with { type: 'json' };
 import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' };
+import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
 import polymorphismQuirksSpec from '../../__datasets__/polymorphism-quirks.json' with { type: 'json' };
@@ -543,6 +544,48 @@ describe('.getParametersAsJSONSchema()', () => {
             },
           },
         });
+      });
+
+      it('should preserve siblings if they are `$ref` pointers', async () => {
+        const oas = Oas.init(cx3195);
+        const operation = oas.operation('/v1/merchants/', 'post');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas?.[0].schema).toStrictEqual({
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          $ref: '#/components/schemas/Example',
+          components: {
+            schemas: {
+              Example: {
+                type: 'object',
+                properties: {
+                  cardAcceptanceSettings: {
+                    type: 'object',
+                    properties: {
+                      second: {
+                        type: 'string',
+                        examples: ['002'],
+                      },
+                      first: {
+                        type: 'string',
+                        examples: ['001'],
+                      },
+                      third: {
+                        type: 'string',
+                        examples: ['003'],
+                      },
+                    },
+                    'x-readme-ref-name': 'First',
+                  },
+                  id: {},
+                },
+                'x-readme-ref-name': 'Example',
+              },
+            },
+          },
+        });
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
     });
   });

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -547,7 +547,7 @@ describe('.getParametersAsJSONSchema()', () => {
       });
 
       it('should preserve siblings if they are `$ref` pointers', async () => {
-        const oas = Oas.init(cx3195);
+        const oas = Oas.init(structuredClone(cx3195));
         const operation = oas.operation('/v1/merchants/', 'post');
         const schemas = operation.getParametersAsJSONSchema();
 


### PR DESCRIPTION
| 🚥 Resolves CX-3194, CX-3195 |
| :------------------- |

## 🧰 Changes

This addresses a race condition where if an `allOf` and `oneOf`, that itself had a nested `allOf` are merged together we would sometimes lose schema properties of the `oneOf` and its nested `allOf`. For example, with the following schema:

```js
allOf: [
  {
    type: 'object',
    properties: {
      testiks: {
        type: 'string'
      }
    }
  }
],
oneOf: [
  {
    title: 'Test 1',
    allOf: [
      {
        properties: {
          testik: {
            type: 'string'
          }
        }
      },
      {
        $ref: '#/components/schemas/Testsasffqefeq'
      }
    ]
  }
]
```

When we resolve and generate a schema for this it would be generated to the following:

```js
{
  type: 'object',
  oneOf: [
    {
      type: 'object',
      properties: { 
        test: { type: 'string' }, 
        testiks: { type: 'string' }
      },
      'x-readme-ref-name': 'Testsasffqefeq',
    }
  ]
}
```

Not only would we lose the `title` property that the `oneOf` had but we also would lose the `testik` object property. With the fix I have here we're now able to fully preserve this object as intended:

```js
{
  title: 'Test 1',
  type: 'object',
  properties: {
    test: {
      type: 'string',
    },
    testik: {
      type: 'string',
    },
    testiks: {
      type: 'string',
    },
  },
  'x-readme-ref-name': 'Testsasffqefeq',
}
```