### PR TITLE
feat(oas-to-har): respect content-type header incoming from form data

### DIFF
--- a/.changeset/neat-birds-look.md
+++ b/.changeset/neat-birds-look.md
@@ -1,0 +1,5 @@
+---
+"@readme/oas-to-har": minor
+---
+
+oasToHar respects content-type from form data

--- a/.changeset/neat-birds-look.md
+++ b/.changeset/neat-birds-look.md
@@ -2,4 +2,4 @@
 '@readme/oas-to-har': minor
 ---
 
-oasToHar respects content-type from form data
+HAR composition for requests including `formData` should respect the `content-type` header available.

--- a/.changeset/neat-birds-look.md
+++ b/.changeset/neat-birds-look.md
@@ -1,5 +1,5 @@
 ---
-"@readme/oas-to-har": minor
+'@readme/oas-to-har': minor
 ---
 
 oasToHar respects content-type from form data

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -401,6 +401,17 @@ export default function oasToHar(
   }
 
   if (formData.header) {
+    // Do we have a `content-type` header set up in the form data, but it hasn't been added yet?
+    const contentTypeFormHeader = Object.keys(formData.header).find(h => h.toLowerCase() === 'content-type');
+    if (contentTypeFormHeader && !har.headers.find(hdr => hdr.name.toLowerCase() === 'content-type')) {
+      hasContentType = true;
+      contentType = String(formData.header[contentTypeFormHeader]);
+      har.headers.push({
+        name: 'content-type',
+        value: contentType,
+      });
+    }
+
     // Do we have an `accept` header set up in the form data, but it hasn't been added yet?
     const acceptHeader = Object.keys(formData.header).find(h => h.toLowerCase() === 'accept');
     if (acceptHeader && !har.headers.find(hdr => hdr.name.toLowerCase() === 'accept')) {

--- a/packages/oas-to-har/test/parameters.test.ts
+++ b/packages/oas-to-har/test/parameters.test.ts
@@ -812,6 +812,26 @@ describe('parameter handling', () => {
     );
 
     it(
+      'should add `content-type` header if specified in formdata',
+      assertHeaders(
+        {
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { type: 'object' },
+              },
+              'application/x-www-form-urlencoded': {
+                schema: { type: 'object' },
+              },
+            },
+          },
+        },
+        { header: { 'content-type': 'application/x-www-form-urlencoded' } },
+        [{ name: 'content-type', value: 'application/x-www-form-urlencoded' }],
+      ),
+    );
+
+    it(
       'should add falsy values to the headers',
       assertHeaders(
         {


### PR DESCRIPTION
| 🚥 Resolves RM-4392 |
| :------------------- |

## 🧰 Changes

- respect content-type from form data, which will update the code snippet/"try it" window's content-type as the user changes the header in the api explorer.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
