### PR TITLE
feat(parser): improve pre-AJV security scheme validation messages

### DIFF
--- a/.changeset/pre-ajv-security-scheme-validation.md
+++ b/.changeset/pre-ajv-security-scheme-validation.md
@@ -1,0 +1,5 @@
+---
+"@readme/openapi-parser": minor
+---
+
+Added pre-AJV validation for quirky security schemes. Surfaces clear, targeted errors (missing `type`, cross-type contamination, invalid `apiKey.in`, empty `oauth2.flows`, Swagger 2.0 ↔ OAS 3.x type confusion) instead of AJV's noisy `oneOf` failures, configurable via the new `invalid-security-scheme-properties` rule.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -262,7 +262,7 @@ function inlinePropertyRefsForMerge(
  * left as stubs for render-time resolution.
  */
 function inlineAllOfRefsDeep(schema: SchemaObject, usedSchemas: Map<string, SchemaObject>): void {
-  const allOfKey = '/allOf'
+  const allOfKey = '/allOf';
 
   for (const keyword of ['oneOf', 'anyOf'] as const) {
     if (!Array.isArray(schema[keyword])) continue;

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -5,7 +5,7 @@ import { $RefParser, dereferenceInternal, MissingPointerError } from '@apidevtoo
 import { isOpenAPI, isSwagger } from './lib/assertions.js';
 import { convertOptionsForParser, normalizeArguments, repairSchema } from './util.js';
 import { validateSchema } from './validators/schema.js';
-import { validateSpec } from './validators/spec.js';
+import { validateSpec, validateSpecPreSchema } from './validators/spec.js';
 
 export type { ParserOptions, ValidationResult, ErrorDetails, WarningDetails };
 
@@ -149,10 +149,47 @@ export async function validate<S extends APIDocument, Options extends ParserOpti
   // Restore the original options, now that we're done dereferencing
   parserOptions.dereference.circular = circular$RefOption;
 
-  // Validate the API against the OpenAPI or Swagger JSON schema definition.
+  const openapiRules = options?.validate?.rules?.openapi;
+  const swaggerRules = options?.validate?.rules?.swagger;
+  const rules = {
+    openapi: {
+      'array-without-items': openapiRules?.['array-without-items'] || 'error',
+      'duplicate-non-request-body-parameters': openapiRules?.['duplicate-non-request-body-parameters'] || 'error',
+      'duplicate-operation-id': openapiRules?.['duplicate-operation-id'] || 'error',
+      'invalid-security-scheme-properties': openapiRules?.['invalid-security-scheme-properties'] || 'error',
+      'non-optional-path-parameters': openapiRules?.['non-optional-path-parameters'] || 'error',
+      'path-parameters-not-in-parameters': openapiRules?.['path-parameters-not-in-parameters'] || 'error',
+      'path-parameters-not-in-path': openapiRules?.['path-parameters-not-in-path'] || 'error',
+    },
+    swagger: {
+      'array-without-items': swaggerRules?.['array-without-items'] || 'error',
+      'duplicate-non-request-body-parameters': swaggerRules?.['duplicate-non-request-body-parameters'] || 'error',
+      'duplicate-operation-id': swaggerRules?.['duplicate-operation-id'] || 'error',
+      'invalid-security-scheme-properties': swaggerRules?.['invalid-security-scheme-properties'] || 'error',
+      'non-optional-path-parameters': swaggerRules?.['non-optional-path-parameters'] || 'error',
+      'path-parameters-not-in-parameters': swaggerRules?.['path-parameters-not-in-parameters'] || 'error',
+      'path-parameters-not-in-path': swaggerRules?.['path-parameters-not-in-path'] || 'error',
+      'unknown-required-schema-property': swaggerRules?.['unknown-required-schema-property'] || 'error',
+    },
+  };
+
+  // Run pre-schema spec validation (i.e. things that AJV does poorly), like security scheme
+  // structural checks. If these fail, surface their errors directly instead of letting AJV
+  // produce confusing `oneOf` noise.
+  const { result: preSchemaResult, flaggedInstancePaths } = validateSpecPreSchema(parser.schema, rules);
+  if (!preSchemaResult.valid) {
+    return preSchemaResult;
+  }
+
+  // Validate the API against the OpenAPI or Swagger JSON schema definition. We pass the
+  // pre-schema-flagged instance paths so that AJV errors against those paths are filtered out
+  // (their issues have already been reported by the pre-schema validator).
   // NOTE: This is safe to do, because we haven't dereferenced circular $refs yet
-  result = validateSchema(parser.schema, options);
+  result = validateSchema(parser.schema, options, flaggedInstancePaths);
   if (!result.valid) {
+    if (preSchemaResult.warnings.length) {
+      result.warnings = [...preSchemaResult.warnings, ...result.warnings];
+    }
     return result;
   }
 
@@ -169,27 +206,11 @@ export async function validate<S extends APIDocument, Options extends ParserOpti
   }
 
   // Validate the API against the OpenAPI or Swagger specification.
-  const openapiRules = options?.validate?.rules?.openapi;
-  const swaggerRules = options?.validate?.rules?.swagger;
-  result = validateSpec(parser.schema, {
-    openapi: {
-      'array-without-items': openapiRules?.['array-without-items'] || 'error',
-      'duplicate-non-request-body-parameters': openapiRules?.['duplicate-non-request-body-parameters'] || 'error',
-      'duplicate-operation-id': openapiRules?.['duplicate-operation-id'] || 'error',
-      'non-optional-path-parameters': openapiRules?.['non-optional-path-parameters'] || 'error',
-      'path-parameters-not-in-parameters': openapiRules?.['path-parameters-not-in-parameters'] || 'error',
-      'path-parameters-not-in-path': openapiRules?.['path-parameters-not-in-path'] || 'error',
-    },
-    swagger: {
-      'array-without-items': swaggerRules?.['array-without-items'] || 'error',
-      'duplicate-non-request-body-parameters': swaggerRules?.['duplicate-non-request-body-parameters'] || 'error',
-      'duplicate-operation-id': swaggerRules?.['duplicate-operation-id'] || 'error',
-      'non-optional-path-parameters': swaggerRules?.['non-optional-path-parameters'] || 'error',
-      'path-parameters-not-in-parameters': swaggerRules?.['path-parameters-not-in-parameters'] || 'error',
-      'path-parameters-not-in-path': swaggerRules?.['path-parameters-not-in-path'] || 'error',
-      'unknown-required-schema-property': swaggerRules?.['unknown-required-schema-property'] || 'error',
-    },
-  });
+  result = validateSpec(parser.schema, rules);
+
+  if (preSchemaResult.warnings.length) {
+    result.warnings = [...preSchemaResult.warnings, ...result.warnings];
+  }
 
   return result;
 }

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -54,6 +54,15 @@ export interface ParserRulesOpenAPI extends Record<string, 'error' | 'warning'> 
   'duplicate-operation-id': 'error' | 'warning';
 
   /**
+   * Security schemes must only contain properties valid for their declared `type`. Catches
+   * common mistakes like an `http` scheme having a `name` (which belongs to `apiKey`) before
+   * AJV has a chance to surface confusing `oneOf` noise. The default is `error`.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object}
+   */
+  'invalid-security-scheme-properties': 'error' | 'warning';
+
+  /**
    * Parameters that are defined within the path URI must be specified as being `required`. The
    * default is `error`.
    *
@@ -100,6 +109,15 @@ export interface ParserRulesSwagger extends Record<string, 'error' | 'warning'> 
    * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#user-content-operationid}
    */
   'duplicate-operation-id': 'error' | 'warning';
+
+  /**
+   * Security definitions must only contain properties valid for their declared `type`. Catches
+   * common mistakes like an `apiKey` definition with `in: cookie` (which is OAS 3.0+ only)
+   * before AJV has a chance to surface confusing `oneOf` noise. The default is `error`.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#security-scheme-object}
+   */
+  'invalid-security-scheme-properties': 'error' | 'warning';
 
   /**
    * Parameters that are defined within the path URI must be specified as being `required`. The

--- a/packages/parser/src/validators/schema.ts
+++ b/packages/parser/src/validators/schema.ts
@@ -53,6 +53,7 @@ function initializeAjv(draft04: boolean = true) {
 export function validateSchema(
   api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document,
   options: ParserOptions = {},
+  suppressedInstancePaths: string[] = [],
 ): ValidationResult {
   // Pre-validation check for missing leading slashes in paths
   if (hasInvalidPaths(api)) {
@@ -121,7 +122,14 @@ export function validateSchema(
   }
 
   let additionalErrors = 0;
-  let reducedErrors = reduceAjvErrors(ajv.errors);
+  let reducedErrors = reduceAjvErrors(ajv.errors).filter(err => {
+    return !suppressedInstancePaths.some(path => err.instancePath === path || err.instancePath.startsWith(`${path}/`));
+  });
+
+  // If filtering removed every error, the spec is effectively valid from AJV's perspective.
+  if (!reducedErrors.length) {
+    return { valid: true, warnings: [], specification: specificationName };
+  }
   if (reducedErrors.length >= LARGE_SPEC_ERROR_CAP) {
     try {
       if (JSON.stringify(api).length >= LARGE_SPEC_SIZE_CAP) {

--- a/packages/parser/src/validators/spec.ts
+++ b/packages/parser/src/validators/spec.ts
@@ -50,3 +50,57 @@ export function validateSpec(
     specification: specificationName,
   };
 }
+
+/**
+ * Runs spec-level validation that should happen **before** AJV's JSON Schema validation, so that
+ * the user gets clear, actionable errors instead of confusing schema-level noise.
+ *
+ * @returns The pre-schema validation outcome.
+ * @returns return.result - The `ValidationResult` of the pre-schema checks; `valid: false` when
+ *   any check reported an error, otherwise `valid: true` (warnings are carried either way).
+ * @returns return.flaggedInstancePaths - Instance paths (e.g. `/components/securitySchemes/MyAuth`)
+ *   for which the pre-schema validator already emitted an error or warning. Pass these into
+ *   `validateSchema` so AJV's redundant `oneOf` errors against the same paths get suppressed.
+ */
+export function validateSpecPreSchema(
+  api: OpenAPIV2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document,
+  rules: {
+    openapi: ParserRulesOpenAPI;
+    swagger: ParserRulesSwagger;
+  },
+): { flaggedInstancePaths: string[]; result: ValidationResult } {
+  let validator: SpecificationValidator;
+
+  const specificationName = getSpecificationName(api);
+  if (isOpenAPI(api)) {
+    validator = new OpenAPISpecificationValidator(api, rules.openapi);
+  } else {
+    validator = new SwaggerSpecificationValidator(api, rules.swagger);
+  }
+
+  validator.runPreSchemaChecks();
+
+  const flaggedInstancePaths = validator.flaggedInstancePaths;
+
+  if (!validator.errors.length) {
+    return {
+      flaggedInstancePaths,
+      result: {
+        valid: true,
+        warnings: validator.warnings,
+        specification: specificationName,
+      },
+    };
+  }
+
+  return {
+    flaggedInstancePaths,
+    result: {
+      valid: false,
+      errors: validator.errors,
+      warnings: validator.warnings,
+      additionalErrors: 0,
+      specification: specificationName,
+    },
+  };
+}

--- a/packages/parser/src/validators/spec/index.ts
+++ b/packages/parser/src/validators/spec/index.ts
@@ -5,6 +5,12 @@ export abstract class SpecificationValidator {
 
   warnings: WarningDetails[] = [];
 
+  /**
+   * Instance paths flagged by `runPreSchemaChecks()`. Used to suppress AJV `oneOf` noise that
+   * the pre-schema validator has already produced a clearer error or warning for.
+   */
+  flaggedInstancePaths: string[] = [];
+
   protected reportError(message: string): void {
     this.errors.push({ message });
   }
@@ -13,5 +19,13 @@ export abstract class SpecificationValidator {
     this.warnings.push({ message });
   }
 
+  protected flagInstancePath(path: string): void {
+    if (!this.flaggedInstancePaths.includes(path)) {
+      this.flaggedInstancePaths.push(path);
+    }
+  }
+
   abstract run(): void;
+
+  abstract runPreSchemaChecks(): void;
 }

--- a/packages/parser/src/validators/spec/openapi.ts
+++ b/packages/parser/src/validators/spec/openapi.ts
@@ -29,6 +29,10 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
     this.rules = rules;
   }
 
+  runPreSchemaChecks(): void {
+    this.checkSecuritySchemes();
+  }
+
   run(): void {
     const operationIds: string[] = [];
     Object.keys(this.api.paths || {}).forEach(pathName => {
@@ -318,6 +322,145 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
       } else {
         this.reportError(`\`${schemaId}\` is an array, so it must include an \`items\` schema.`);
       }
+    }
+  }
+
+  /**
+   * Validates security schemes in `components.securitySchemes` against their declared `type`.
+   *
+   * AJV uses a `oneOf` schema to validate security schemes, so when a scheme is malformed AJV
+   * fails every branch and produces overwhelming, unhelpful errors. This pre-AJV pass surfaces
+   * a single targeted error per problem.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object}
+   */
+  private checkSecuritySchemes() {
+    const securitySchemes = this.api.components?.securitySchemes;
+    if (!securitySchemes) {
+      return;
+    }
+
+    const schemeTypeProps: Record<string, { foreign: Record<string, string>; required: string[] }> = {
+      apiKey: {
+        required: ['name', 'in'],
+        foreign: { scheme: 'http', bearerFormat: 'http', flows: 'oauth2', openIdConnectUrl: 'openIdConnect' },
+      },
+      http: {
+        required: ['scheme'],
+        foreign: { name: 'apiKey', in: 'apiKey', flows: 'oauth2', openIdConnectUrl: 'openIdConnect' },
+      },
+      oauth2: {
+        required: ['flows'],
+        foreign: {
+          name: 'apiKey',
+          in: 'apiKey',
+          scheme: 'http',
+          bearerFormat: 'http',
+          openIdConnectUrl: 'openIdConnect',
+        },
+      },
+      openIdConnect: {
+        required: ['openIdConnectUrl'],
+        foreign: { name: 'apiKey', in: 'apiKey', scheme: 'http', bearerFormat: 'http', flows: 'oauth2' },
+      },
+      mutualTLS: {
+        required: [],
+        foreign: {
+          name: 'apiKey',
+          in: 'apiKey',
+          scheme: 'http',
+          bearerFormat: 'http',
+          flows: 'oauth2',
+          openIdConnectUrl: 'openIdConnect',
+        },
+      },
+    };
+
+    Object.keys(securitySchemes).forEach(name => {
+      const scheme = securitySchemes[name] as Record<string, unknown>;
+      if ('$ref' in scheme) {
+        return;
+      }
+
+      const schemeId = `/components/securitySchemes/${name}`;
+      const reportIssue = (message: string) => this.reportSecuritySchemeIssue(message, schemeId);
+
+      // Rule: every scheme must declare a `type`. Without it we can't run any other check.
+      if (!('type' in scheme) || !scheme.type) {
+        reportIssue(
+          `\`${schemeId}\` is missing required property \`type\`. Must be one of: \`apiKey\`, \`http\`, \`oauth2\`, \`openIdConnect\`, \`mutualTLS\`.`,
+        );
+        return;
+      }
+
+      const type = scheme.type as string;
+
+      // Rule: `type: basic` is Swagger 2.0 syntax, produce a migration hint instead of a
+      // generic "invalid type" so users porting from 2.0 know what to change.
+      if (type === 'basic') {
+        reportIssue(
+          `\`${schemeId}\` uses \`type: basic\`, which is a Swagger 2.0 value. In OpenAPI 3.x use \`type: http\` with \`scheme: basic\` instead.`,
+        );
+        return;
+      }
+
+      // Rule: `type` must be one of the recognized OAS 3.x scheme types.
+      if (!(type in schemeTypeProps)) {
+        reportIssue(
+          `\`${schemeId}\` has an invalid \`type\`: \`${type}\`. Must be one of: \`apiKey\`, \`http\`, \`oauth2\`, \`openIdConnect\`, \`mutualTLS\`.`,
+        );
+        return;
+      }
+
+      const config = schemeTypeProps[type];
+
+      // Rule: each `type` has properties it must declare (apiKey needs name+in, http needs
+      // scheme, oauth2 needs flows, etc.). Report each missing required property separately.
+      config.required.forEach(prop => {
+        if (!(prop in scheme)) {
+          reportIssue(`\`${schemeId}\` (\`type: ${type}\`) is missing required property \`${prop}\`.`);
+        }
+      });
+
+      // Rule: cross-type contamination, e.g. an `http` scheme with a `name` field (which
+      // belongs to `apiKey`). The error names the type that *does* own the property to nudge
+      // the user toward the fix.
+      Object.entries(config.foreign).forEach(([prop, ownerType]) => {
+        if (prop in scheme) {
+          reportIssue(
+            `\`${schemeId}\` (\`type: ${type}\`) includes \`${prop}\`, which is only valid for \`type: ${ownerType}\` schemes.`,
+          );
+        }
+      });
+
+      // Rule: `apiKey.in` must be one of `query`, `header`, `cookie` (per OAS 3.0+).
+      if (type === 'apiKey' && typeof scheme.in === 'string') {
+        const validIn = ['query', 'header', 'cookie'];
+        if (!validIn.includes(scheme.in)) {
+          reportIssue(
+            `\`${schemeId}\` has an invalid \`in\` value: \`${scheme.in}\`. Must be one of: \`query\`, \`header\`, \`cookie\`.`,
+          );
+        }
+      }
+
+      // Rule: `oauth2.flows` is structurally present but empty (`flows: {}`), the `required`
+      // check passes, but the spec demands at least one grant type inside.
+      if (type === 'oauth2' && scheme.flows && typeof scheme.flows === 'object') {
+        if (Object.keys(scheme.flows as object).length === 0) {
+          reportIssue(
+            `\`${schemeId}\` has empty \`flows\`. At least one grant type is required: \`implicit\`, \`password\`, \`clientCredentials\`, or \`authorizationCode\`.`,
+          );
+        }
+      }
+    });
+  }
+
+  private reportSecuritySchemeIssue(message: string, schemeId: string) {
+    this.flagInstancePath(schemeId);
+    if (this.rules['invalid-security-scheme-properties'] === 'warning') {
+      this.reportWarning(message);
+    } else {
+      this.reportError(message);
     }
   }
 

--- a/packages/parser/src/validators/spec/swagger.ts
+++ b/packages/parser/src/validators/spec/swagger.ts
@@ -23,6 +23,10 @@ export class SwaggerSpecificationValidator extends SpecificationValidator {
     this.rules = rules;
   }
 
+  runPreSchemaChecks(): void {
+    this.checkSecurityDefinitions();
+  }
+
   run(): void {
     const operationIds: string[] = [];
     Object.keys(this.api.paths || {}).forEach(pathName => {
@@ -336,6 +340,58 @@ export class SwaggerSpecificationValidator extends SpecificationValidator {
           }
         }
       });
+    }
+  }
+
+  /**
+   * Validates security definitions against their declared `type`.
+   *
+   * AJV uses `oneOf` to validate `securityDefinitions`, so when a definition is malformed AJV
+   * fails every branch and produces overwhelming, unhelpful errors. This pre-AJV pass surfaces
+   * a single targeted error per problem.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#security-scheme-object}
+   */
+  private checkSecurityDefinitions() {
+    const securityDefinitions = this.api.securityDefinitions;
+    if (!securityDefinitions) {
+      return;
+    }
+
+    const validApiKeyIn = ['query', 'header'];
+
+    Object.keys(securityDefinitions).forEach(name => {
+      const definition = securityDefinitions[name] as unknown as Record<string, unknown>;
+      const definitionId = `/securityDefinitions/${name}`;
+      const reportIssue = (message: string) => this.reportSecuritySchemeIssue(message, definitionId);
+
+      const type = definition.type as string | undefined;
+
+      // Rule: `type: http` is OpenAPI 3.x syntax, produce a migration hint instead of a
+      // generic "invalid type" so users porting from 3.x know to use `type: basic` instead.
+      if (type === 'http') {
+        reportIssue(
+          `\`${definitionId}\` uses \`type: http\`, which is an OpenAPI 3.x value. In Swagger 2.0 use \`type: basic\` for HTTP Basic auth.`,
+        );
+        return;
+      }
+
+      // Rule: Swagger 2.0 `apiKey.in` only allows `query` or `header`. `cookie` was added in
+      // OAS 3.0+, so users carrying it back into a 2.0 spec is the typical mistake.
+      if (type === 'apiKey' && typeof definition.in === 'string' && !validApiKeyIn.includes(definition.in)) {
+        reportIssue(
+          `\`${definitionId}\` has an invalid \`in\` value: \`${definition.in}\`. Swagger 2.0 only supports \`query\` or \`header\`.`,
+        );
+      }
+    });
+  }
+
+  private reportSecuritySchemeIssue(message: string, definitionId: string) {
+    this.flagInstancePath(definitionId);
+    if (this.rules['invalid-security-scheme-properties'] === 'warning') {
+      this.reportWarning(message);
+    } else {
+      this.reportError(message);
     }
   }
 

--- a/packages/parser/test/specs/validate-spec/invalid/2.0/security-schemes/apikey-in-cookie.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/2.0/security-schemes/apikey-in-cookie.yaml
@@ -1,0 +1,12 @@
+swagger: '2.0'
+info:
+  title: Test
+  version: '1.0'
+host: api.example.com
+basePath: /
+paths: {}
+securityDefinitions:
+  ApiKeyAuth:
+    type: apiKey
+    name: session
+    in: cookie

--- a/packages/parser/test/specs/validate-spec/invalid/3.0/component-schema-with-space.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.0/component-schema-with-space.yaml
@@ -16,5 +16,3 @@ components:
       type: apiKey
       name: API-TOKEN
       in: header
-      scheme: api token # <---- `scheme` or `bearerFormat` be here but this spec should fail on the component name
-      bearerFormat: JWT

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-invalid-in-value.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-invalid-in-value.yaml
@@ -1,0 +1,11 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      name: X-API-Key
+      in: body

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-missing-in.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-missing-in.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      name: X-API-Key

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-missing-name.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-missing-name.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-with-scheme.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/apikey-with-scheme.yaml
@@ -1,0 +1,12 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    ApiKeyWithScheme:
+      type: apiKey
+      name: Authorization
+      in: header
+      scheme: bearer

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/http-missing-scheme.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/http-missing-scheme.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    HttpNoScheme:
+      type: http
+      description: Forgot the scheme

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/http-with-name-and-in.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/http-with-name-and-in.yaml
@@ -1,0 +1,12 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    MyAuth:
+      type: http
+      scheme: bearer
+      name: Authorization
+      in: header

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/http-with-name.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/http-with-name.yaml
@@ -1,0 +1,12 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    ServiceAccount:
+      name: Service Account
+      description: Service Account
+      type: http
+      scheme: basic

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/missing-type.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/missing-type.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    NoType:
+      description: I forgot to set the type
+      scheme: basic

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/multiple-quirky-schemes.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/multiple-quirky-schemes.yaml
@@ -1,0 +1,19 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    HttpWithName:
+      type: http
+      scheme: basic
+      name: Should Not Be Here
+    ApiKeyNoIn:
+      type: apiKey
+      name: X-Key
+    OAuth2WithScheme:
+      type: oauth2
+      scheme: bearer
+    MissingType:
+      description: No type field

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/oauth2-empty-flows.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/oauth2-empty-flows.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    OAuthEmpty:
+      type: oauth2
+      flows: {}

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/oauth2-with-scheme.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/oauth2-with-scheme.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    OAuthMixed:
+      type: oauth2
+      scheme: bearer

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/openidconnect-with-name.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/openidconnect-with-name.yaml
@@ -1,0 +1,10 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    OIDC:
+      type: openIdConnect
+      name: Authorization

--- a/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/swagger-basic-in-oas3.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.x/security-schemes/swagger-basic-in-oas3.yaml
@@ -1,0 +1,9 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+components:
+  securitySchemes:
+    BasicAuth:
+      type: basic

--- a/packages/parser/test/specs/validate-spec/validate-spec.test.ts
+++ b/packages/parser/test/specs/validate-spec/validate-spec.test.ts
@@ -851,6 +851,253 @@ describe('Invalid APIs (specification validation)', () => {
     });
   });
 
+  describe('rule: `invalid-security-scheme-properties`', () => {
+    describe('OpenAPI 3.x', () => {
+      it('catches `type: http` with an `apiKey`-only `name` property', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/http-with-name.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/ServiceAccount` (`type: http`) includes `name`, which is only valid for `type: apiKey` schemes.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: http` with both `name` and `in` (looks like a misdeclared apiKey)', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/http-with-name-and-in.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/MyAuth` (`type: http`) includes `name`, which is only valid for `type: apiKey` schemes.',
+            },
+            {
+              message:
+                '`/components/securitySchemes/MyAuth` (`type: http`) includes `in`, which is only valid for `type: apiKey` schemes.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: apiKey` missing `in`', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/apikey-missing-in.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message: '`/components/securitySchemes/ApiKeyAuth` (`type: apiKey`) is missing required property `in`.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: apiKey` missing `name`', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/apikey-missing-name.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message: '`/components/securitySchemes/ApiKeyAuth` (`type: apiKey`) is missing required property `name`.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: apiKey` with an invalid `in` value', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/apikey-invalid-in-value.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/ApiKeyAuth` has an invalid `in` value: `body`. Must be one of: `query`, `header`, `cookie`.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: oauth2` with `scheme` and missing `flows`', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/oauth2-with-scheme.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/OAuthMixed` (`type: oauth2`) is missing required property `flows`.',
+            },
+            {
+              message:
+                '`/components/securitySchemes/OAuthMixed` (`type: oauth2`) includes `scheme`, which is only valid for `type: http` schemes.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: openIdConnect` with `name` and missing `openIdConnectUrl`', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/openidconnect-with-name.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/OIDC` (`type: openIdConnect`) is missing required property `openIdConnectUrl`.',
+            },
+            {
+              message:
+                '`/components/securitySchemes/OIDC` (`type: openIdConnect`) includes `name`, which is only valid for `type: apiKey` schemes.',
+            },
+          ],
+        });
+      });
+
+      it('catches a security scheme missing `type`', async () => {
+        await expect(relativePath('specs/validate-spec/invalid/3.x/security-schemes/missing-type.yaml')).not.toValidate(
+          {
+            errors: [
+              {
+                message:
+                  '`/components/securitySchemes/NoType` is missing required property `type`. Must be one of: `apiKey`, `http`, `oauth2`, `openIdConnect`, `mutualTLS`.',
+              },
+            ],
+          },
+        );
+      });
+
+      it('catches a Swagger 2.0 `type: basic` value used in OpenAPI 3.x', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/swagger-basic-in-oas3.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/BasicAuth` uses `type: basic`, which is a Swagger 2.0 value. In OpenAPI 3.x use `type: http` with `scheme: basic` instead.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: http` missing `scheme`', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/http-missing-scheme.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/HttpNoScheme` (`type: http`) is missing required property `scheme`.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: apiKey` with an `http`-only `scheme` property', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/apikey-with-scheme.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/ApiKeyWithScheme` (`type: apiKey`) includes `scheme`, which is only valid for `type: http` schemes.',
+            },
+          ],
+        });
+      });
+
+      it('catches `type: oauth2` with empty `flows`', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/oauth2-empty-flows.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/OAuthEmpty` has empty `flows`. At least one grant type is required: `implicit`, `password`, `clientCredentials`, or `authorizationCode`.',
+            },
+          ],
+        });
+      });
+
+      it('reports issues from every quirky scheme in a multi-scheme spec', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/3.x/security-schemes/multiple-quirky-schemes.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/components/securitySchemes/HttpWithName` (`type: http`) includes `name`, which is only valid for `type: apiKey` schemes.',
+            },
+            {
+              message: '`/components/securitySchemes/ApiKeyNoIn` (`type: apiKey`) is missing required property `in`.',
+            },
+            {
+              message:
+                '`/components/securitySchemes/OAuth2WithScheme` (`type: oauth2`) is missing required property `flows`.',
+            },
+            {
+              message:
+                '`/components/securitySchemes/OAuth2WithScheme` (`type: oauth2`) includes `scheme`, which is only valid for `type: http` schemes.',
+            },
+            {
+              message:
+                '`/components/securitySchemes/MissingType` is missing required property `type`. Must be one of: `apiKey`, `http`, `oauth2`, `openIdConnect`, `mutualTLS`.',
+            },
+          ],
+        });
+      });
+
+      it('emits warnings instead of errors when configured as such', async () => {
+        await expect(relativePath('specs/validate-spec/invalid/3.x/security-schemes/http-with-name.yaml')).toValidate({
+          rules: {
+            openapi: {
+              'invalid-security-scheme-properties': 'warning',
+            },
+          },
+          warnings: [
+            {
+              message:
+                '`/components/securitySchemes/ServiceAccount` (`type: http`) includes `name`, which is only valid for `type: apiKey` schemes.',
+            },
+          ],
+        });
+      });
+    });
+
+    describe('Swagger 2.0', () => {
+      it('catches `type: apiKey` with `in: cookie` (only valid in OpenAPI 3.x)', async () => {
+        await expect(
+          relativePath('specs/validate-spec/invalid/2.0/security-schemes/apikey-in-cookie.yaml'),
+        ).not.toValidate({
+          errors: [
+            {
+              message:
+                '`/securityDefinitions/ApiKeyAuth` has an invalid `in` value: `cookie`. Swagger 2.0 only supports `query` or `header`.',
+            },
+          ],
+        });
+      });
+
+      it('emits warnings instead of errors when configured as such', async () => {
+        await expect(relativePath('specs/validate-spec/invalid/2.0/security-schemes/apikey-in-cookie.yaml')).toValidate(
+          {
+            rules: {
+              swagger: {
+                'invalid-security-scheme-properties': 'warning',
+              },
+            },
+            warnings: [
+              {
+                message:
+                  '`/securityDefinitions/ApiKeyAuth` has an invalid `in` value: `cookie`. Swagger 2.0 only supports `query` or `header`.',
+              },
+            ],
+          },
+        );
+      });
+    });
+  });
+
   describe('parameter content validation', () => {
     describe('should catch a parameter with empty content', () => {
       it('OpenAPI 3.x', async () => {


### PR DESCRIPTION
| 🚥 Resolves RM-3321 |
| :------------------- |

## 🧰 Changes

OpenAPI/Swagger security schemes use a JSON Schema `oneOf` over every scheme type. When a user makes a common mistake like a `type: http` scheme with an `apiKey`-only `name` field, AJV fails every branch and dumps a wall of unrelated errors which is honestly really confusing and bad...

This adds a custom validator that runs **before** AJV and emits one targeted, actionable error per quirk:

- **OAS 3.x:** missing `type`, invalid `type` (incl. Swagger 2.0 `basic` migration hint), missing required props, cross-type contamination (e.g. `http` with `name`), invalid `apiKey.in`, empty `oauth2.flows`.
- **Swagger 2.0:** `type: http` migration hint, invalid `apiKey.in` (no `cookie` in 2.0).

Architecture:

- New `invalid-security-scheme-properties` rule (configurable as `error`/`warning`).
- New abstract `runPreSchemaChecks()` on `SpecificationValidator` so the dispatcher stays polymorphic.
- New `validateSpecPreSchema()` runs before AJV 
  - on errors, short-circuits and skips AJV. 
  - on warnings, lets AJV run but filters its redundant errors at flagged instance paths.
- `validateSchema()` accepts `suppressedInstancePaths` and short-circuits to `valid: true` if filtering empties the AJV error list (this is what makes warning mode functionally pass).

## 🧬 QA & Testing

Made some invalid files with invalid security schemes and their respective new error message:

- [01-http-with-name.yaml](https://github.com/user-attachments/files/27149825/01-http-with-name.yaml)
- [02-http-with-name-and-in.yaml](https://github.com/user-attachments/files/27149827/02-http-with-name-and-in.yaml)
- [03-apikey-missing-in.yaml](https://github.com/user-attachments/files/27149829/03-apikey-missing-in.yaml)
- [04-apikey-missing-name.yaml](https://github.com/user-attachments/files/27149830/04-apikey-missing-name.yaml)
- [05-apikey-invalid-in-value.yaml](https://github.com/user-attachments/files/27149831/05-apikey-invalid-in-value.yaml)
- [06-oauth2-with-scheme.yaml](https://github.com/user-attachments/files/27149832/06-oauth2-with-scheme.yaml)
- [07-openidconnect-with-name.yaml](https://github.com/user-attachments/files/27149834/07-openidconnect-with-name.yaml)
- [08-missing-type.yaml](https://github.com/user-attachments/files/27149835/08-missing-type.yaml)
- [09-swagger-basic-in-oas3.yaml](https://github.com/user-attachments/files/27149836/09-swagger-basic-in-oas3.yaml)
- [10-http-missing-scheme.yaml](https://github.com/user-attachments/files/27149837/10-http-missing-scheme.yaml)
- [11-multiple-quirky-schemes.yaml](https://github.com/user-attachments/files/27149838/11-multiple-quirky-schemes.yaml)
- [12-apikey-with-scheme.yaml](https://github.com/user-attachments/files/27149839/12-apikey-with-scheme.yaml)
- [13-oauth2-empty-flows.yaml](https://github.com/user-attachments/files/27149840/13-oauth2-empty-flows.yaml)
- [14-swagger2-apikey-in-body.yaml](https://github.com/user-attachments/files/27149841/14-swagger2-apikey-in-body.yaml)

<details>
<summary>Error Messages</summary>

File | Error Message
-- | --
[01-http-with-name.yaml](https://github.com/user-attachments/files/27149680/01-http-with-name.yaml) | <img width="341" height="220" alt="Screenshot 2026-04-28 at 13 32 40" src="https://github.com/user-attachments/assets/1829a182-9a3f-4014-b52c-e379819d69b9" />
[02-http-with-name-and-in.yaml](https://github.com/user-attachments/files/27149681/02-http-with-name-and-in.yaml) | <img width="341" height="269" alt="Screenshot 2026-04-28 at 13 34 26" src="https://github.com/user-attachments/assets/3ae31827-be08-47b1-a556-436e9c046e8f" />
[03-apikey-missing-in.yaml](https://github.com/user-attachments/files/27149682/03-apikey-missing-in.yaml) | <img width="341" height="202" alt="Screenshot 2026-04-28 at 13 34 50" src="https://github.com/user-attachments/assets/0ed24303-62b2-49cf-965b-1a04ff042515" />
[04-apikey-missing-name.yaml](https://github.com/user-attachments/files/27149683/04-apikey-missing-name.yaml) | <img width="342" height="203" alt="Screenshot 2026-04-28 at 13 35 32" src="https://github.com/user-attachments/assets/7c730351-06dc-43b8-bb4a-c2d00e00be29" />
[05-apikey-invalid-in-value.yaml](https://github.com/user-attachments/files/27149684/05-apikey-invalid-in-value.yaml) | <img width="342" height="220" alt="Screenshot 2026-04-28 at 13 35 54" src="https://github.com/user-attachments/assets/92c9a0df-646d-4313-bfa3-64fba1bf8e51" />
[06-oauth2-with-scheme.yaml](https://github.com/user-attachments/files/27149685/06-oauth2-with-scheme.yaml) | <img width="341" height="252" alt="Screenshot 2026-04-28 at 13 36 31" src="https://github.com/user-attachments/assets/7d61c32d-aa28-4656-b696-daa4a318b46b" />
[07-openidconnect-with-name.yaml](https://github.com/user-attachments/files/27149687/07-openidconnect-with-name.yaml) | <img width="341" height="269" alt="Screenshot 2026-04-28 at 13 36 56" src="https://github.com/user-attachments/assets/96e0e576-3701-47d2-8ef2-1b6ccdba5e9f" />
[08-missing-type.yaml](https://github.com/user-attachments/files/27149688/08-missing-type.yaml) | <img width="341" height="219" alt="Screenshot 2026-04-28 at 13 37 22" src="https://github.com/user-attachments/assets/b45b3ec1-03fc-4eaa-ab09-8c486a168b37" />
[09-swagger-basic-in-oas3.yaml](https://github.com/user-attachments/files/27149689/09-swagger-basic-in-oas3.yaml) | <img width="340" height="236" alt="Screenshot 2026-04-28 at 13 37 53" src="https://github.com/user-attachments/assets/d835a483-f2e3-487a-9d28-7bf84b417978" />
[10-http-missing-scheme.yaml](https://github.com/user-attachments/files/27149690/10-http-missing-scheme.yaml) | <img width="342" height="203" alt="Screenshot 2026-04-28 at 13 38 13" src="https://github.com/user-attachments/assets/fbea2050-14f5-4d58-b716-5ef3592c6303" />
[11-multiple-quirky-schemes.yaml](https://github.com/user-attachments/files/27149691/11-multiple-quirky-schemes.yaml) | <img width="343" height="405" alt="Screenshot 2026-04-28 at 13 39 02" src="https://github.com/user-attachments/assets/73084142-e7b4-4018-bfc6-7567d590f28a" />
[12-apikey-with-scheme.yaml](https://github.com/user-attachments/files/27149693/12-apikey-with-scheme.yaml) | <img width="341" height="221" alt="Screenshot 2026-04-28 at 13 39 21" src="https://github.com/user-attachments/assets/c869de6f-640e-4a62-a4a7-3b74d00cf987" />
[13-oauth2-empty-flows.yaml](https://github.com/user-attachments/files/27149694/13-oauth2-empty-flows.yaml) | <img width="342" height="236" alt="Screenshot 2026-04-28 at 13 40 10" src="https://github.com/user-attachments/assets/b3aa4d02-0396-4e98-ab72-847a889ed924" />
[14-swagger2-apikey-in-body.yaml](https://github.com/user-attachments/files/27149695/14-swagger2-apikey-in-body.yaml) | <img width="341" height="220" alt="Screenshot 2026-04-28 at 13 40 29" src="https://github.com/user-attachments/assets/8e91cf18-20c1-4c79-bacf-0ee0b12c996c" />

</details>
