### PR TITLE
fix: resolve deep self-ref through allOf

### DIFF
--- a/.changeset/fix-deep-self-ref-allof.md
+++ b/.changeset/fix-deep-self-ref-allof.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Fixed a crash when a schema contains a deep self-referencing `$ref` through an `allOf` (e.g. `#/components/schemas/Foo/allOf/1/properties/bar`) by sorting ref entries by path depth before merging into the root schema.

--- a/packages/oas/src/lib/refs.ts
+++ b/packages/oas/src/lib/refs.ts
@@ -313,7 +313,16 @@ function childShouldBeSchemaArray(parentKey: string, childSeg: string | undefine
  * @example `#/components/schemas/MySchema` -> `root.components.schemas.MySchema`
  */
 export function mergeReferencedSchemasIntoRoot(root: SchemaObject, refToSchema: Map<string, unknown>): void {
-  for (const [ref, schema] of refToSchema) {
+  // we need to sort this so parent schemas are placed before child schemas to
+  // prevent a parent from overwriting a child's synthetically created path
+  // sorting by path depth (shallowest first)
+  const sortedEntries = [...refToSchema.entries()].sort((a, b) => {
+    const aDepth = a[0].split('/').length;
+    const bDepth = b[0].split('/').length;
+    return aDepth - bDepth;
+  });
+
+  for (const [ref, schema] of sortedEntries) {
     const segments = getRefPathSegments(ref);
     if (!segments || segments.length === 0) {
       continue;

--- a/packages/oas/test/__datasets__/issues/CX-3152.json
+++ b/packages/oas/test/__datasets__/issues/CX-3152.json
@@ -14,9 +14,7 @@
     "/test/json-media-type-examples": {
       "post": {
         "operationId": "jsonMediaTypeExamples",
-        "tags": [
-          "1. Baseline (application/json)"
-        ],
+        "tags": ["1. Baseline (application/json)"],
         "summary": "JSON — examples on Media Type Object",
         "description": "Baseline: `examples` at the Media Type Object level for `application/json`. Should render in all tools.",
         "requestBody": {
@@ -34,10 +32,7 @@
                     "format": "email"
                   }
                 },
-                "required": [
-                  "name",
-                  "email"
-                ]
+                "required": ["name", "email"]
               },
               "examples": {
                 "Alice": {
@@ -68,9 +63,7 @@
     "/test/multipart-media-type-examples": {
       "post": {
         "operationId": "multipartMediaTypeExamples",
-        "tags": [
-          "2. Multipart variants"
-        ],
+        "tags": ["2. Multipart variants"],
         "summary": "Multipart — examples on Media Type Object",
         "description": "Your current approach: `examples` at the Media Type Object level for `multipart/form-data`.",
         "requestBody": {
@@ -92,10 +85,7 @@
                     "format": "binary"
                   }
                 },
-                "required": [
-                  "name",
-                  "email"
-                ]
+                "required": ["name", "email"]
               },
               "examples": {
                 "Alice": {
@@ -128,9 +118,7 @@
     "/test/multipart-schema-example": {
       "post": {
         "operationId": "multipartSchemaExample",
-        "tags": [
-          "2. Multipart variants"
-        ],
+        "tags": ["2. Multipart variants"],
         "summary": "Multipart — example on Schema Object",
         "description": "Single `example` (singular) on the root Schema Object.",
         "requestBody": {
@@ -152,10 +140,7 @@
                     "format": "binary"
                   }
                 },
-                "required": [
-                  "name",
-                  "email"
-                ],
+                "required": ["name", "email"],
                 "example": {
                   "name": "Alice",
                   "email": "alice@example.com"
@@ -174,9 +159,7 @@
     "/test/multipart-property-examples": {
       "post": {
         "operationId": "multipartPropertyExamples",
-        "tags": [
-          "2. Multipart variants"
-        ],
+        "tags": ["2. Multipart variants"],
         "summary": "Multipart — example on each property",
         "description": "`example` (singular) on each individual property inside the schema.",
         "requestBody": {
@@ -200,10 +183,7 @@
                     "format": "binary"
                   }
                 },
-                "required": [
-                  "name",
-                  "email"
-                ]
+                "required": ["name", "email"]
               }
             }
           }
@@ -218,9 +198,7 @@
     "/test/multipart-oneof-media-type-examples": {
       "post": {
         "operationId": "multipartOneOfMediaTypeExamples",
-        "tags": [
-          "3. Multipart + oneOf"
-        ],
+        "tags": ["3. Multipart + oneOf"],
         "summary": "Multipart + oneOf — examples on Media Type Object",
         "description": "Closest to your real case: `oneOf` in schema + `examples` at Media Type Object level.",
         "requestBody": {
@@ -245,11 +223,7 @@
                         "format": "binary"
                       }
                     },
-                    "required": [
-                      "name",
-                      "email",
-                      "avatar"
-                    ]
+                    "required": ["name", "email", "avatar"]
                   },
                   {
                     "title": "Without avatar",
@@ -263,10 +237,7 @@
                         "format": "email"
                       }
                     },
-                    "required": [
-                      "name",
-                      "email"
-                    ]
+                    "required": ["name", "email"]
                   }
                 ]
               },
@@ -300,9 +271,7 @@
     "/test/multipart-oneof-property-examples": {
       "post": {
         "operationId": "multipartOneOfPropertyExamples",
-        "tags": [
-          "3. Multipart + oneOf"
-        ],
+        "tags": ["3. Multipart + oneOf"],
         "summary": "Multipart + oneOf — example on each property",
         "description": "`oneOf` in schema + `example` on each property inside each variant.",
         "requestBody": {
@@ -329,11 +298,7 @@
                         "format": "binary"
                       }
                     },
-                    "required": [
-                      "name",
-                      "email",
-                      "avatar"
-                    ]
+                    "required": ["name", "email", "avatar"]
                   },
                   {
                     "title": "Without avatar",
@@ -349,10 +314,7 @@
                         "example": "bob@example.com"
                       }
                     },
-                    "required": [
-                      "name",
-                      "email"
-                    ]
+                    "required": ["name", "email"]
                   }
                 ]
               }
@@ -369,9 +331,7 @@
     "/test/multipart-oneof-schema-examples": {
       "post": {
         "operationId": "multipartOneOfSchemaExamples",
-        "tags": [
-          "3. Multipart + oneOf"
-        ],
+        "tags": ["3. Multipart + oneOf"],
         "summary": "Multipart + oneOf — example on each oneOf variant schema",
         "description": "`example` (singular) on each `oneOf` variant's root schema.",
         "requestBody": {
@@ -396,11 +356,7 @@
                         "format": "binary"
                       }
                     },
-                    "required": [
-                      "name",
-                      "email",
-                      "avatar"
-                    ],
+                    "required": ["name", "email", "avatar"],
                     "example": {
                       "name": "Alice",
                       "email": "alice@example.com"
@@ -418,10 +374,7 @@
                         "format": "email"
                       }
                     },
-                    "required": [
-                      "name",
-                      "email"
-                    ],
+                    "required": ["name", "email"],
                     "example": {
                       "name": "Bob",
                       "email": "bob@example.com"

--- a/packages/oas/test/__datasets__/issues/CX-3218.json
+++ b/packages/oas/test/__datasets__/issues/CX-3218.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Minimal Deep Self-Ref Crash Repro",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/endpoint": {
+      "post": {
+        "operationId": "postEndpoint",
+        "summary": "Post Endpoint",
+        "tags": ["Tag"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Payload": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "rate": {
+                "description": "Conversion rate",
+                "type": "number",
+                "format": "double",
+                "minimum": 0,
+                "maximum": 10000000000
+              },
+              "nested": {
+                "type": "object",
+                "properties": {
+                  "tid": {
+                    "type": "integer"
+                  },
+                  "currency": {
+                    "type": "string"
+                  },
+                  "amount": {
+                    "type": "integer"
+                  },
+                  "rate": {
+                    "$ref": "#/components/schemas/Payload/allOf/1/properties/rate"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -28,6 +28,7 @@ import cx3185 from '../../__datasets__/issues/CX-3185.json' with { type: 'json' 
 import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' };
 import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' };
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
+import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
 import polymorphismQuirksSpec from '../../__datasets__/polymorphism-quirks.json' with { type: 'json' };
@@ -1815,6 +1816,65 @@ describe('.getParametersAsJSONSchema()', () => {
             },
           },
         ]);
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should resolve a deep self-referencing `$ref` through `allOf`', async () => {
+        const oas = Oas.init(structuredClone(cx3218));
+        const operation = oas.operation('/endpoint', 'post');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const expectedAllOf: unknown[] = [];
+        expectedAllOf[1] = {
+          properties: {
+            rate: {
+              description: 'Conversion rate',
+              type: 'number',
+              format: 'double',
+              minimum: 0,
+              maximum: 10000000000,
+            },
+          },
+        };
+
+        expect(bodySchema?.schema).toStrictEqual({
+          $ref: '#/components/schemas/Payload',
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          components: {
+            schemas: {
+              Payload: {
+                type: 'object',
+                'x-readme-ref-name': 'Payload',
+                properties: {
+                  id: { type: 'string' },
+                  version: { type: 'string' },
+                  rate: {
+                    description: 'Conversion rate',
+                    type: 'number',
+                    format: 'double',
+                    minimum: 0,
+                    maximum: 10000000000,
+                  },
+                  nested: {
+                    type: 'object',
+                    properties: {
+                      tid: { type: 'integer' },
+                      currency: { type: 'string' },
+                      amount: { type: 'integer' },
+                      rate: { $ref: '#/components/schemas/Payload/allOf/1/properties/rate' },
+                      status: { type: 'string' },
+                    },
+                  },
+                },
+                allOf: expectedAllOf,
+              },
+            },
+          },
+        });
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });


### PR DESCRIPTION
| 🚥 Resolves CX-3218 |
| :------------------- |

## 🧰 Changes

When a schema contains a deep self-referencing `$ref` through an `allOf` (e.g. `#/components/schemas/Foo/allOf/1/properties/bar`), `toJSONSchema` merges the `allOf` flat but preserves the `$ref` stub in the output. The resolved schema is stored in `usedSchemas` and later placed into the root schema by `mergeReferencedSchemasIntoRoot`.

The bug: `mergeReferencedSchemasIntoRoot` iterated the ref map in insertion order. When the child ref (the deep `allOf` pointer) was inserted before the parent ref (the component schema), the child was placed first — creating the `allOf` path — and then the parent overwrote the entire component schema with the merged flat object, destroying the child's path. This left a dangling `$ref` that crashed `findSchemaDefinition` at render time.

The fix: sort entries by path depth (shallowest first) before placing them so parent schemas are always written before their children.

## 🧬 QA & Testing

[minimal-self-ref.json](https://github.com/user-attachments/files/26952387/minimal-self-ref.json)

Use this file to test.

### Before (broken)

The `allOf` is merged flat but `nested.properties.rate` still has a `$ref` pointing into the old `allOf` path which no longer exists. Dangling pointer → crash.

```json
{
  "$ref": "#/components/schemas/Payload",
  "components": {
    "schemas": {
      "Payload": {
        "type": "object",
        "properties": {
          "id": { "type": "string" },
          "rate": { "type": "number", "format": "double" },
          "nested": {
            "type": "object",
            "properties": {
              "rate": {
                "$ref": "#/components/schemas/Payload/allOf/1/properties/rate"
              }
            }
          }
        }
      }
    }
  }
}
```

### After (fixed)

`mergeReferencedSchemasIntoRoot` now places the parent first, then the child creates the `allOf` path on top. The `$ref` resolves.

```json
{
  "$ref": "#/components/schemas/Payload",
  "components": {
    "schemas": {
      "Payload": {
        "type": "object",
        "properties": {
          "id": { "type": "string" },
          "rate": { "type": "number", "format": "double" },
          "nested": {
            "type": "object",
            "properties": {
              "rate": {
                "$ref": "#/components/schemas/Payload/allOf/1/properties/rate"
              }
            }
          }
        },
        "allOf": [
          null,
          {
            "properties": {
              "rate": { "type": "number", "format": "double" }
            }
          }
        ]
      }
    }
  }
}
```