### PR TITLE
feat: allow empty arrays in json request body

### DIFF
--- a/.changeset/polite-arrays-smile.md
+++ b/.changeset/polite-arrays-smile.md
@@ -1,0 +1,5 @@
+---
+'@readme/oas-to-har': patch
+---
+
+Preserve explicit empty arrays in JSON request bodies when generating HAR payloads.

--- a/.changeset/polite-arrays-smile.md
+++ b/.changeset/polite-arrays-smile.md
@@ -2,4 +2,4 @@
 '@readme/oas-to-har': patch
 ---
 
-Preserve explicit empty arrays in JSON request bodies when generating HAR payloads.
+Preserve explicit empty arrays in JSON request payloads when generating HAR payloads.

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -162,6 +162,7 @@ function stringify(json: Record<string | 'RAW_BODY', unknown>) {
   return JSON.stringify(
     removeUndefinedObjects(typeof json.RAW_BODY !== 'undefined' ? json.RAW_BODY : json, {
       preserveNullishArrays: true,
+      preserveEmptyArray: true,
     }),
   );
 }
@@ -471,7 +472,10 @@ export default function oasToHar(
 
       if (isMultipart || isJSON) {
         try {
-          let cleanBody = removeUndefinedObjects(formData.body, { preserveNullishArrays: true });
+          let cleanBody = removeUndefinedObjects(formData.body, {
+            preserveNullishArrays: true,
+            preserveEmptyArray: true,
+          });
 
           if (isMultipart) {
             har.postData = { params: [], mimeType: 'multipart/form-data' };

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -342,6 +342,51 @@ describe('request body handling', () => {
       expect(har.log.entries[0].request.postData?.text).toBeUndefined();
     });
 
+    it('should preserve empty arrays in JSON request body properties', () => {
+      const spec = Oas.init({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        tags: {
+                          type: 'array',
+                          items: {
+                            type: 'string',
+                          },
+                        },
+                        metadata: {
+                          type: 'object',
+                          properties: {
+                            reviews: {
+                              type: 'array',
+                              items: {
+                                type: 'object',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+        body: { tags: [], metadata: { reviews: [] }, omitted: undefined },
+      });
+
+      expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ tags: [], metadata: { reviews: [] } }));
+    });
+
     // When we first render the form, `formData.body` is `undefined` until something is typed into
     // the form. When using anyOf/oneOf if we change the schema before typing anything into the
     // form, then `onChange` is fired with `undefined` which causes this to error.
@@ -447,6 +492,12 @@ describe('request body handling', () => {
         const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: { a: 'test' } } });
 
         expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ a: 'test' }));
+      });
+
+      it('should preserve empty arrays in `RAW_BODY` objects', () => {
+        const har = oasToHar(spec, spec.operation('/objects', 'post'), { body: { RAW_BODY: { a: [] } } });
+
+        expect(har.log.entries[0].request.postData?.text).toBe(JSON.stringify({ a: [] }));
       });
 
       it('should work for `RAW_BODY` objects (but data is a primitive somehow)', () => {


### PR DESCRIPTION
| 🚥 Resolves [CX-3296](https://linear.app/readme-io/issue/CX-3296/feature-request-ability-to-add-and-send-empty-arrays-in-try-it) | 🤖 Prepared with `/prep-pr` |
| :------------------------------------------------------------------------------------------------------------------------------ | :------------------------- |

## 🧰 Changes

Preserves explicit empty arrays in JSON request bodies when `@readme/oas-to-har` removes undefined values before generating HAR payloads. This covers both regular JSON request bodies and ReadMe `RAW_BODY` object payloads, while still omitting undefined properties.

## 👥 Customer Impact

Customers using Try It! with JSON request examples or defaults that intentionally contain `[]` can send those empty arrays instead of having them stripped from the generated request payload.

## 🧬 QA & Testing

- Test file:  [cx-3296-empty-arrays.json](https://github.com/user-attachments/files/27355755/cx-3296-empty-arrays.json)
- Ensure that empty arrays are preserved in both the code snippet and request

Related downstream PR: https://github.com/readmeio/readme/pull/18593