### PR TITLE
fix(oas): support `$ref` pointers in `allOf` during example generation

### DIFF
--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -140,14 +140,32 @@ function sampleFromResolvedSchema(
   const hasPolymorphism = usesPolymorphism(schema);
   if (hasPolymorphism === 'allOf') {
     try {
+      const definition = opts.definition;
+      const resolvedAllOf = schema.allOf.map((subSchema: SchemaObject) => {
+        let sub = objectify(subSchema);
+        if (definition && isRef(sub)) {
+          // We need to dereference `$ref` pointers before mmerging our schemas together because
+          // `json-schema-merge-allof` does not support `$ref` resolutions.
+          const resolved = dereferenceRef(sub, definition, new Set<string>());
+          if (resolved && !isRef(resolved)) {
+            sub = resolved as SchemaObject;
+          }
+        }
+
+        return sub;
+      });
+
       return sampleFromSchema(
-        mergeJSONSchemaAllOf(schema, {
-          resolvers: {
-            // Ignore any unrecognized OAS-specific keywords that might be present on the schema
-            // (like `xml`).
-            defaultResolver: mergeJSONSchemaAllOf.options.resolvers.title,
+        mergeJSONSchemaAllOf(
+          { ...schema, allOf: resolvedAllOf },
+          {
+            resolvers: {
+              // Ignore any unrecognized OAS-specific keywords that might be present on the schema
+              // (like `xml`).
+              defaultResolver: mergeJSONSchemaAllOf.options.resolvers.title,
+            },
           },
-        }),
+        ),
         {
           ...opts,
           seenRefs,

--- a/packages/oas/test/__datasets__/issues/CX-3191.json
+++ b/packages/oas/test/__datasets__/issues/CX-3191.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Combined Ref Response API",
+    "version": "1.0.0",
+    "description": "API with response composed of two schemas using allOf and $ref"
+  },
+  "paths": {
+    "/combined": {
+      "get": {
+        "summary": "Get combined response",
+        "responses": {
+          "200": {
+            "description": "Combined response of two schemas using $ref",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/UserStatus"
+                    },
+                    {
+                      "$ref": "#/components/schemas/UserInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UserInfo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 123
+          },
+          "name": {
+            "type": "string",
+            "example": "John Doe"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "UserStatus": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "john.doe@example.com"
+          },
+          "active": {
+            "type": "boolean",
+            "example": true
+          }
+        },
+        "required": ["email", "active"]
+      }
+    }
+  }
+}

--- a/packages/oas/test/operation/lib/get-response-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-response-examples.test.ts
@@ -8,6 +8,7 @@ import Oas from '../../../src/index.js';
 import circularSpec from '../../__datasets__/circular.json' with { type: 'json' };
 import deprecatedSpec from '../../__datasets__/deprecated.json' with { type: 'json' };
 import cx3172 from '../../__datasets__/issues/CX-3172.json' with { type: 'json' };
+import cx3191 from '../../__datasets__/issues/CX-3191.json' with { type: 'json' };
 import operationExamplesSpec from '../../__datasets__/operation-examples.json' with { type: 'json' };
 import readonlyWriteonlySpec from '../../__datasets__/readonly-writeonly.json' with { type: 'json' };
 import { jsonStringifyClean } from '../../__fixtures__/json-stringify-clean.js';
@@ -561,6 +562,29 @@ describe('.getResponseExamples()', () => {
                         last_name: 'Lovelace',
                       },
                     ],
+                  },
+                ],
+              },
+            },
+          ]);
+        });
+
+        it('should support examples in polymorphic schemas', async () => {
+          const oas = Oas.init(cx3191);
+          const operation = oas.operation('/combined', 'get');
+
+          expect(operation.getResponseExamples()).toStrictEqual([
+            {
+              status: '200',
+              mediaTypes: {
+                'application/json': [
+                  {
+                    value: {
+                      id: 123,
+                      name: 'John Doe',
+                      active: true,
+                      email: 'john.doe@example.com',
+                    },
                   },
                 ],
               },


### PR DESCRIPTION
| 🚥 Resolves CX-3191 |
| :------------------- |

## 🧰 Changes

This fixes a bug in our `getResponseExamples` method where we weren't pre-resolving `$ref` pointers in `allOf` schemas prior to merging them together with `json-schema-merge-allof`. For example the following schema:

```js
{
  allOf: [
    {
      $ref: '#/components/schemas/UserStatus'
    },
    {
      $ref: '#/components/schemas/UserInfo'
    }
  ]
}
```

When generating an example from this we'd only pick the first entry, `UserStatus`, and generate an example for our response from that:

```js
{
  active: true,
  email: 'john.doe@example.com',
}
```

With this work we're now able to fully handle _both_ branches of this `allOf` and generate the following:

```js
{
  id: 123,
  name: 'John Doe',
  active: true,
  email: 'john.doe@example.com',
}
```