### PR TITLE
fix(oas-to-har): polymorphic `multipart/form-data` schema support

### DIFF
--- a/.changeset/wet-views-jump.md
+++ b/.changeset/wet-views-jump.md
@@ -1,0 +1,6 @@
+---
+"@readme/oas-to-har": patch
+"oas": patch
+---
+
+Improved support for polymorphic schema payload matching during HAR generation.

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -27,8 +27,8 @@ import { formatStyle } from './lib/style-formatting/index.js';
 import {
   getParameterContentSchema,
   getParameterContentType,
-  getSafeRequestBody,
   getTypedFormatsInSchema,
+  getSafeRequestBody,
   hasSchemaType,
   parseJSONStringsInBodyWithSchema,
 } from './lib/utils.js';
@@ -468,7 +468,7 @@ export default function oasToHar(
             // Because some request body schema shapes might not always be a top-level `properties`,
             // instead nesting it in an `oneOf` or `anyOf` we need to extract the first usable
             // schema that we have in order to process this multipart payload.
-            const safeBodySchema = getSafeRequestBody(requestBodySchema);
+            const safeBodySchema = getSafeRequestBody(requestBodySchema, formData.body, operation.api);
 
             /**
              * Discover all `{ type: string, format: binary }` properties, or arrays containing the
@@ -481,8 +481,16 @@ export default function oasToHar(
              * @example `{ type: string, format: binary }`
              * @example `{ type: array, items: { type: string, format: binary } }`
              */
-            const binaryTypes = Object.keys(safeBodySchema.properties).filter(key => {
-              const propData: JSONSchema = safeBodySchema.properties[key];
+            const binaryTypes = Object.keys(safeBodySchema.properties ?? {}).filter(key => {
+              if (
+                !safeBodySchema.properties?.[key] ||
+                typeof safeBodySchema.properties[key] !== 'object' ||
+                safeBodySchema.properties[key] === null
+              ) {
+                return false;
+              }
+
+              const propData = safeBodySchema.properties[key] as JSONSchema;
               if (propData.format === 'binary') {
                 return true;
               } else if (

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import type { OASDocument, ParameterObject, SchemaObject } from 'oas/types';
 
 import { isRef } from 'oas/types';
-import { dereferenceRef, getParameterContentType as getParameterContentTypeUtil } from 'oas/utils';
+import { dereferenceRef, dereferenceRefDeep, getParameterContentType as getParameterContentTypeUtil } from 'oas/utils';
 
 import { get } from './lodash.js';
 
@@ -21,17 +21,17 @@ export function hasSchemaType(
 }
 
 /**
- * Because some request body schema shapes might not always be a top-level `properties`, instead
- * nesting it in an `oneOf` or `anyOf` we need to extract the first usable schema that we have. If
- * we don't do this then these non-conventional request body schema payloads may not be properly
- * represented in the HAR that we generate.
+ * When we only have a schema fragment (no request payload), peel a single top-level polymorphic
+ * schema to its first branch so we can enumerate its properties.
  *
  */
-export function getSafeRequestBody(obj: any): any {
-  if ('oneOf' in obj) {
-    return getSafeRequestBody(obj.oneOf[0]);
-  } else if ('anyOf' in obj) {
-    return getSafeRequestBody(obj.anyOf[0]);
+function unwrapFirstPolymorphicBranch(obj: SchemaObject): SchemaObject {
+  if (obj.oneOf && Array.isArray(obj.oneOf) && obj.oneOf.length) {
+    return unwrapFirstPolymorphicBranch(obj.oneOf[0] as SchemaObject);
+  }
+
+  if (obj.anyOf && Array.isArray(obj.anyOf) && obj.anyOf.length) {
+    return unwrapFirstPolymorphicBranch(obj.anyOf[0] as SchemaObject);
   }
 
   return obj;
@@ -141,7 +141,7 @@ function getSubschemas(
     ) {
       for (const [propName, propSchema] of Object.entries(resolvedSchema)) {
         if (propSchema && (Array.isArray(propSchema) || (typeof propSchema === 'object' && propSchema !== null))) {
-          const raw = getSafeRequestBody(propSchema);
+          const raw = unwrapFirstPolymorphicBranch(propSchema as SchemaObject);
           const resolved = isRef(raw) ? dereferenceRef(raw, api) : raw;
           const toPush = resolved && !isRef(resolved) ? resolved : raw;
           if (toPush && typeof toPush === 'object') {
@@ -406,8 +406,7 @@ function collectSchemaObjectProperties(
     node = deref;
   }
 
-  const safe = getSafeRequestBody(node);
-
+  const safe = unwrapFirstPolymorphicBranch(node);
   if (isRef(safe)) {
     return collectSchemaObjectProperties(safe, api, seenRefs);
   }
@@ -425,6 +424,98 @@ function collectSchemaObjectProperties(
   }
 
   return undefined;
+}
+
+function getPayloadPropertyKeys(payload: unknown): string[] {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return [];
+  }
+
+  return Object.keys(payload as Record<string, unknown>).filter(
+    k => typeof (payload as Record<string, unknown>)[k] !== 'undefined',
+  );
+}
+
+function getPolymorphicSchema(node: SchemaObject): SchemaObject[] | null {
+  return node.oneOf && Array.isArray(node.oneOf) && node.oneOf.length
+    ? (node.oneOf as SchemaObject[])
+    : node.anyOf && Array.isArray(node.anyOf) && node.anyOf.length
+      ? (node.anyOf as SchemaObject[])
+      : null;
+}
+
+/**
+ * Choose a single branch from a polymorphic schema that best matches the payload we have.
+ *
+ * A branch matches when every non-`undefined` payload key exists on that branch's merged object
+ * properties. If we have no payload, or no branches match, we use the first branch.
+ *
+ * When several branches match the one with the fewest declared properties wins, which would get us
+ * as close to a best match as possible, however having more data in our payload would give us more
+ * insight into which branch is what the user wants.
+ */
+function pickPolymorphicBranch(alternatives: SchemaObject[], keys: string[], api: OASDocument): SchemaObject {
+  if (!keys.length) {
+    return alternatives[0];
+  }
+
+  const scored = alternatives.map((branch, idx) => {
+    const props = collectSchemaObjectProperties(branch, api, new Set<string>());
+    const allMatch = Boolean(props && keys.every(k => Object.prototype.hasOwnProperty.call(props, k)));
+    const propCount = props ? Object.keys(props).length : Number.POSITIVE_INFINITY;
+
+    return { idx, branch, allMatch, propCount };
+  });
+
+  const matches = scored.filter(entry => entry.allMatch);
+  if (matches.length === 1) return matches[0].branch;
+  if (matches.length > 1) {
+    matches.sort((a, b) => a.propCount - b.propCount || a.idx - b.idx);
+    return matches[0].branch;
+  }
+
+  return scored[0].branch;
+}
+
+/**
+ * Resolve a request-body JSON Schema against a concrete payload.
+ *
+ */
+export function getSafeRequestBody(schema: SchemaObject, payload: unknown, api: OASDocument): SchemaObject {
+  // This isn't ideal but let's do a full dereference of our current schema so we can quickly pick
+  // up and determine the polymorphic branch we need to use for this payload.
+  let resolved = dereferenceRefDeep(schema, api);
+
+  const keys = getPayloadPropertyKeys(payload);
+
+  // Stop when `resolved` has no top-level polymorphic schema. Each pass replaces `resolved` with
+  // one branch, which may still be polymorphic, so the increment step recomputes `alternatives`
+  // from the new `resolved`.
+  for (
+    let alternatives = getPolymorphicSchema(resolved);
+    alternatives != null;
+    alternatives = getPolymorphicSchema(resolved)
+  ) {
+    resolved = pickPolymorphicBranch(alternatives, keys, api);
+  }
+
+  if ('allOf' in resolved && Array.isArray(resolved.allOf) && resolved.allOf.length) {
+    const fromAllOf = mergePropertiesFromAllOf(resolved.allOf as SchemaObject[], api, new Set());
+    if (fromAllOf && Object.keys(fromAllOf).length) {
+      const existing =
+        resolved.properties && typeof resolved.properties === 'object' && resolved.properties !== null
+          ? resolved.properties
+          : {};
+
+      resolved = {
+        ...resolved,
+        type: 'object',
+        properties: { ...fromAllOf, ...existing },
+      } as SchemaObject;
+    }
+  }
+
+  return resolved;
 }
 
 /**
@@ -462,7 +553,7 @@ export function parseJSONStringsInBodyWithSchema(
   // If our resolved schema is a polymorphic `oneOf` or `anyOf` schema then we should use the first
   // branch of the schema to guide our parsing behavior. If the schema is _not_ polymorphic then
   // we'll use that schema as-is.
-  const safe = getSafeRequestBody(resolved);
+  const safe = getSafeRequestBody(resolved, obj, api);
   if (isRef(safe)) {
     return parseJSONStringsInBodyWithSchema(obj, safe, api, seenRefs);
   }

--- a/packages/oas-to-har/test/__datasets__/issues/CX-3220.json
+++ b/packages/oas-to-har/test/__datasets__/issues/CX-3220.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/GrantTypeA"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GrantTypeB"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Null response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GrantTypeA": {
+        "type": "object",
+        "properties": {
+          "grant_type": {
+            "type": "string",
+            "example": "client_credentials"
+          }
+        }
+      },
+      "GrantTypeB": {
+        "type": "object",
+        "properties": {
+          "grant_type2": {
+            "type": "string",
+            "example": "authorization_code"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas-to-har/test/lib/utils.test.ts
+++ b/packages/oas-to-har/test/lib/utils.test.ts
@@ -424,7 +424,7 @@ describe('#parseJSONStringsInBodyWithSchema()', () => {
     });
   });
 
-  it('should use `getSafeRequestBody` (first `oneOf` branch) when schema uses `oneOf`', () => {
+  it('should pick the `oneOf` branch whose properties match the payload keys when schema uses `oneOf`', () => {
     const schema: SchemaObject = {
       oneOf: [
         {

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -11,6 +11,7 @@ import oasToHar from '../src/index.js';
 import deeplyNestedJsonFormats from './__datasets__/deeply-nested-json-formats.json' with { type: 'json' };
 import formdataNestedObject from './__datasets__/formData-nested-object.json' with { type: 'json' };
 import cx3182 from './__datasets__/issues/CX-3182.json' with { type: 'json' };
+import cx3220 from './__datasets__/issues/CX-3220.json' with { type: 'json' };
 import multipartFormData from './__datasets__/multipart-form-data.json' with { type: 'json' };
 import multipartFormDataArrayOfFiles from './__datasets__/multipart-form-data/array-of-files.json' with { type: 'json' };
 import multipartFormDataOneOfRequestBody from './__datasets__/multipart-form-data/oneOf-requestbody.json' with { type: 'json' };
@@ -22,7 +23,7 @@ expect.extend({ toBeAValidHAR });
 
 describe('request body handling', () => {
   describe('`body` data handling', () => {
-    it('should not fail if a requestBody is present without a `schema`', () => {
+    it('should not fail if a request body is present without a `schema`', () => {
       const spec = Oas.init({
         paths: {
           '/requestBody': {
@@ -418,43 +419,43 @@ describe('request body handling', () => {
         spec = Oas.init(structuredClone(requestBodyRawBody));
       });
 
-      it('should work for RAW_BODY primitives', () => {
+      it('should work for `RAW_BODY` primitives', () => {
         const har = oasToHar(spec, spec.operation('/primitive', 'post'), { body: { RAW_BODY: 'test' } });
 
         expect(har.log.entries[0].request.postData?.text).toBe('test');
       });
 
-      it('should return empty for falsy RAW_BODY primitives', () => {
+      it('should return empty for falsy `RAW_BODY` primitives', () => {
         const har = oasToHar(spec, spec.operation('/primitive', 'post'), { body: { RAW_BODY: '' } });
 
         expect(har.log.entries[0].request.postData?.text).toBe('');
       });
 
-      it('should work for RAW_BODY json', () => {
+      it('should work for `RAW_BODY` JSON', () => {
         const har = oasToHar(spec, spec.operation('/json', 'post'), { body: { RAW_BODY: '{ "a": 1 }' } });
 
         expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ a: 1 }));
       });
 
-      it('should work for RAW_BODY xml', () => {
+      it('should work for `RAW_BODY` XML', () => {
         const har = oasToHar(spec, spec.operation('/xml', 'post'), { body: { RAW_BODY: '<xml>' } });
 
         expect(har.log.entries[0].request.postData?.text).toBe('<xml>');
       });
 
-      it('should work for RAW_BODY objects', () => {
+      it('should work for `RAW_BODY` objects', () => {
         const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: { a: 'test' } } });
 
         expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ a: 'test' }));
       });
 
-      it('should work for RAW_BODY objects (but data is a primitive somehow)', () => {
+      it('should work for `RAW_BODY` objects (but data is a primitive somehow)', () => {
         const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: 'test' } });
 
         expect(har.log.entries[0].request.postData?.text).toBe('test');
       });
 
-      it('should return empty for RAW_BODY objects', () => {
+      it('should return empty for `RAW_BODY` objects', () => {
         const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: {} } });
 
         expect(har.log.entries[0].request.postData?.text).toBeUndefined();
@@ -463,7 +464,7 @@ describe('request body handling', () => {
 
     describe('content types', () => {
       describe('multipart/form-data', () => {
-        it('should handle multipart/form-data request bodies', () => {
+        it('should handle `multipart/form-data` request bodies', () => {
           const fixture = Oas.init(structuredClone(multipartFormData));
           const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
             body: { orderId: 12345, userId: 67890, documentFile: owlbertDataURL },
@@ -488,7 +489,7 @@ describe('request body handling', () => {
           });
         });
 
-        it('should handle multipart/form-data requests where the requestBody is a `oneOf`', () => {
+        it('should handle `multipart/form-data` requests where the requestBody is a `oneOf`', () => {
           const oas = Oas.init(structuredClone(multipartFormDataOneOfRequestBody));
           const operation = oas.operation('/anything', 'post');
           const values = {
@@ -519,7 +520,28 @@ describe('request body handling', () => {
           });
         });
 
-        it('should handle multipart/form-data request bodies where the filename contains parentheses', () => {
+        it('should handle `multipart/form-data` requests where the requestBody is a `oneOf` containing `$ref` pointers', () => {
+          const oas = Oas.init(structuredClone(cx3220));
+          const operation = oas.operation('/pets', 'post');
+          const values = {
+            body: {
+              grant_type2: 'two',
+            },
+          };
+
+          const har = oasToHar(oas, operation, values, {});
+
+          expect(har.log.entries[0].request.headers).toStrictEqual([
+            { name: 'content-type', value: 'multipart/form-data' },
+          ]);
+
+          expect(har.log.entries[0].request.postData).toStrictEqual({
+            mimeType: 'multipart/form-data',
+            params: [{ name: 'grant_type2', value: 'two' }],
+          });
+        });
+
+        it('should handle `multipart/form-data` request bodies where the filename contains parentheses', () => {
           // Doing this manually for now until when/if https://github.com/data-uri/datauri/pull/29 is accepted.
           const specialcharacters = owlbertDataURL.replace(
             'name=owlbert.png;',
@@ -550,7 +572,7 @@ describe('request body handling', () => {
           });
         });
 
-        it('should handle a multipart/form-data request where files are in an array', () => {
+        it('should handle a `multipart/form-data` request where files are in an array', () => {
           const fixture = Oas.init(structuredClone(multipartFormDataArrayOfFiles));
           const har = oasToHar(fixture, fixture.operation('/anything', 'post'), {
             body: {
@@ -621,7 +643,7 @@ describe('request body handling', () => {
       });
 
       describe('image/png', () => {
-        it('should handle a image/png request body', async () => {
+        it('should handle a `image/png` request body', async () => {
           const spec = Oas.init({
             paths: {
               '/image': {
@@ -765,7 +787,7 @@ describe('request body handling', () => {
         );
       });
 
-      it('should work for refs that require a lookup', () => {
+      it('should work for `$ref` pointers that require a lookup', () => {
         const spec = Oas.init({
           paths: {
             '/requestBody': {
@@ -1050,7 +1072,7 @@ describe('request body handling', () => {
       expect(oasToHar(spec, spec.operation('/requestBody', 'post')).log.entries[0].request.postData).toBeUndefined();
     });
 
-    it('should not add undefined formData into postData', () => {
+    it('should not add undefined form data into `postData`', () => {
       const spec = Oas.init({
         paths: {
           '/requestBody': {
@@ -1084,7 +1106,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData).toBeUndefined();
     });
 
-    it('should preserve null values in arrays & still remove undefined values', () => {
+    it('should preserve null values in arrays and still remove undefined values', () => {
       const spec = Oas.init({
         paths: {
           '/requestBody': {
@@ -1163,7 +1185,7 @@ describe('request body handling', () => {
       ]);
     });
 
-    it('should stringify falsy primitive values in form-urlencoded params', () => {
+    it('should stringify falsy primitive values in `application/x-www-form-urlencoded` params', () => {
       const spec = Oas.init({
         paths: {
           '/requestBody': {
@@ -1287,7 +1309,7 @@ describe('request body handling', () => {
       },
     });
 
-    it('should be sent through if there are no body values but there is a requestBody', async () => {
+    it('should be sent through if there are no body values but there is a request body', async () => {
       let har = oasToHar(spec, spec.operation('/requestBody', 'post'), {});
 
       await expect(har).toBeAValidHAR();
@@ -1309,7 +1331,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.headers).toStrictEqual([{ name: 'content-type', value: 'application/json' }]);
     });
 
-    it('should be sent through if there are any formData values', async () => {
+    it('should be sent through if there are any `formData` values', async () => {
       const har = oasToHar(spec, spec.operation('/requestBody', 'post'), { formData: { a: 'test' } });
 
       await expect(har).toBeAValidHAR();
@@ -1352,7 +1374,7 @@ describe('request body handling', () => {
     });
 
     // Whether this is right or wrong, i'm not sure but this is what readme currently does
-    it('should prioritize json if it exists', async () => {
+    it('should prioritize JSON if it exists', async () => {
       const contentSpec = Oas.init({
         paths: {
           '/requestBody': {
@@ -1441,8 +1463,8 @@ describe('request body handling', () => {
     });
   });
 
-  describe('circular $ref schemas', () => {
-    it('should handle direct self-referencing $ref (TreeNode.parent → TreeNode)', () => {
+  describe('circular `$ref` schemas', () => {
+    it('should handle direct self-referencing `$ref` (`TreeNode.parent` → `TreeNode`)', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/direct', 'post');
 
@@ -1451,7 +1473,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ id: 'node-1', name: 'root' }));
     });
 
-    it('should handle direct self-ref with nested children in payload', () => {
+    it('should handle direct self-`$ref` with nested children in payload', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/direct', 'post');
 
@@ -1461,7 +1483,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify(body));
     });
 
-    it('should handle indirect circular $ref (Person → Company → Person)', () => {
+    it('should handle indirect circular `$ref` (`Person` → `Company` → `Person`)', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/indirect', 'post');
 
@@ -1470,7 +1492,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ name: 'Alice' }));
     });
 
-    it('should handle indirect circular $ref with nested payload', () => {
+    it('should handle indirect circular `$ref` with nested payload', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/indirect', 'post');
 
@@ -1480,7 +1502,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify(body));
     });
 
-    it('should handle polymorphic circular $ref (Expression with oneOf → Expression)', () => {
+    it('should handle polymorphic circular `$ref` (`Expression` with `oneOf` → `Expression`)', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/polymorphic', 'post');
 
@@ -1489,7 +1511,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ type: 'literal', value: 'hello' }));
     });
 
-    it('should handle multiple self-referencing properties (LinkedNode.prev + LinkedNode.next)', () => {
+    it('should handle multiple self-referencing properties (`LinkedNode.prev` + `LinkedNode.next`)', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/multiple', 'post');
 
@@ -1508,7 +1530,7 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify(body));
     });
 
-    it('should not hang after getParametersAsJSONSchema has already been called', () => {
+    it('should not hang after `Operation.getParametersAsJSONSchema()` has already been called', () => {
       const oas = Oas.init(circularRefs);
       const operation = oas.operation('/multiple', 'post');
 

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -1,10 +1,10 @@
 import { getParameterContentType } from './lib/get-parameter-content-type.js';
 import matchesMimeType from './lib/matches-mimetype.js';
-import { dereferenceRef } from './lib/refs.js';
+import { dereferenceRef, dereferenceRefDeep } from './lib/refs.js';
 import { types as jsonSchemaTypes } from './operation/transformers/get-parameters-as-json-schema.js';
 
 export const supportedMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
 export const SERVER_VARIABLE_REGEX: RegExp = /{([-_a-zA-Z0-9:.[\]]+)}/g;
 
-export { getParameterContentType, jsonSchemaTypes, matchesMimeType, dereferenceRef };
+export { getParameterContentType, jsonSchemaTypes, matchesMimeType, dereferenceRef, dereferenceRefDeep };


### PR DESCRIPTION
| 🚥 Resolves CX-3220 |
| :------------------- |

## 🧰 Changes

This fixes a number of quirky issues with how we do payload matching against polymorphic schemas.

Currently the way it works is that if you have a polymorphic schema, meaning you have a `oneOf` or an `anyOf` we will just pick the first an say good luck, we hope the payload you have matches that. The way it'll work now is that we'll do branch-level scoring within each `oneOf` and `anyOf` schema in order to determine which branch best matches the payload given. This means we'll now be able to generate HAR files, and by extension code snippets in `oas-to-snippet`, for polymirphic branches that _aren't_ the first schema.