### PR TITLE
fix(oas): inline allOf-path $refs in oneOf/anyOf before merge

### DIFF
--- a/.changeset/fix-oneof-duplication-allof-self-ref.md
+++ b/.changeset/fix-oneof-duplication-allof-self-ref.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Fixed `oneOf`/`anyOf` items being duplicated when a variant contains a deep `$ref` through an `allOf` path by inlining stale allOf-path refs before the `allOf` merge.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -237,12 +237,67 @@ function inlinePropertyRefsForMerge(
           ...structuredClone(resolved),
         };
       }
-    } else if (val && typeof val === 'object' && !Array.isArray(val) && 'properties' in val) {
-      out.properties[key] = inlinePropertyRefsForMerge(val as SchemaObject, usedSchemas, refLogger);
+    } else if (val && typeof val === 'object' && !Array.isArray(val)) {
+      if ('properties' in val) {
+        out.properties[key] = inlinePropertyRefsForMerge(val as SchemaObject, usedSchemas, refLogger);
+      }
+
+      // Inline allOf-path refs inside oneOf/anyOf to prevent synthetic allOf scaffolding.
+      inlineAllOfRefsDeep((out.properties[key] ?? val) as SchemaObject, usedSchemas);
     }
   }
 
   return out;
+}
+
+/**
+ * Some OAS specs use `$ref` pointers that path through `allOf`, e.g.
+ * `#/components/schemas/Foo/allOf/1/properties/bar`. After `toJSONSchema` merges the `allOf` flat,
+ * these paths become stale, the `allOf` no longer exists in the output. If left as stubs,
+ * `mergeReferencedSchemasIntoRoot` recreates a synthetic `allOf` to make them resolvable, which
+ * causes downstream consumers to re-merge it and duplicate `oneOf`/`anyOf` entries.
+ *
+ * This function walks `oneOf`/`anyOf` options and their nested `properties` to find and inline
+ * these stale refs. Only refs containing `/allOf/` are replaced and regular component refs are
+ * left as stubs for render-time resolution.
+ */
+function inlineAllOfRefsDeep(schema: SchemaObject, usedSchemas: Map<string, SchemaObject>): void {
+  const allOfKey = '/allOf'
+
+  for (const keyword of ['oneOf', 'anyOf'] as const) {
+    if (!Array.isArray(schema[keyword])) continue;
+    for (let i = 0; i < schema[keyword].length; i++) {
+      const option = schema[keyword][i] as SchemaObject | undefined;
+      if (!option || typeof option !== 'object') continue;
+      if (isRef(option) && option.$ref.includes(allOfKey)) {
+        const resolved = usedSchemas.get(option.$ref);
+        if (resolved !== undefined && !isPendingSchema(resolved)) {
+          schema[keyword][i] = structuredClone(resolved);
+        }
+      } else if (!isRef(option)) {
+        inlineAllOfRefsDeep(option, usedSchemas);
+      }
+    }
+  }
+
+  // We cant rely on `inlinePropertyRefsForMerge` here because it inlines ALL refs, we only
+  // want to inline refs through `/allOf/` paths, leaving component refs as stubs.
+  if ('properties' in schema && typeof schema.properties === 'object' && schema.properties !== null) {
+    for (const key of Object.keys(schema.properties)) {
+      const val = schema.properties[key];
+      if (isRef(val) && val.$ref.includes(allOfKey)) {
+        const resolved = usedSchemas.get(val.$ref);
+        if (resolved !== undefined && !isPendingSchema(resolved)) {
+          schema.properties[key] = structuredClone(resolved);
+        }
+      } else if (val && typeof val === 'object' && !Array.isArray(val) && !isRef(val)) {
+        inlineAllOfRefsDeep(val as SchemaObject, usedSchemas);
+      }
+    }
+  }
+
+  // refs through `allOf/` in `items` and `additionalProperties` are resolved via the depth-sorted
+  // scaffold in `mergeReferencedSchemasIntoRoot` (refs.ts)
 }
 
 /**

--- a/packages/oas/test/__datasets__/issues/CX-3280.json
+++ b/packages/oas/test/__datasets__/issues/CX-3280.json
@@ -1,0 +1,118 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "oneOf Duplication via Deep Self-Ref through allOf",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/endpoint": {
+      "post": {
+        "operationId": "createNotification",
+        "summary": "Create Notification",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Payload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Payload": {
+        "type": "object",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "event": {
+                "description": "Data specific to the event type.",
+                "oneOf": [
+                  {
+                    "title": "TypeA",
+                    "type": "object",
+                    "properties": {
+                      "plan": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "title": "TypeB",
+                    "type": "object",
+                    "properties": {
+                      "started_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    }
+                  },
+                  {
+                    "title": "TypeC",
+                    "type": "object",
+                    "properties": {
+                      "stopped_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    }
+                  },
+                  {
+                    "title": "TypeD",
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "type": "integer"
+                      },
+                      "metadata": {
+                        "type": "object",
+                        "properties": {
+                          "token": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "title": "TypeE",
+                    "type": "object",
+                    "properties": {
+                      "ref_id": {
+                        "type": "string"
+                      },
+                      "metadata": {
+                        "$ref": "#/components/schemas/Payload/allOf/1/properties/event/oneOf/3/properties/metadata"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -30,6 +30,7 @@ import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' 
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
 import cx3213 from '../../__datasets__/issues/CX-3213.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
+import cx3280 from '../../__datasets__/issues/CX-3280.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
@@ -1910,6 +1911,30 @@ describe('.getParametersAsJSONSchema()', () => {
             },
           },
         });
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should not duplicate oneOf items when a variant contains a deep self-ref through allOf', async () => {
+        const oas = Oas.init(structuredClone(cx3280));
+        const operation = oas.operation('/endpoint', 'post');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const payload = bodySchema?.schema?.components?.schemas?.Payload as Record<string, unknown>;
+        const event = (payload?.properties as Record<string, unknown>)?.event as Record<string, unknown>;
+
+        expect(event?.oneOf).toHaveLength(5);
+        expect(payload).not.toHaveProperty('allOf');
+
+        const typeD = (event?.oneOf as Record<string, unknown>[])?.[3];
+        const typeE = (event?.oneOf as Record<string, unknown>[])?.[4];
+        const typeDMetadata = (typeD?.properties as Record<string, unknown>)?.metadata as Record<string, unknown>;
+        const typeEMetadata = (typeE?.properties as Record<string, unknown>)?.metadata as Record<string, unknown>;
+        expect(typeEMetadata).not.toHaveProperty('$ref');
+        expect(typeEMetadata).toStrictEqual(typeDMetadata);
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });


### PR DESCRIPTION
| 🚥 Resolves CX-3280 |
| :------------------- |

## 🧰 Changes

This issue was sadly introduced in #1121 which caused a side effect. The scaffolds created there was correct to some degree but consumers like our monorepo app was confused on how to handle them and sometimes caused duplicate schemas because it was merging the scaffold `allOf` array thinking it was a legitimate `allOf` array. #1122 partially addressed this by making `inlinePropertyRefsForMerge` recursive for nested `properties`, but it can't reach refs inside `oneOf`/`anyOf` keywords, which is exactly the case in here.

This approach simplifies the return shape to have them inlined instead of needing to create a separate scaffold `allOf` array. we do this via the new `inlineAllOfRefsDeep` to walk all options in the `oneOf` or `anyOf` array and any nested `properties` and then inlines them in

> [!IMPORTANT]
regular component refs like `#/components/schemas/Foo` are left untouched!

> [!NOTE]
`items` and `additionalProperties` refs through `allOf/` are still handled via the depth-sorted scaffold in `mergeReferencedSchemasIntoRoot` (`refs.ts`)

## 🧬 QA & Testing

Upload this spec and open the `/endpoint` endpoint: [cx-3280.json](https://github.com/user-attachments/files/27116317/cx-3280.json)

<details>

### Before (broken)

The `allOf` is merged flat but `oneOf[4].properties.metadata` still has a `$ref` through the old `allOf` path. `mergeReferencedSchemasIntoRoot` recreates a synthetic `allOf` to make it resolvable, which consumers sometime duplicate:

```json
{
  "Payload": {
    "properties": {
      "id": { "type": "string" },
      "event": {
        "oneOf": [
          { "title": "TypeA", "properties": { "plan": { "type": "string" } } },
          { "title": "TypeB", "properties": { "started_at": { "type": "string" } } },
          { "title": "TypeC", "properties": { "stopped_at": { "type": "string" } } },
          { "title": "TypeD", "properties": { "amount": { "type": "integer" }, "metadata": { "type": "object", "properties": { "token": {}, "kind": {} } } } },
          { "title": "TypeE", "properties": { "ref_id": { "type": "string" }, "metadata": { "$ref": "#/.../Payload/allOf/1/properties/event/oneOf/3/properties/metadata" } } }
        ]
      }
    },
    "allOf": [
      null,
      {
        "properties": {
          "event": {
            "oneOf": [ null, null, null, { "properties": { "metadata": { "type": "object", "properties": { "token": {}, "kind": {} } } } } ]
          }
        }
      }
    ]
  }
}
```

### After (fixed)

The `$ref` is inlined before the `allOf` merge. No synthetic `allOf`, no duplication:

```json
{
  "Payload": {
    "properties": {
      "id": { "type": "string" },
      "event": {
        "oneOf": [
          { "title": "TypeA", "properties": { "plan": { "type": "string" } } },
          { "title": "TypeB", "properties": { "started_at": { "type": "string" } } },
          { "title": "TypeC", "properties": { "stopped_at": { "type": "string" } } },
          { "title": "TypeD", "properties": { "amount": { "type": "integer" }, "metadata": { "type": "object", "properties": { "token": {}, "kind": {} } } } },
          { "title": "TypeE", "properties": { "ref_id": { "type": "string" }, "metadata": { "type": "object", "properties": { "token": {}, "kind": {} } } } }
        ]
      }
    }
  }
}
```
</details>

