### PR TITLE
fix(oas-to-har): improved support for allOf handling

### DIFF
--- a/.changeset/metal-lights-refuse.md
+++ b/.changeset/metal-lights-refuse.md
@@ -1,0 +1,5 @@
+---
+'@readme/oas-to-har': patch
+---
+
+Resolved a bug where `allOf` schemas would be treated as JSON when their properties don't contain `format: json`.

--- a/packages/oas-to-har/biome.jsonc
+++ b/packages/oas-to-har/biome.jsonc
@@ -7,6 +7,9 @@
   },
   "linter": {
     "rules": {
+      "correctness": {
+        "useImportExtensions": "off",
+      },
       "performance": {
         // Temporarily disabled but should be addressed.
         "noAccumulatingSpread": "off",

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -328,6 +328,103 @@ export function parseJSONStrings(obj: unknown): unknown {
 }
 
 /**
+ * Like {@link parseJSONStrings} but only parses string values that are clearly JSON objects or
+ * arrays (after trim, starts with `{` or `[`). Used for payload keys that are not declared on the
+ * schema's `properties` map so numerical strings are not coerced into numbers.
+ */
+function parseJSONStringsObjectContainersOnly(obj: unknown): unknown {
+  if (typeof obj === 'string') {
+    const trimmed = obj.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(obj);
+        return parseJSONStringsObjectContainersOnly(parsed);
+      } catch {
+        return obj;
+      }
+    }
+
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(parseJSONStringsObjectContainersOnly);
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      out[k] = parseJSONStringsObjectContainersOnly(v);
+    }
+
+    return out;
+  }
+
+  return obj;
+}
+
+function mergePropertiesFromAllOf(
+  allOf: SchemaObject[],
+  api: OASDocument,
+  seenRefs: Set<string>,
+): Record<string, SchemaObject> | undefined {
+  const merged: Record<string, SchemaObject> = {};
+  let found = false;
+
+  for (const branch of allOf) {
+    const collected = collectSchemaObjectProperties(branch, api, new Set(seenRefs));
+    if (collected) {
+      found = true;
+      Object.assign(merged, collected);
+    }
+  }
+
+  return found ? merged : undefined;
+}
+
+function collectSchemaObjectProperties(
+  schema: SchemaObject,
+  api: OASDocument,
+  seenRefs: Set<string>,
+): Record<string, SchemaObject> | undefined {
+  let node: SchemaObject | undefined = schema;
+
+  if (isRef(node)) {
+    if (seenRefs.has(node.$ref)) {
+      return undefined;
+    }
+
+    seenRefs.add(node.$ref);
+    const deref = dereferenceRef(node, api);
+    if (!deref || isRef(deref)) {
+      return undefined;
+    }
+
+    node = deref;
+  }
+
+  const safe = getSafeRequestBody(node);
+
+  if (isRef(safe)) {
+    return collectSchemaObjectProperties(safe, api, seenRefs);
+  }
+
+  node = safe;
+
+  if (node) {
+    if ('allOf' in node && Array.isArray(node.allOf) && node.allOf.length) {
+      return mergePropertiesFromAllOf(node.allOf as SchemaObject[], api, seenRefs);
+    }
+
+    if (node.properties && typeof node.properties === 'object') {
+      return node.properties as Record<string, SchemaObject>;
+    }
+  }
+
+  return undefined;
+}
+
+/**
  * Recursively runs through a schema, parsing any values that have `format: json` attached and
  * deserializing them into their JSON representations.
  *
@@ -359,7 +456,7 @@ export function parseJSONStringsInBodyWithSchema(
     resolved = deref;
   }
 
-  // If our resovled schema is a polymorphic `oneOf` or `anyOf` schema then we should use the first
+  // If our resolved schema is a polymorphic `oneOf` or `anyOf` schema then we should use the first
   // branch of the schema to guide our parsing behavior. If the schema is _not_ polymorphic then
   // we'll use that schema as-is.
   const safe = getSafeRequestBody(resolved);
@@ -368,6 +465,22 @@ export function parseJSONStringsInBodyWithSchema(
   }
 
   resolved = safe;
+
+  if ('allOf' in resolved && Array.isArray(resolved.allOf) && resolved.allOf.length) {
+    const fromAllOf = mergePropertiesFromAllOf(resolved.allOf as SchemaObject[], api, new Set(seenRefs));
+    if (fromAllOf && Object.keys(fromAllOf).length) {
+      const existing =
+        resolved.properties && typeof resolved.properties === 'object' && resolved.properties !== null
+          ? resolved.properties
+          : {};
+
+      resolved = {
+        ...resolved,
+        type: 'object',
+        properties: { ...fromAllOf, ...existing },
+      } as SchemaObject;
+    }
+  }
 
   if (typeof obj === 'string') {
     // If the schema is a string but does **not** have `format: json` then it should be left alone.
@@ -407,7 +520,10 @@ export function parseJSONStringsInBodyWithSchema(
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) {
       const propSchema = resolved.properties[k] as SchemaObject | undefined;
-      out[k] = parseJSONStringsInBodyWithSchema(v, propSchema, api, new Set(seenRefs));
+      out[k] =
+        propSchema !== undefined
+          ? parseJSONStringsInBodyWithSchema(v, propSchema, api, new Set(seenRefs))
+          : parseJSONStringsObjectContainersOnly(v);
     }
 
     return out;

--- a/packages/oas-to-har/test/__datasets__/issues/CX-3182.json
+++ b/packages/oas-to-har/test/__datasets__/issues/CX-3182.json
@@ -31,6 +31,23 @@
             "description": "OK"
           }
         }
+      },
+      "patch": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/test"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
@@ -57,6 +74,27 @@
             "type": "string",
             "maxLength": 500,
             "examples": ["123 Main St, Anytown, USA"]
+          }
+        }
+      },
+      "TINVerificationRequest_allOf": {
+        "type": "object",
+        "properties": {
+          "tin": {
+            "type": "string",
+            "example": "100"
+          }
+        }
+      },
+      "test": {
+        "type": "object",
+        "properties": {
+          "test": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TINVerificationRequest_allOf"
+              }
+            ]
           }
         }
       }

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -1237,6 +1237,27 @@ describe('request body handling', () => {
         text: '{"tin":"11111"}',
       });
     });
+
+    it('should not transform strings to numbers on a `string` input when schema is an `allOf`', async () => {
+      const spec = Oas.init(structuredClone(cx3182));
+      const operation = spec.operation('/tin_verifications', 'patch');
+
+      const har = oasToHar(spec, operation, {
+        server: {
+          selected: 0,
+          variables: {},
+        },
+        body: {
+          tin: '12345',
+        },
+      });
+
+      await expect(har).toBeAValidHAR();
+      expect(har.log.entries[0].request.postData).toStrictEqual({
+        mimeType: 'application/json',
+        text: '{"tin":"12345"}',
+      });
+    });
   });
 
   describe('`content-type` and `accept` header', () => {

--- a/packages/oas/biome.jsonc
+++ b/packages/oas/biome.jsonc
@@ -7,6 +7,9 @@
   },
   "linter": {
     "rules": {
+      "correctness": {
+        "useImportExtensions": "off",
+      },
       "performance": {
         "noAccumulatingSpread": "off", // temporarily disabled but we should re-evaluate and address
       },

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -817,7 +817,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
                   delete (resolved as Record<string, unknown>).anyOf;
                 }
 
-                // Instead of relying on the `resovled` reference populating back into `usedSchemas`
+                // Instead of relying on the `resolved` reference populating back into `usedSchemas`
                 // we should make sure that that schema is refreshed with our new schema.
                 usedSchemas.set(childSchema.$ref, resolved);
               }

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -1018,7 +1018,7 @@ describe('.getParametersAsJSONSchema()', () => {
         },
       });
 
-      // Ensure that the `$ref` we have can actually be resovled.
+      // Ensure that the `$ref` we have can actually be resolved.
       expect(
         dereferenceRef(structuredClone(schemas?.[0].schema.properties?.hm), structuredClone(oas.api)),
       ).toStrictEqual({

--- a/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
@@ -788,7 +788,7 @@ describe('.getResponseAsJSONSchema()', () => {
           },
         ]);
 
-        // Ensure that the `$ref` we have can actually be resovled.
+        // Ensure that the `$ref` we have can actually be resolved.
         expect(dereferenceRef({ $ref: (schemas?.[0].schema as ReferenceObject).$ref }, oas.api)).toStrictEqual({
           type: 'object',
           properties: expect.objectContaining({


### PR DESCRIPTION
| 🚥 Resolves CX-3182 |
| :------------------- |

## 🧰 Changes

This resolves another bug in `oas-to-har` with regard to `format: json` handling where it would always treat objects in an `allOf` as JSON and encode them, resulting in numerical strings being incorrectly converted to numbers.