### PR TITLE
fix(oas): correctly resolve deeply nested ref schemas in allof merge

### DIFF
--- a/.changeset/cx-3312-deep-ref-chain-allof-merge.md
+++ b/.changeset/cx-3312-deep-ref-chain-allof-merge.md
@@ -2,4 +2,4 @@
 'oas': patch
 ---
 
-Deep-merge `allOf` branches when nested properties at the same path resolve through a chain of `$ref` schemas. Previously `inlinePropertyRefsForMerge` only inlined one ref level deep; if two branches reached the same property path through chained refs, the inner refs survived into `json-schema-merge-allof`, which silently kept only the first branch. Now allOf branches are scanned for conflicting property paths and refs along those paths are recursively inlined before merging. Non-conflicting refs are still preserved.
+Deep-merge `allOf` branches when nested properties at the same path resolve through a chain of `$ref` schemas. Previously `inlinePropertyRefsForMerge` only inlined one ref level deep; if two branches reached the same property path through chained refs, the inner refs survived into `json-schema-merge-allof`, which silently kept only the first branch. Now `allOf` branches are scanned for conflicting property paths and refs along those paths are recursively inlined before merging. Non-conflicting refs are still preserved.

--- a/.changeset/cx-3312-deep-ref-chain-allof-merge.md
+++ b/.changeset/cx-3312-deep-ref-chain-allof-merge.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Deep-merge `allOf` branches when nested properties at the same path resolve through a chain of `$ref` schemas. Previously `inlinePropertyRefsForMerge` only inlined one ref level deep; if two branches reached the same property path through chained refs, the inner refs survived into `json-schema-merge-allof`, which silently kept only the first branch. Now allOf branches are scanned for conflicting property paths and refs along those paths are recursively inlined before merging. Non-conflicting refs are still preserved.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -248,7 +248,13 @@ function inlinePropertyRefsForMerge(
       }
     } else if (val && typeof val === 'object' && !Array.isArray(val)) {
       if ('properties' in val) {
-        out.properties[key] = inlinePropertyRefsForMerge(val as SchemaObject, usedSchemas, refLogger, conflictPaths, path);
+        out.properties[key] = inlinePropertyRefsForMerge(
+          val as SchemaObject,
+          usedSchemas,
+          refLogger,
+          conflictPaths,
+          path,
+        );
       }
 
       // Inline allOf-path refs inside oneOf/anyOf to prevent synthetic allOf scaffolding.
@@ -269,10 +275,7 @@ function inlinePropertyRefsForMerge(
  * however, in theory, usedSchemas should already contain all the possible $refs since that should
  * be resolved and populated by toJSONSchema, the only caller of this function
  */
-function collectConflictPaths(
-  allOfBranches: SchemaObject[],
-  usedSchemas: Map<string, SchemaObject>,
-): Set<string> {
+function collectConflictPaths(allOfBranches: SchemaObject[], usedSchemas: Map<string, SchemaObject>): Set<string> {
   // Maps each property path to the number of branches that reach it.
   const pathBranchCount = new Map<string, number>();
 

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -224,7 +224,7 @@ function inlinePropertyRefsForMerge(
   usedSchemas: Map<string, SchemaObject>,
   refLogger: NonNullable<toJSONSchemaOptions['refLogger']>,
   conflictPaths?: Set<string>,
-  currentPath = '',
+  currentPath?: string,
 ): SchemaObject {
   const out = structuredClone(schema);
   if (!('properties' in out) || typeof out.properties !== 'object' || out.properties === null) {
@@ -332,7 +332,7 @@ function collectConflictPaths(allOfBranches: SchemaObject[], usedSchemas: Map<st
     pathBranchCount.set(path, (pathBranchCount.get(path) ?? 0) + 1);
   }
 
-  function walk(schema: unknown, path: string): void {
+  function walk(schema: unknown, path?: string): void {
     if (!isObject(schema)) return;
 
     // Resolve `$ref`s and keep walking from the resolved schema. If we re-enter a ref we're
@@ -362,7 +362,7 @@ function collectConflictPaths(allOfBranches: SchemaObject[], usedSchemas: Map<st
   for (const branch of allOfBranches) {
     pathsSeenInThisBranch.clear();
     refsCurrentlyResolving.clear();
-    walk(branch, '');
+    walk(branch);
   }
 
   const conflictPaths = new Set<string>();
@@ -873,7 +873,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
         const conflictPaths = collectConflictPaths(allOfSchemas, usedSchemas);
         schema = {
           ...schema,
-          allOf: allOfSchemas.map(s => inlinePropertyRefsForMerge(s, usedSchemas, refLogger, conflictPaths, '')),
+          allOf: allOfSchemas.map(s => inlinePropertyRefsForMerge(s, usedSchemas, refLogger, conflictPaths)),
         } as SchemaObject;
       }
 

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -215,6 +215,8 @@ function inlinePropertyRefsForMerge(
   schema: SchemaObject,
   usedSchemas: Map<string, SchemaObject>,
   refLogger: NonNullable<toJSONSchemaOptions['refLogger']>,
+  conflictPaths?: Set<string>,
+  currentPath = '',
 ): SchemaObject {
   const out = structuredClone(schema);
   if (!('properties' in out) || typeof out.properties !== 'object' || out.properties === null) {
@@ -222,6 +224,7 @@ function inlinePropertyRefsForMerge(
   }
 
   for (const key of Object.keys(out.properties)) {
+    const path = currentPath ? `${currentPath}.${key}` : key;
     const val = out.properties[key];
     if (isRef(val)) {
       // Do not inline `#/paths/...` refs when we merge `allOf` schemas together, they should
@@ -233,13 +236,19 @@ function inlinePropertyRefsForMerge(
 
       const resolved = usedSchemas.get(val.$ref);
       if (resolved !== undefined && !isPendingSchema(resolved)) {
-        out.properties[key] = {
-          ...structuredClone(resolved),
-        };
+        const inlined: SchemaObject = { ...structuredClone(resolved) };
+        const isConflictPath = conflictPaths?.has(path) ?? false;
+
+        // At conflict paths, recurse so nested `$ref`s in the chain are inlined too
+        // otherwise the merge sees a surviving `$ref` and drops sibling properties.
+        // NOTE: we only recurse down to the first non conflict path and not the full resolution
+        out.properties[key] = isConflictPath
+          ? inlinePropertyRefsForMerge(inlined, usedSchemas, refLogger, conflictPaths, path)
+          : inlined;
       }
     } else if (val && typeof val === 'object' && !Array.isArray(val)) {
       if ('properties' in val) {
-        out.properties[key] = inlinePropertyRefsForMerge(val as SchemaObject, usedSchemas, refLogger);
+        out.properties[key] = inlinePropertyRefsForMerge(val as SchemaObject, usedSchemas, refLogger, conflictPaths, path);
       }
 
       // Inline allOf-path refs inside oneOf/anyOf to prevent synthetic allOf scaffolding.
@@ -248,6 +257,73 @@ function inlinePropertyRefsForMerge(
   }
 
   return out;
+}
+
+/**
+ * Finds property paths that appear in two or more `allOf` branches. These are the paths where a
+ * surviving `$ref` would cause `json-schema-merge-allof` to drop sibling properties, so callers
+ * use this set to know where to deep-resolve refs before merging.
+ *
+ * usedSchemas isnt actually a must here. the walk does use that map for $ref resolution, but missing
+ * entries or a completely empty map will not cause any errors, it just wont find all the conflict paths.
+ * however, in theory, usedSchemas should already contain all the possible $refs since that should
+ * be resolved and populated by toJSONSchema, the only caller of this function
+ */
+function collectConflictPaths(
+  allOfBranches: SchemaObject[],
+  usedSchemas: Map<string, SchemaObject>,
+): Set<string> {
+  // Maps each property path to the number of branches that reach it.
+  const pathBranchCount = new Map<string, number>();
+
+  // Reset between branches.
+  const pathsSeenInThisBranch = new Set<string>();
+  const refsCurrentlyResolving = new Set<string>();
+
+  function recordPath(path: string): void {
+    if (pathsSeenInThisBranch.has(path)) return;
+    pathsSeenInThisBranch.add(path);
+    pathBranchCount.set(path, (pathBranchCount.get(path) ?? 0) + 1);
+  }
+
+  function walk(schema: unknown, path: string): void {
+    if (!isObject(schema)) return;
+
+    // Resolve `$ref`s and keep walking from the resolved schema. If we re-enter a ref we're
+    // already resolving, that's a circular reference. bail
+    if (typeof schema.$ref === 'string') {
+      const ref = schema.$ref;
+      const resolved = usedSchemas.get(ref);
+
+      // bail out if we see a ref we're already resolving, or if the ref is not resolved or is pending
+      // or even if the resolved schema doesnt exists in useSchemas
+      if (refsCurrentlyResolving.has(ref) || !resolved || isPendingSchema(resolved)) return;
+
+      refsCurrentlyResolving.add(ref);
+      walk(resolved, path);
+      refsCurrentlyResolving.delete(ref);
+      return;
+    }
+
+    if (!isObject(schema.properties)) return;
+    for (const [propertyName, childSchema] of Object.entries(schema.properties)) {
+      const childPath = path ? `${path}.${propertyName}` : propertyName;
+      recordPath(childPath);
+      walk(childSchema, childPath);
+    }
+  }
+
+  for (const branch of allOfBranches) {
+    pathsSeenInThisBranch.clear();
+    refsCurrentlyResolving.clear();
+    walk(branch, '');
+  }
+
+  const conflictPaths = new Set<string>();
+  for (const [path, branchCount] of pathBranchCount) {
+    if (branchCount > 1) conflictPaths.add(path);
+  }
+  return conflictPaths;
 }
 
 /**
@@ -746,9 +822,12 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
           return toJSONSchema(item as SchemaObject, allOfOptions);
         });
 
+        // Find paths reached by 2+ branches, then inline each branch with deep recursion at
+        // those conflict paths.
+        const conflictPaths = collectConflictPaths(allOfSchemas, usedSchemas);
         schema = {
           ...schema,
-          allOf: allOfSchemas.map(s => inlinePropertyRefsForMerge(s, usedSchemas, refLogger)),
+          allOf: allOfSchemas.map(s => inlinePropertyRefsForMerge(s, usedSchemas, refLogger, conflictPaths, '')),
         } as SchemaObject;
       }
 

--- a/packages/oas/test/__datasets__/issues/CX-3312.json
+++ b/packages/oas/test/__datasets__/issues/CX-3312.json
@@ -32,15 +32,10 @@
   "components": {
     "schemas": {
       "UpdateRequest": {
-        "allOf": [
-          { "$ref": "#/components/schemas/BaseRequest" },
-          { "$ref": "#/components/schemas/SettingsWithExtras" }
-        ]
+        "allOf": [{ "$ref": "#/components/schemas/BaseRequest" }, { "$ref": "#/components/schemas/SettingsWithExtras" }]
       },
       "BaseRequest": {
-        "allOf": [
-          { "$ref": "#/components/schemas/Settings" }
-        ]
+        "allOf": [{ "$ref": "#/components/schemas/Settings" }]
       },
       "Settings": {
         "type": "object",
@@ -112,7 +107,7 @@
           { "$ref": "#/components/schemas/B" }
         ]
       },
-      "B":    { "type": "object", "properties": { "l1": { "$ref": "#/components/schemas/B_l1" } } },
+      "B": { "type": "object", "properties": { "l1": { "$ref": "#/components/schemas/B_l1" } } },
       "B_l1": { "type": "object", "properties": { "l2": { "$ref": "#/components/schemas/B_l2" } } },
       "B_l2": { "type": "object", "properties": { "l3": { "$ref": "#/components/schemas/B_l3" } } },
       "B_l3": { "type": "object", "properties": { "l4": { "$ref": "#/components/schemas/B_l4" } } },

--- a/packages/oas/test/__datasets__/issues/CX-3312.json
+++ b/packages/oas/test/__datasets__/issues/CX-3312.json
@@ -1,0 +1,123 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test", "version": "1.0.0" },
+  "paths": {
+    "/endpoint": {
+      "patch": {
+        "operationId": "updateItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/deep-chain": {
+      "patch": {
+        "operationId": "updateDeepChainItem",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/DeepChainRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UpdateRequest": {
+        "allOf": [
+          { "$ref": "#/components/schemas/BaseRequest" },
+          { "$ref": "#/components/schemas/SettingsWithExtras" }
+        ]
+      },
+      "BaseRequest": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Settings" }
+        ]
+      },
+      "Settings": {
+        "type": "object",
+        "properties": {
+          "settings": { "$ref": "#/components/schemas/Settings_settings" }
+        }
+      },
+      "Settings_settings": {
+        "type": "object",
+        "properties": {
+          "notifications": { "$ref": "#/components/schemas/Settings_settings_notifications" }
+        }
+      },
+      "Settings_settings_notifications": {
+        "type": "object",
+        "properties": {
+          "channel": { "type": "string", "enum": ["email", "sms"] }
+        }
+      },
+      "SettingsWithExtras": {
+        "type": "object",
+        "properties": {
+          "settings": { "$ref": "#/components/schemas/SettingsWithExtras_settings" }
+        }
+      },
+      "SettingsWithExtras_settings": {
+        "type": "object",
+        "properties": {
+          "notifications": { "$ref": "#/components/schemas/SettingsWithExtras_settings_notifications" }
+        }
+      },
+      "SettingsWithExtras_settings_notifications": {
+        "type": "object",
+        "properties": {
+          "muted": { "type": "boolean", "default": false }
+        }
+      },
+      "DeepChainRequest": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "l1": {
+                "type": "object",
+                "properties": {
+                  "l2": {
+                    "type": "object",
+                    "properties": {
+                      "l3": {
+                        "type": "object",
+                        "properties": {
+                          "l4": {
+                            "type": "object",
+                            "properties": {
+                              "l5": {
+                                "type": "object",
+                                "properties": { "fromA": { "type": "string" } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          { "$ref": "#/components/schemas/B" }
+        ]
+      },
+      "B":    { "type": "object", "properties": { "l1": { "$ref": "#/components/schemas/B_l1" } } },
+      "B_l1": { "type": "object", "properties": { "l2": { "$ref": "#/components/schemas/B_l2" } } },
+      "B_l2": { "type": "object", "properties": { "l3": { "$ref": "#/components/schemas/B_l3" } } },
+      "B_l3": { "type": "object", "properties": { "l4": { "$ref": "#/components/schemas/B_l4" } } },
+      "B_l4": { "type": "object", "properties": { "l5": { "$ref": "#/components/schemas/B_l5" } } },
+      "B_l5": { "type": "object", "properties": { "fromB": { "type": "string" } } }
+    }
+  }
+}

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -29,9 +29,9 @@ import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' 
 import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' };
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
 import cx3213 from '../../__datasets__/issues/CX-3213.json' with { type: 'json' };
-import cx3312 from '../../__datasets__/issues/CX-3312.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
 import cx3280 from '../../__datasets__/issues/CX-3280.json' with { type: 'json' };
+import cx3312 from '../../__datasets__/issues/CX-3312.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
@@ -2013,9 +2013,7 @@ describe('.getParametersAsJSONSchema()', () => {
             const next = i === DEPTH - 1 ? null : `B_${i + 1}`;
             componentSchemas[`B_${i}`] = {
               type: 'object',
-              properties: next
-                ? { lvl: { $ref: `#/components/schemas/${next}` } }
-                : { fromB: { type: 'string' } },
+              properties: next ? { lvl: { $ref: `#/components/schemas/${next}` } } : { fromB: { type: 'string' } },
             };
           }
 
@@ -2053,8 +2051,10 @@ describe('.getParametersAsJSONSchema()', () => {
 
           expect(schemas).not.toBeNull();
 
-          let cursor = (schemas?.find(s => s.type === 'body')?.schema?.components?.schemas?.Root ??
-            {}) as Record<string, unknown>;
+          let cursor = (schemas?.find(s => s.type === 'body')?.schema?.components?.schemas?.Root ?? {}) as Record<
+            string,
+            unknown
+          >;
           for (let i = 0; i < DEPTH - 1; i += 1) {
             cursor = (cursor.properties as Record<string, Record<string, unknown>> | undefined)?.lvl ?? {};
           }

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -29,6 +29,7 @@ import cx3194 from '../../__datasets__/issues/CX-3194.json' with { type: 'json' 
 import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' };
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
 import cx3213 from '../../__datasets__/issues/CX-3213.json' with { type: 'json' };
+import cx3312 from '../../__datasets__/issues/CX-3312.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
 import cx3280 from '../../__datasets__/issues/CX-3280.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
@@ -1959,6 +1960,110 @@ describe('.getParametersAsJSONSchema()', () => {
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
+
+      it('should deep-merge `allOf` when nested properties resolve via a chain of `$ref` schemas', async () => {
+        const oas = Oas.init(structuredClone(cx3312));
+        const operation = oas.operation('/endpoint', 'patch');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const updateRequest = bodySchema?.schema?.components?.schemas?.UpdateRequest as Record<string, unknown>;
+        const settings = (updateRequest?.properties as Record<string, unknown>)?.settings as Record<string, unknown>;
+        const notificationsSchema = (settings?.properties as Record<string, unknown>)?.notifications as
+          | Record<string, unknown>
+          | undefined;
+
+        expect(notificationsSchema).toBeDefined();
+        expect(notificationsSchema?.properties).toHaveProperty('channel');
+        expect(notificationsSchema?.properties).toHaveProperty('muted');
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should deep-merge `allOf` when one branch has a 5-level `$ref` chain and the other is fully inline', async () => {
+        const oas = Oas.init(structuredClone(cx3312));
+        const operation = oas.operation('/deep-chain', 'patch');
+        const schemas = operation.getParametersAsJSONSchema();
+
+        expect(schemas).not.toBeNull();
+
+        const bodySchema = schemas?.find(s => s.type === 'body');
+        const deepChainRequest = bodySchema?.schema?.components?.schemas?.DeepChainRequest as Record<string, unknown>;
+        const props = deepChainRequest?.properties as Record<string, Record<string, unknown>>;
+        const leaf = props?.l1?.properties?.l2?.properties?.l3?.properties?.l4?.properties?.l5 as
+          | Record<string, unknown>
+          | undefined;
+
+        expect(leaf).toBeDefined();
+        expect(leaf?.properties).toHaveProperty('fromA');
+        expect(leaf?.properties).toHaveProperty('fromB');
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it(
+        'should resolve a 100-level `$ref` chain in `allOf` merge within a tight time budget',
+        { timeout: 1000 },
+        async () => {
+          const DEPTH = 100;
+          const componentSchemas: Record<string, unknown> = {};
+          for (let i = 0; i < DEPTH; i += 1) {
+            const next = i === DEPTH - 1 ? null : `B_${i + 1}`;
+            componentSchemas[`B_${i}`] = {
+              type: 'object',
+              properties: next
+                ? { lvl: { $ref: `#/components/schemas/${next}` } }
+                : { fromB: { type: 'string' } },
+            };
+          }
+
+          let inlineLeaf: Record<string, unknown> = {
+            type: 'object',
+            properties: { fromA: { type: 'string' } },
+          };
+          for (let i = 0; i < DEPTH - 1; i += 1) {
+            inlineLeaf = { type: 'object', properties: { lvl: inlineLeaf } };
+          }
+
+          componentSchemas.Root = {
+            allOf: [inlineLeaf, { $ref: '#/components/schemas/B_0' }],
+          };
+
+          const spec = {
+            openapi: '3.0.0',
+            info: { title: 'Deep chain bench', version: '1.0.0' },
+            paths: {
+              '/endpoint': {
+                patch: {
+                  requestBody: {
+                    content: { 'application/json': { schema: { $ref: '#/components/schemas/Root' } } },
+                  },
+                  responses: { '200': { description: 'OK' } },
+                },
+              },
+            },
+            components: { schemas: componentSchemas },
+          };
+
+          const oas = Oas.init(spec);
+          const operation = oas.operation('/endpoint', 'patch');
+          const schemas = operation.getParametersAsJSONSchema();
+
+          expect(schemas).not.toBeNull();
+
+          let cursor = (schemas?.find(s => s.type === 'body')?.schema?.components?.schemas?.Root ??
+            {}) as Record<string, unknown>;
+          for (let i = 0; i < DEPTH - 1; i += 1) {
+            cursor = (cursor.properties as Record<string, Record<string, unknown>> | undefined)?.lvl ?? {};
+          }
+          expect(cursor.properties).toHaveProperty('fromA');
+          expect(cursor.properties).toHaveProperty('fromB');
+
+          await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+        },
+      );
     });
   });
 


### PR DESCRIPTION
| 🚥 Resolves CX-3312 |
| :------------------- |

## 🧰 Changes

This is a follow-up to CX-3213. That fix made `inlinePropertyRefsForMerge` recurse into nested `properties` objects, but only when the property *value* was already concrete. When the value was itself a `$ref` likely chained `$refs`, it inlined one hop and stopped. 

If two `allOf` branches reach the same property path through chained refs, the surviving inner `$ref` collides with the other branch's content during merge, and downstream `$ref`-sibling cleanup strips everyone's properties.

<details>
<summary>Walkthrough of the bug with a minimal schema</summary>

### Setup

```jsonc
allOf: [
  // branch A — fully inline
  { properties: { email: { properties: { nested: { properties: { fromA } } } } } },

  // branch B — chain of refs
  { properties: { email: { $ref: "EmailRef" } } }
]

EmailRef    = { properties: { nested: { $ref: "EmailNested" } } }   // ← chained
EmailNested = { properties: { fromB } }
```

Both branches reach `email.nested`.

### Step 1 — old single-hop inlining on branch B

```jsonc
B = {
  properties: {
    email: {                            // ← $ref replaced (one hop)
      properties: {
        nested: { $ref: "EmailNested" } // ← survived, NOT inlined
      }
    }
  }
}
```

### Step 2 — what the merge sees at `email.nested`

```jsonc
A.email.nested = { properties: { fromA } }
B.email.nested = { $ref: "EmailNested" }
```

### Step 3 — merge produces

```jsonc
email.nested = {
  $ref: "EmailNested",
  properties: { fromA }   // briefly survives
}
```

### Step 4 — `$ref`-sibling cleanup runs

OpenAPI 3.0 says `$ref` can't have siblings, so cleanup strips them:

```jsonc
email.nested = {
  $ref: "EmailNested"
  // ✗ properties: { fromA }   stripped
}
```

The renderer follows `$ref` to `EmailNested`, gets `{ fromB }`, and shows only that. `fromA` is gone.

That's the bug: a `$ref` survived past one inlining hop, hit a conflict path, and triggered the sibling-strip.

</details>

## 🛠 The fix

Introduces a `collectConflictPaths` helper that walks every `allOf` branch, following `$ref`s through the existing `usedSchemas` cache and returns property paths reached by 2+ branches. 

`inlinePropertyRefsForMerge` then takes that set as input: at conflict paths it inlines AND recurses into the just-inlined value 

> [!NOTE]
the deep `$ref` resolution is only fixing UP UNTIL the conflict paths, once in a non conflicting path it hops ONE last time and then preserves the rest. this is inline with the strategy `toJSONSchema` currently has. we could in theory recurse to resolve it entirely but then it may very likely bloat the schema and produce unnecessarily large schemas

## 🧬 QA & Testing

