### PR TITLE
fix: use deep nested object style in multipart form data by default

### DIFF
--- a/.changeset/nested-multipart-objects.md
+++ b/.changeset/nested-multipart-objects.md
@@ -1,0 +1,5 @@
+---
+'@readme/oas-to-har': patch
+---
+
+Default nested `multipart/form-data` object fields to bracket notation when no explicit encoding is supplied.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9923,7 +9923,6 @@
         "@readme/oas-examples": "file:../oas-examples",
         "@types/har-format": "^1.2.15",
         "@types/qs": "^6.15.0",
-        "fetch-har": "^11.1.1",
         "jest-expect-har": "^10.0.2",
         "tsup": "^8.5.0",
         "typescript": "^5.2.2",
@@ -9931,30 +9930,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/oas-to-har/node_modules/fetch-har": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-11.1.1.tgz",
-      "integrity": "sha512-FXmC4o6bqnMJ/ru/F1R+ik7QqYq8aWx7NZk6Xx4iQ/4jiVb4N/HUtd3BDBP8RT+UXFEndei4diHVqUd4vwsKGA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@readme/data-urls": "^3.0.0",
-        "@types/har-format": "^1.2.13"
-      },
-      "engines": {
-        "node": ">=18.13.0"
-      }
-    },
-    "packages/oas-to-har/node_modules/fetch-har/node_modules/@readme/data-urls": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-3.0.1.tgz",
-      "integrity": "sha512-N0JGQe7cmD3hqHwfsvkIsUOdUyUMVl3ezVFkMRuvYakNx47wGSkS83EiZR2gpidceOb9xZ3FVnst2D1sCqpRIg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/oas-to-snippet": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9911,7 +9911,7 @@
     },
     "packages/oas-to-har": {
       "name": "@readme/oas-to-har",
-      "version": "33.0.0",
+      "version": "33.1.0",
       "license": "ISC",
       "dependencies": {
         "@readme/data-urls": "^4.0.2",
@@ -9923,6 +9923,7 @@
         "@readme/oas-examples": "file:../oas-examples",
         "@types/har-format": "^1.2.15",
         "@types/qs": "^6.9.14",
+        "fetch-har": "^11.1.1",
         "jest-expect-har": "^10.0.1",
         "tsup": "^8.5.0",
         "typescript": "^5.2.2",
@@ -9930,6 +9931,30 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/oas-to-har/node_modules/fetch-har": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-har/-/fetch-har-11.1.1.tgz",
+      "integrity": "sha512-FXmC4o6bqnMJ/ru/F1R+ik7QqYq8aWx7NZk6Xx4iQ/4jiVb4N/HUtd3BDBP8RT+UXFEndei4diHVqUd4vwsKGA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@readme/data-urls": "^3.0.0",
+        "@types/har-format": "^1.2.13"
+      },
+      "engines": {
+        "node": ">=18.13.0"
+      }
+    },
+    "packages/oas-to-har/node_modules/fetch-har/node_modules/@readme/data-urls": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@readme/data-urls/-/data-urls-3.0.1.tgz",
+      "integrity": "sha512-N0JGQe7cmD3hqHwfsvkIsUOdUyUMVl3ezVFkMRuvYakNx47wGSkS83EiZR2gpidceOb9xZ3FVnst2D1sCqpRIg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/oas-to-snippet": {

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -57,6 +57,7 @@
     "@readme/oas-examples": "file:../oas-examples",
     "@types/har-format": "^1.2.15",
     "@types/qs": "^6.9.14",
+    "fetch-har": "^11.1.1",
     "jest-expect-har": "^10.0.1",
     "tsup": "^8.5.0",
     "typescript": "^5.2.2",

--- a/packages/oas-to-har/package.json
+++ b/packages/oas-to-har/package.json
@@ -57,7 +57,6 @@
     "@readme/oas-examples": "file:../oas-examples",
     "@types/har-format": "^1.2.15",
     "@types/qs": "^6.15.0",
-    "fetch-har": "^11.1.1",
     "jest-expect-har": "^10.0.2",
     "tsup": "^8.5.0",
     "typescript": "^5.2.2",

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -110,13 +110,25 @@ function multipartBodyToFormatterParams(payload: unknown, oasMediaTypeObject: Me
         }
 
         const paramEncoding = encoding ? encoding[key] : undefined;
+        const propertySchema = schema.properties[key];
+        const isObjectSchema = typeof propertySchema === 'object' && propertySchema !== null && !isRef(propertySchema);
+        const hasObjectType =
+          isObjectSchema &&
+          // OAS 3.1 uses JSON Schema union types, so object schemas can appear as
+          // `type: ['object', 'null']` or another union that includes `object`.
+          (Array.isArray(propertySchema.type)
+            ? propertySchema.type.includes('object')
+            : propertySchema.type === 'object');
+        const hasObjectProperties =
+          isObjectSchema && typeof propertySchema.properties === 'object' && propertySchema.properties !== null;
+        const shouldDefaultNestedMultipartObject = !paramEncoding && (hasObjectType || hasObjectProperties);
 
         return {
           name: key,
-          // If the style isn't defined, use the default
-          style: paramEncoding ? paramEncoding.style : undefined,
-          // If explode isn't defined, use the default
-          explode: paramEncoding ? paramEncoding.explode : undefined,
+          // Preserve nested multipart object paths as form fields unless the spec supplies explicit
+          // encoding for this property.
+          style: paramEncoding ? paramEncoding.style : shouldDefaultNestedMultipartObject ? 'deepObject' : undefined,
+          explode: paramEncoding ? paramEncoding.explode : shouldDefaultNestedMultipartObject ? true : undefined,
           required:
             (schema.required && typeof schema.required === 'boolean' && Boolean(schema.required)) ||
             (Array.isArray(schema.required) && schema.required.includes(key)),

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -1,7 +1,6 @@
 import circularRefs from '@readme/oas-examples/3.0/json/circular-request-bodies.json' with { type: 'json' };
 import fileUploads from '@readme/oas-examples/3.0/json/file-uploads.json' with { type: 'json' };
 import schemaTypes from '@readme/oas-examples/3.0/json/schema-types.json' with { type: 'json' };
-import fetchHAR from 'fetch-har';
 import toBeAValidHAR from 'jest-expect-har';
 import Oas from 'oas';
 import { HEADERS } from 'oas/extensions';
@@ -619,86 +618,6 @@ describe('request body handling', () => {
               { name: 'metadata[source]', value: 'api-explorer' },
               { name: 'workspace_id', value: 'aaaa-bbbb-cccc-dddd' },
             ],
-          });
-        });
-
-        it('should send nested `multipart/form-data` fields through `fetch-har`', { timeout: 10_000 }, async () => {
-          const spec = Oas.init({
-            openapi: '3.1.0',
-            servers: [
-              {
-                url: 'https://httpbin.org',
-              },
-            ],
-            paths: {
-              '/post': {
-                post: {
-                  requestBody: {
-                    required: true,
-                    content: {
-                      'multipart/form-data': {
-                        schema: {
-                          type: 'object',
-                          properties: {
-                            natural_person: {
-                              type: 'object',
-                              properties: {
-                                first_name: {
-                                  type: 'string',
-                                },
-                                last_name: {
-                                  type: 'string',
-                                },
-                                address: {
-                                  type: 'object',
-                                  properties: {
-                                    city: {
-                                      type: 'string',
-                                    },
-                                  },
-                                },
-                              },
-                            },
-                            workspace_id: {
-                              type: 'string',
-                            },
-                          },
-                        },
-                      },
-                    },
-                  },
-                  responses: {
-                    200: {
-                      description: 'OK',
-                    },
-                  },
-                },
-              },
-            },
-          });
-
-          const har = oasToHar(spec, spec.operation('/post', 'post'), {
-            body: {
-              natural_person: {
-                first_name: 'John',
-                last_name: 'Doe',
-                address: {
-                  city: 'Sydney',
-                },
-              },
-              workspace_id: 'aaaa-bbbb-cccc-dddd',
-            },
-          });
-
-          const response = await fetchHAR(har);
-          const json = await response.json();
-
-          expect(response.ok).toBe(true);
-          expect(json.form).toStrictEqual({
-            'natural_person[address][city]': 'Sydney',
-            'natural_person[first_name]': 'John',
-            'natural_person[last_name]': 'Doe',
-            workspace_id: 'aaaa-bbbb-cccc-dddd',
           });
         });
 

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -489,6 +489,87 @@ describe('request body handling', () => {
           });
         });
 
+        it('should preserve nested object paths in `multipart/form-data` request bodies without explicit encoding', () => {
+          const spec = Oas.init({
+            openapi: '3.1.0',
+            paths: {
+              '/verifications/identity': {
+                post: {
+                  requestBody: {
+                    required: true,
+                    content: {
+                      'multipart/form-data': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            natural_person: {
+                              properties: {
+                                first_name: {
+                                  type: 'string',
+                                },
+                                last_name: {
+                                  type: 'string',
+                                },
+                                address: {
+                                  type: 'object',
+                                  properties: {
+                                    city: {
+                                      type: 'string',
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                            metadata: {
+                              type: ['object', 'null'],
+                              additionalProperties: true,
+                            },
+                            workspace_id: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  responses: {
+                    201: {
+                      description: 'Created',
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          const har = oasToHar(spec, spec.operation('/verifications/identity', 'post'), {
+            body: {
+              natural_person: {
+                first_name: 'John',
+                last_name: 'Doe',
+                address: {
+                  city: 'Sydney',
+                },
+              },
+              metadata: {
+                source: 'api-explorer',
+              },
+              workspace_id: 'aaaa-bbbb-cccc-dddd',
+            },
+          });
+
+          expect(har.log.entries[0].request.postData).toStrictEqual({
+            mimeType: 'multipart/form-data',
+            params: [
+              { name: 'natural_person[first_name]', value: 'John' },
+              { name: 'natural_person[last_name]', value: 'Doe' },
+              { name: 'natural_person[address][city]', value: 'Sydney' },
+              { name: 'metadata[source]', value: 'api-explorer' },
+              { name: 'workspace_id', value: 'aaaa-bbbb-cccc-dddd' },
+            ],
+          });
+        });
+
         it('should handle `multipart/form-data` requests where the requestBody is a `oneOf`', () => {
           const oas = Oas.init(structuredClone(multipartFormDataOneOfRequestBody));
           const operation = oas.operation('/anything', 'post');

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -1,6 +1,7 @@
 import circularRefs from '@readme/oas-examples/3.0/json/circular-request-bodies.json' with { type: 'json' };
 import fileUploads from '@readme/oas-examples/3.0/json/file-uploads.json' with { type: 'json' };
 import schemaTypes from '@readme/oas-examples/3.0/json/schema-types.json' with { type: 'json' };
+import fetchHAR from 'fetch-har';
 import toBeAValidHAR from 'jest-expect-har';
 import Oas from 'oas';
 import { HEADERS } from 'oas/extensions';
@@ -567,6 +568,86 @@ describe('request body handling', () => {
               { name: 'metadata[source]', value: 'api-explorer' },
               { name: 'workspace_id', value: 'aaaa-bbbb-cccc-dddd' },
             ],
+          });
+        });
+
+        it('should send nested `multipart/form-data` fields through `fetch-har`', { timeout: 10_000 }, async () => {
+          const spec = Oas.init({
+            openapi: '3.1.0',
+            servers: [
+              {
+                url: 'https://httpbin.org',
+              },
+            ],
+            paths: {
+              '/post': {
+                post: {
+                  requestBody: {
+                    required: true,
+                    content: {
+                      'multipart/form-data': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            natural_person: {
+                              type: 'object',
+                              properties: {
+                                first_name: {
+                                  type: 'string',
+                                },
+                                last_name: {
+                                  type: 'string',
+                                },
+                                address: {
+                                  type: 'object',
+                                  properties: {
+                                    city: {
+                                      type: 'string',
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                            workspace_id: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  responses: {
+                    200: {
+                      description: 'OK',
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          const har = oasToHar(spec, spec.operation('/post', 'post'), {
+            body: {
+              natural_person: {
+                first_name: 'John',
+                last_name: 'Doe',
+                address: {
+                  city: 'Sydney',
+                },
+              },
+              workspace_id: 'aaaa-bbbb-cccc-dddd',
+            },
+          });
+
+          const response = await fetchHAR(har);
+          const json = await response.json();
+
+          expect(response.ok).toBe(true);
+          expect(json.form).toStrictEqual({
+            'natural_person[address][city]': 'Sydney',
+            'natural_person[first_name]': 'John',
+            'natural_person[last_name]': 'Doe',
+            workspace_id: 'aaaa-bbbb-cccc-dddd',
           });
         });
 


### PR DESCRIPTION
| 🚥 Resolves CX-3294 |
| :------------------- |

## 🧰 Changes

Fixes `multipart/form-data` request generation when a request body has nested object fields without explicit `encoding`.

Previously, nested object properties could be flattened into top-level form fields, so `natural_person.first_name` became `first_name`. This now defaults object-shaped multipart fields to deep object bracket notation, so generated HAR/cURL output keeps the full field path, like `natural_person[first_name]` and `natural_person[address][city]`.

Explicit multipart `encoding` still wins. If a spec defines `encoding.style` or `encoding.explode` for a field, `oas-to-har` keeps using that instead of overriding it with the default.

## 🧬 QA & Testing

Test OAS file: [cx-3294-multipart-nested-objects.json](https://github.com/user-attachments/files/27426847/cx-3294-multipart-nested-objects.json)

- Import a multipart/form-data endpoint with a nested object field and no explicit `encoding`.
- Fill out nested fields in Try It. 
- Check the generated cURL/form params.
- Expected: nested fields preserve the parent path, like `natural_person[first_name]=John` and `natural_person[address][city]=Sydney`.
- Not expected: nested fields appear as top-level params like `first_name=John` or `city=Sydney`.
<img width="1117" height="389" alt="image" src="https://github.com/user-attachments/assets/ff03f7fe-90a2-4882-a47b-3d7e21a8a697" />


- Import a multipart/form-data endpoint that explicitly defines `encoding` for the nested object.
- Confirm the explicit `encoding.style` / `encoding.explode` behavior is still respected and is not overridden by the new default.
<img width="1119" height="388" alt="image" src="https://github.com/user-attachments/assets/9c66fad6-3ad5-49ba-95d0-96e78ac189fe" />

Automated QA:

- `npx vitest run packages/oas-to-har/test/requestBody.test.ts`
  - Covers generated HAR params and sends the HAR through `fetch-har` to `https://httpbin.org/post` to verify native `FormData` submission preserves the nested form field names.
- `npm run lint:types --workspace @readme/oas-to-har`
