### PR TITLE
fix(oas): deep-merge allOf when nested properties at the same path use $ref

### DIFF
--- a/.changeset/fix-allof-nested-ref-merge.md
+++ b/.changeset/fix-allof-nested-ref-merge.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Fixed `allOf` merging silently dropping properties when two or more branches define the same nested property path with `$ref` leaf values by making `inlinePropertyRefsForMerge` recurse into nested object properties.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -237,6 +237,8 @@ function inlinePropertyRefsForMerge(
           ...structuredClone(resolved),
         };
       }
+    } else if (val && typeof val === 'object' && !Array.isArray(val) && 'properties' in val) {
+      out.properties[key] = inlinePropertyRefsForMerge(val as SchemaObject, usedSchemas, refLogger);
     }
   }
 

--- a/packages/oas/test/__datasets__/issues/CX-3213.json
+++ b/packages/oas/test/__datasets__/issues/CX-3213.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test", "version": "1.0.0" },
+  "paths": {
+    "/endpoint": {
+      "patch": {
+        "operationId": "updateItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UpdateRequest": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "notifications": { "$ref": "#/components/schemas/NotificationBase" }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "notifications": { "$ref": "#/components/schemas/NotificationExtras" }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "NotificationBase": {
+        "type": "object",
+        "properties": {
+          "channel": { "type": "string", "enum": ["email", "sms"] }
+        }
+      },
+      "NotificationExtras": {
+        "type": "object",
+        "properties": {
+          "muted": { "type": "boolean", "default": false }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/__datasets__/issues/deep-self-ref-in-items.json
+++ b/packages/oas/test/__datasets__/issues/deep-self-ref-in-items.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.2",
+  "info": { "title": "Test", "version": "1.0.0" },
+  "paths": {
+    "/endpoint": {
+      "post": {
+        "operationId": "postEndpoint",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Payload" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Payload": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "rate": { "type": "number", "format": "double" },
+              "history": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Payload/allOf/1/properties/rate"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -28,6 +28,7 @@ import cx3185 from '../../__datasets__/issues/CX-3185.json' with { type: 'json' 
 import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' };
 import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' };
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
+import cx3213 from '../../__datasets__/issues/CX-3213.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
@@ -1909,6 +1910,27 @@ describe('.getParametersAsJSONSchema()', () => {
             },
           },
         });
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should deep-merge `allOf` when nested properties at the same path both use `$ref`', async () => {
+        const oas = Oas.init(structuredClone(cx3213));
+        const operation = oas.operation('/endpoint', 'patch');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const updateRequest = bodySchema?.schema?.components?.schemas?.UpdateRequest as Record<string, unknown>;
+        const settings = (updateRequest?.properties as Record<string, unknown>)?.settings as Record<string, unknown>;
+        const notificationsSchema = (settings?.properties as Record<string, unknown>)?.notifications as
+          | Record<string, unknown>
+          | undefined;
+
+        expect(notificationsSchema).toBeDefined();
+        expect(notificationsSchema?.properties).toHaveProperty('channel');
+        expect(notificationsSchema?.properties).toHaveProperty('muted');
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -29,6 +29,7 @@ import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' 
 import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' };
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
+import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
 import polymorphismQuirksSpec from '../../__datasets__/polymorphism-quirks.json' with { type: 'json' };
@@ -1828,18 +1829,6 @@ describe('.getParametersAsJSONSchema()', () => {
         expect(schemas).not.toBeNull();
 
         const bodySchema = schemas?.find(s => s.type === 'body');
-        const expectedAllOf: unknown[] = [];
-        expectedAllOf[1] = {
-          properties: {
-            rate: {
-              description: 'Conversion rate',
-              type: 'number',
-              format: 'double',
-              minimum: 0,
-              maximum: 10000000000,
-            },
-          },
-        };
 
         expect(bodySchema?.schema).toStrictEqual({
           $ref: '#/components/schemas/Payload',
@@ -1865,9 +1854,54 @@ describe('.getParametersAsJSONSchema()', () => {
                       tid: { type: 'integer' },
                       currency: { type: 'string' },
                       amount: { type: 'integer' },
-                      rate: { $ref: '#/components/schemas/Payload/allOf/1/properties/rate' },
+                      rate: {
+                        description: 'Conversion rate',
+                        type: 'number',
+                        format: 'double',
+                        minimum: 0,
+                        maximum: 10000000000,
+                      },
                       status: { type: 'string' },
                     },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should resolve a deep self-referencing `$ref` inside `items` through `allOf`', async () => {
+        const oas = Oas.init(structuredClone(deepSelfRefInItems));
+        const operation = oas.operation('/endpoint', 'post');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const expectedAllOf: unknown[] = [];
+        expectedAllOf[1] = {
+          properties: {
+            rate: { type: 'number', format: 'double' },
+          },
+        };
+
+        expect(bodySchema?.schema).toStrictEqual({
+          $ref: '#/components/schemas/Payload',
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          components: {
+            schemas: {
+              Payload: {
+                type: 'object',
+                'x-readme-ref-name': 'Payload',
+                properties: {
+                  id: { type: 'string' },
+                  rate: { type: 'number', format: 'double' },
+                  history: {
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/Payload/allOf/1/properties/rate' },
                   },
                 },
                 allOf: expectedAllOf,


### PR DESCRIPTION
| 🚥 Resolves CX-3213 |
| :------------------- |

## 🧰 Changes

`inlinePropertyRefsForMerge` only inlined `$ref` pointers at the **direct property level**  and didn't recurse into nested object properties. When two `allOf` branches defined the same nested property path with `$ref` leaf values, the `$ref` pointers were passed through un-inlined to `json-schema-merge-allof`. That library doesn't understand `$ref`, so its `defaultResolver` (first-value-wins) silently dropped the second branch.

<details>
<summary>Some More RCA</summary>

### Root Cause

Each `allOf` branch defines `settings.notifications` as a `$ref`:

```json
{
  "allOf": [
    {
      "type": "object",
      "properties": {
        "settings": {
          "type": "object",
          "properties": {
            "notifications": { "$ref": "#/components/schemas/NotificationBase" }
          }
        }
      }
    },
    {
      "type": "object",
      "properties": {
        "settings": {
          "type": "object",
          "properties": {
            "notifications": { "$ref": "#/components/schemas/NotificationExtras" }
          }
        }
      }
    }
  ]
}
```

Before merging, `inlinePropertyRefsForMerge` is called to replace `$ref` pointers with resolved schemas so `json-schema-merge-allof` can deep-merge them. But it only checked **direct** children of `properties`:

```json
{
  "properties": {
    "settings": { ... }  // ← checked here (not a $ref, skipped)
  }
}
```

It never recursed into `settings.properties.notifications`, so the `$ref` pointers survived into the merge. `json-schema-merge-allof` saw two opaque `$ref` strings at the same path and kept only the first:

```json
{
  "settings": {
    "type": "object",
    "properties": {
      "notifications": { "$ref": "#/components/schemas/NotificationBase" }
    }
  }
}
```

`NotificationExtras` (with `muted`) was silently dropped.

### Fix

Added a recursive case so that when a property value is an object with its own `properties`, recurse into it. After the fix, both `$ref` pointers are inlined before the merge, producing:

```json
{
  "settings": {
    "type": "object",
    "properties": {
      "notifications": {
        "type": "object",
        "properties": {
          "channel": { "type": "string", "enum": ["email", "sms"] },
          "muted": { "type": "boolean", "default": false }
        }
      }
    }
  }
}
```
</details>

> [!NOTE]
> This PR also touches logic that was fixed in #1121. The recursive inlining in this PR resolves the original issue flagged in #1121 more thoroughly (by inlining the nested `$ref` before it ever reaches `mergeReferencedSchemasIntoRoot`), but we **still** need the depth-sorting fix from #1121 for `$ref` pointers inside `items`, `additionalProperties`, and other non-`properties` keywords that the recursive inlining can't reach. Added dedicated test fixture (`deep-self-ref-in-items.json`) in 9df24d9

## 🧬 QA & Testing

Upload this spec and open the endpoint referencing `UpdateRequest`: [cx-3213-simplified.json](https://github.com/user-attachments/files/26993151/cx-3213-simplified.json)

Expand `settings` → `notifications` in the rendered request body. Both `channel` and `muted` should be visible.

<img width="1480" height="1099" alt="Screenshot 2026-04-23 at 12 01 43" src="https://github.com/user-attachments/assets/f4c2a53b-980a-4e9d-8975-2bda05162616" />