### PR TITLE
fix(oas): preserve $ref metadata siblings on props inside allOf

### DIFF
--- a/.changeset/cx-3276-preserve-ref-siblings-in-allof.md
+++ b/.changeset/cx-3276-preserve-ref-siblings-in-allof.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Preserve metadata siblings (e.g. `description`, `summary`) alongside `$ref` pointers on properties inside `allOf` branches so they survive merging instead of being silently dropped during inlining. Continues to strip the invalid `properties` sibling to keep the CX-3171 crash regression covered.

--- a/.changeset/pre-ajv-security-scheme-validation.md
+++ b/.changeset/pre-ajv-security-scheme-validation.md
@@ -1,5 +1,5 @@
 ---
-"@readme/openapi-parser": minor
+'@readme/openapi-parser': minor
 ---
 
 Added pre-AJV validation for quirky security schemes. Surfaces clear, targeted errors (missing `type`, cross-type contamination, invalid `apiKey.in`, empty `oauth2.flows`, Swagger 2.0 ↔ OAS 3.x type confusion) instead of AJV's noisy `oneOf` failures, configurable via the new `invalid-security-scheme-properties` rule.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -32,6 +32,14 @@ const UNSUPPORTED_SCHEMA_PROPS = [
   'xml',
 ] as const;
 
+/**
+ * Annotation-only keywords we preserve when they appear as siblings of `$ref` inside `allOf`
+ * properties. Validation keywords (`type`, `properties`, `items`, etc.) are intentionally
+ * excluded, they would conflict with the resolved schema. `x-` extensions are also preserved
+ * (handled separately at the call site).
+ */
+const METADATA_SIBLING_KEYS = new Set(['description', 'summary', 'title']);
+
 const mergeAllOfSchemasOptions: JSONSchemaMergeAllOfOptions = {
   ignoreAdditionalProperties: true,
   resolvers: {
@@ -233,24 +241,38 @@ function inlinePropertyRefsForMerge(
 
       const resolved = usedSchemas.get(val.$ref);
       if (resolved !== undefined && !isPendingSchema(resolved)) {
-        // Preserve metadata siblings (e.g. description, summary) alongside the `$ref` pointer so
-        // they survive `allOf` merging.
+        // Preserve metadata-only siblings (e.g. `description`, `title`) alongside a `$ref` so
+        // they survive `allOf` merging. Validation keywords (`properties`, `items`, `type`, etc.)
+        // are dropped.
         //
-        // NOTE: This deviates a little bit from the 3.0 spec but is necessary
-        // to avoid losing metadata when inlining `$ref` schemas into `allOf`. Also just better
-        // user experience to keep the metadata around.
+        // The spec treats `{$ref: "..."}` in a schema slot differently across versions:
         //
-        // OpenAPI 3.0 requires us to strip everything, see:
-        // https://swagger.io/docs/specification/v3_0/using-ref/#:~:text=%24ref%20and%20Sibling%20Elements
+        // - OAS 3.0: it becomes a Reference Object (the Schema Object section says "a Reference
+        //   Object can be used in its place"), and Reference Objects forbid siblings. So 3.0
+        //   strips everything.
+        //   https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.4.md#schema-object
+        //   https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.4.md#reference-object
         //
-        // OpenAPI 3.1 permits us! OAS 3.1 Schema Object is "a superset of the JSON Schema Specification
-        // Draft 2020-12", see:
-        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object
+        // - OAS 3.1: it stays a Schema Object with `$ref` as a JSON Schema 2020-12 keyword. Per
+        //   JSON Schema 2020-12 §8.2.3.1, "$ref" is an applicator whose "results are the results
+        //   of the referenced schema", and the spec explicitly notes that "other keywords can
+        //   appear alongside of '$ref' in the same schema object". Those siblings are part of
+        //   the same schema; the spec doesn't say a `$ref` causes them to be dropped.
+        //   https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#schema-object
+        //   https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-8.2.3.1
         //
-        // …and it explicitly states that "other keywords can appear alongside of `$ref` in the same schema
-        // object", see:
-        // https://json-schema.org/draft/2020-12/json-schema-core#name-direct-references-with-ref
-        const { $ref: _$ref, properties: _propertiesWithRef, ...siblings } = val as Record<string, unknown>;
+        // We flatten via spread, so validation siblings would silently override the resolved
+        // schema rather than evaluate alongside it. Dropping them is the safer call; metadata
+        // siblings are safe to spread on top.
+        //
+        // TODO: evaluate validation siblings alongside the resolved schema
+
+        const siblings: Record<string, unknown> = {};
+        for (const siblingKey of Object.keys(val)) {
+          if (METADATA_SIBLING_KEYS.has(siblingKey) || siblingKey.startsWith('x-')) {
+            siblings[siblingKey] = (val as Record<string, unknown>)[siblingKey];
+          }
+        }
         out.properties[key] = {
           ...structuredClone(resolved),
           ...siblings,

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -233,8 +233,27 @@ function inlinePropertyRefsForMerge(
 
       const resolved = usedSchemas.get(val.$ref);
       if (resolved !== undefined && !isPendingSchema(resolved)) {
+        // Preserve metadata siblings (e.g. description, summary) alongside the `$ref` pointer so
+        // they survive `allOf` merging.
+        //
+        // NOTE: This deviates a little bit from the 3.0 spec but is necessary
+        // to avoid losing metadata when inlining `$ref` schemas into `allOf`. Also just better
+        // user experience to keep the metadata around.
+        //
+        // OpenAPI 3.0 requires us to strip everything, see:
+        // https://swagger.io/docs/specification/v3_0/using-ref/#:~:text=%24ref%20and%20Sibling%20Elements
+        //
+        // OpenAPI 3.1 permits us! OAS 3.1 Schema Object is "a superset of the JSON Schema Specification
+        // Draft 2020-12", see:
+        // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object
+        //
+        // …and it explicitly states that "other keywords can appear alongside of `$ref` in the same schema
+        // object", see:
+        // https://json-schema.org/draft/2020-12/json-schema-core#name-direct-references-with-ref
+        const { $ref: _$ref, properties: _propertiesWithRef, ...siblings } = val as Record<string, unknown>;
         out.properties[key] = {
           ...structuredClone(resolved),
+          ...siblings,
         };
       }
     } else if (val && typeof val === 'object' && !Array.isArray(val)) {

--- a/packages/oas/test/__datasets__/issues/CX-3276.json
+++ b/packages/oas/test/__datasets__/issues/CX-3276.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Test", "version": "1.0.0" },
+  "paths": {
+    "/endpoint": {
+      "post": {
+        "operationId": "createItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Error" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        }
+      },
+      "Base": {
+        "type": "object",
+        "description": "Base schema",
+        "properties": {
+          "baseField": { "type": "integer" }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "description": "Tag entity"
+      },
+      "Error": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Base" },
+          {
+            "type": "object",
+            "required": ["code", "message"],
+            "properties": {
+              "code": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "The code of the error",
+                "summary": "Error code"
+              },
+              "stripMe": {
+                "$ref": "#/components/schemas/Pet",
+                "properties": {
+                  "deepRef": { "$ref": "#/components/schemas/Tag" }
+                }
+              },
+              "message": { "type": "string" }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/oas/test/__datasets__/issues/CX-3276.json
+++ b/packages/oas/test/__datasets__/issues/CX-3276.json
@@ -20,6 +20,7 @@
     "schemas": {
       "Pet": {
         "type": "object",
+        "description": "A pet entity",
         "required": ["id", "name"],
         "properties": {
           "id": { "type": "integer", "format": "int64" },
@@ -44,16 +45,61 @@
             "type": "object",
             "required": ["code", "message"],
             "properties": {
-              "code": {
-                "$ref": "#/components/schemas/Pet",
-                "description": "The code of the error",
-                "summary": "Error code"
+              "bareRef": {
+                "$ref": "#/components/schemas/Pet"
               },
-              "stripMe": {
+              "withDescription": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "A custom description"
+              },
+              "withSummary": {
+                "$ref": "#/components/schemas/Pet",
+                "summary": "Pet summary"
+              },
+              "withTitle": {
+                "$ref": "#/components/schemas/Pet",
+                "title": "Pet Title"
+              },
+              "withExtensions": {
+                "$ref": "#/components/schemas/Pet",
+                "x-foo": "bar",
+                "x-custom-flag": true
+              },
+              "withAllMetadata": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "All metadata",
+                "summary": "All summary",
+                "title": "All title",
+                "x-tag": "yes"
+              },
+              "overrideDescription": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "Sibling wins"
+              },
+              "stripProperties": {
                 "$ref": "#/components/schemas/Pet",
                 "properties": {
                   "deepRef": { "$ref": "#/components/schemas/Tag" }
                 }
+              },
+              "stripItems": {
+                "$ref": "#/components/schemas/Pet",
+                "items": { "type": "string" }
+              },
+              "stripValidation": {
+                "$ref": "#/components/schemas/Pet",
+                "type": "string",
+                "enum": ["a", "b"],
+                "required": ["foo"],
+                "pattern": "^x"
+              },
+              "mixedKeepsMetadataDropsValidation": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "Mixed kept",
+                "x-keep": "yes",
+                "properties": { "fakeField": { "type": "string" } },
+                "type": "string",
+                "enum": ["x"]
               },
               "message": { "type": "string" }
             }

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -1940,29 +1940,79 @@ describe('.getParametersAsJSONSchema()', () => {
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
 
-      it('should preserve sibling `description` and strip invalid sibling `properties` next to a property `$ref` inside `allOf`', async () => {
+      describe('`$ref` siblings inside `allOf` properties', () => {
         const oas = Oas.init(structuredClone(cx3276));
         const operation = oas.operation('/endpoint', 'post');
         const schemas = operation.getParametersAsJSONSchema();
 
-        expect(schemas).not.toBeNull();
-
         const bodySchema = schemas?.find(s => s.type === 'body');
         const error = bodySchema?.schema?.components?.schemas?.Error as Record<string, unknown>;
-        const errorProps = error?.properties as Record<string, Record<string, unknown>>;
+        const props = error?.properties as Record<string, Record<string, unknown>>;
 
-        const code = errorProps?.code;
-        expect(code?.description).toBe('The code of the error');
-        expect(code?.summary).toBe('Error code');
-        expect(code).toHaveProperty('properties.id');
-        expect(code).toHaveProperty('properties.name');
+        it('resolves a bare `$ref` to the referenced schema', () => {
+          expect(props.bareRef?.description).toBe('A pet entity');
+          expect(props.bareRef).toHaveProperty('properties.id');
+        });
 
-        const stripMe = errorProps?.stripMe;
-        expect(stripMe).toHaveProperty('properties.id');
-        expect(stripMe).toHaveProperty('properties.name');
-        expect(stripMe?.properties).not.toHaveProperty('deepRef');
+        it('preserves a `description` sibling', () => {
+          expect(props.withDescription?.description).toBe('A custom description');
+          expect(props.withDescription).toHaveProperty('properties.id');
+        });
 
-        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+        it('preserves a `summary` sibling', () => {
+          expect(props.withSummary?.summary).toBe('Pet summary');
+        });
+
+        it('preserves a `title` sibling', () => {
+          expect(props.withTitle?.title).toBe('Pet Title');
+        });
+
+        it('preserves `x-` extension siblings', () => {
+          expect(props.withExtensions?.['x-foo']).toBe('bar');
+          expect(props.withExtensions?.['x-custom-flag']).toBe(true);
+        });
+
+        it('preserves all metadata siblings together', () => {
+          expect(props.withAllMetadata).toMatchObject({
+            description: 'All metadata',
+            summary: 'All summary',
+            title: 'All title',
+            'x-tag': 'yes',
+          });
+        });
+
+        it('lets a sibling `description` override the resolved schema description', () => {
+          expect(props.overrideDescription?.description).toBe('Sibling wins');
+        });
+
+        it('drops a sibling `properties`', () => {
+          expect(props.stripProperties).toHaveProperty('properties.id');
+          expect(props.stripProperties?.properties).not.toHaveProperty('deepRef');
+        });
+
+        it('drops a sibling `items`', () => {
+          expect(props.stripItems).not.toHaveProperty('items');
+          expect(props.stripItems).toHaveProperty('properties.id');
+        });
+
+        it('drops sibling validation keywords (`type`, `enum`, `required`, `pattern`)', () => {
+          expect(props.stripValidation?.type).toBe('object');
+          expect(props.stripValidation?.required).toStrictEqual(['id', 'name']);
+          expect(props.stripValidation).not.toHaveProperty('enum');
+          expect(props.stripValidation).not.toHaveProperty('pattern');
+        });
+
+        it('keeps metadata while dropping validation siblings on the same property', () => {
+          const mixed = props.mixedKeepsMetadataDropsValidation;
+          expect(mixed).toMatchObject({ description: 'Mixed kept', 'x-keep': 'yes', type: 'object' });
+          expect(mixed).not.toHaveProperty('enum');
+          expect(mixed).toHaveProperty('properties.id');
+          expect(mixed?.properties).not.toHaveProperty('fakeField');
+        });
+
+        it('produces a valid JSON Schema for the entire document', async () => {
+          await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+        });
       });
 
       it('should deep-merge `allOf` when nested properties at the same path both use `$ref`', async () => {

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -30,6 +30,7 @@ import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' 
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
 import cx3213 from '../../__datasets__/issues/CX-3213.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
+import cx3276 from '../../__datasets__/issues/CX-3276.json' with { type: 'json' };
 import cx3280 from '../../__datasets__/issues/CX-3280.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
@@ -1935,6 +1936,31 @@ describe('.getParametersAsJSONSchema()', () => {
         const typeEMetadata = (typeE?.properties as Record<string, unknown>)?.metadata as Record<string, unknown>;
         expect(typeEMetadata).not.toHaveProperty('$ref');
         expect(typeEMetadata).toStrictEqual(typeDMetadata);
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should preserve sibling `description` and strip invalid sibling `properties` next to a property `$ref` inside `allOf`', async () => {
+        const oas = Oas.init(structuredClone(cx3276));
+        const operation = oas.operation('/endpoint', 'post');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const error = bodySchema?.schema?.components?.schemas?.Error as Record<string, unknown>;
+        const errorProps = error?.properties as Record<string, Record<string, unknown>>;
+
+        const code = errorProps?.code;
+        expect(code?.description).toBe('The code of the error');
+        expect(code?.summary).toBe('Error code');
+        expect(code).toHaveProperty('properties.id');
+        expect(code).toHaveProperty('properties.name');
+
+        const stripMe = errorProps?.stripMe;
+        expect(stripMe).toHaveProperty('properties.id');
+        expect(stripMe).toHaveProperty('properties.name');
+        expect(stripMe?.properties).not.toHaveProperty('deepRef');
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });


### PR DESCRIPTION
| 🚥 Resolves CX-3276 |
| :------------------- |

## 🧰 Changes

When a property under an `allOf` branch had `$ref` with sibling keywords (e.g. `description`, `summary`), the siblings were being dropped during property-ref inlining — so customers writing valid OAS 3.1 schemas like:

```json
"code": {
  "$ref": "#/components/schemas/Pet",
  "description": "The code of the error"
}
```

…would see `code` render without the description in API Explorer.

This PR updates `inlinePropertyRefsForMerge` to spread the original `$ref` siblings on top of the resolved schema, mirroring the existing top-level `$ref` sibling-preservation pattern. The invalid `properties` is still stripped to prevent another occurrence of [CX-3171](https://linear.app/readme-io/issue/CX-3171) (added a regression test as well)

> [!NOTE]
this does deviate from the original OpenAPI 3.0 spec. in version 3.0, `refs` need ALL their sibling props removed including `description` and `summary`, see [here](https://swagger.io/docs/specification/v3_0/using-ref/). but this preservation does align with the OpenAPI 3.1 spec: [here](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object) and [here](https://json-schema.org/draft/2020-12/json-schema-core#name-direct-references-with-ref)

## 🧬 QA & Testing

Added `CX-3276.json` fixture and a regression test in `get-parameters-as-json-schema.test.ts` covering both shapes below.

<details>
<summary>Testing Details</summary>

### 1. Preserve `description` / `summary` (CX-3276)

**Input**: property `code` with `$ref` plus sibling `description` and `summary`:

```json
"Error": {
  "allOf": [
    { "$ref": "#/components/schemas/Base" },
    {
      "type": "object",
      "properties": {
        "code": {
          "$ref": "#/components/schemas/Pet",
          "description": "The code of the error",
          "summary": "Error code"
        }
      }
    }
  ]
}
```

<table>
<thead>
<tr>
<th>❌ Before: siblings silently dropped</th>
<th>✅ After: <code>description</code> and <code>summary</code> survive</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```json
"code": {
  "type": "object",
  "x-readme-ref-name": "Pet",
  "properties": {
    "id": { "type": "integer", "format": "int64" },
    "name": { "type": "string" }
  }
}
```

</td>
<td>

```json
"code": {
  "type": "object",
  "x-readme-ref-name": "Pet",
  "description": "The code of the error",
  "summary": "Error code",
  "properties": {
    "id": { "type": "integer", "format": "int64" },
    "name": { "type": "string" }
  }
}
```

</td>
</tr>
</tbody>
</table>

### 2. Strip invalid `properties` sibling (CX-3171 regression)

**Input**: property `stripMe` with `$ref` plus an invalid `properties` sibling that contains a deeper `$ref` (this was the original CX-3171 crash shape):

```json
"stripMe": {
  "$ref": "#/components/schemas/Pet",
  "properties": {
    "deepRef": { "$ref": "#/components/schemas/Tag" }
  }
}
```

<table>
<thead>
<tr>
<th>❌ Before: would crash on the stray <code>deepRef</code></th>
<th>✅ After: invalid <code>properties</code> dropped, no leak</th>
</tr>
</thead>
<tbody>
<tr>
<td>

```
(crash in API Explorer — CX-3171)
```

</td>
<td>

```json
"stripMe": {
  "type": "object",
  "x-readme-ref-name": "Pet",
  "properties": {
    "id": { "type": "integer", "format": "int64" },
    "name": { "type": "string" }
  }
}
```

</td>
</tr>
</tbody>
</table>

The regression test asserts both shapes simultaneously, so any future change that removes the `properties` strip (or breaks sibling preservation) will fail.

</details>
