### PR TITLE
fix(oas-to-har): honor additionalProperties schemas

### DIFF
--- a/.changeset/quiet-fields-parse.md
+++ b/.changeset/quiet-fields-parse.md
@@ -1,0 +1,5 @@
+---
+'@readme/oas-to-har': patch
+---
+
+Preserve numeric strings in JSON request body maps when `additionalProperties` defines string values.

--- a/packages/oas-to-har/src/lib/utils.ts
+++ b/packages/oas-to-har/src/lib/utils.ts
@@ -365,6 +365,12 @@ function parseJSONStringsObjectContainersOnly(obj: unknown): unknown {
   return obj;
 }
 
+function getAdditionalPropertiesSchema(schema: SchemaObject): SchemaObject | undefined {
+  return schema.additionalProperties && typeof schema.additionalProperties === 'object'
+    ? (schema.additionalProperties as SchemaObject)
+    : undefined;
+}
+
 function mergePropertiesFromAllOf(
   allOf: SchemaObject[],
   api: OASDocument,
@@ -605,18 +611,30 @@ export function parseJSONStringsInBodyWithSchema(
   }
 
   if (obj !== null && typeof obj === 'object') {
-    // If we have an object schema that doesn't have any `properties` then we should just parse
-    // anything that looks like JSON within whatever we _do_ have here.
+    const additionalPropertiesSchema = getAdditionalPropertiesSchema(resolved);
+
+    // If we have an object schema that doesn't have any `properties`, use a schema-object
+    // `additionalProperties` as the schema for each key. Otherwise parse whatever we have loosely.
     if (!resolved.properties || typeof resolved.properties !== 'object') {
+      if (additionalPropertiesSchema) {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(obj)) {
+          out[k] = parseJSONStringsInBodyWithSchema(v, additionalPropertiesSchema, api, new Set(seenRefs));
+        }
+
+        return out;
+      }
+
       return parseJSONStrings(obj);
     }
 
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) {
       const propSchema = resolved.properties[k] as SchemaObject | undefined;
+      const schemaForValue = propSchema ?? additionalPropertiesSchema;
       out[k] =
-        propSchema !== undefined
-          ? parseJSONStringsInBodyWithSchema(v, propSchema, api, new Set(seenRefs))
+        schemaForValue !== undefined
+          ? parseJSONStringsInBodyWithSchema(v, schemaForValue, api, new Set(seenRefs))
           : parseJSONStringsObjectContainersOnly(v);
     }
 

--- a/packages/oas-to-har/test/lib/utils.test.ts
+++ b/packages/oas-to-har/test/lib/utils.test.ts
@@ -262,6 +262,85 @@ describe('#parseJSONStringsInBodyWithSchema()', () => {
     });
   });
 
+  it('should keep numerical additionalProperties values as strings when additionalProperties is `type: string`', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        custom_fields: {
+          type: 'object',
+          additionalProperties: { type: 'string' },
+        },
+      },
+    };
+
+    const payload = {
+      custom_fields: {
+        employeeID: '1009',
+        costCenter: '00042',
+        metadata: '{"not":"json"}',
+      },
+    };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      custom_fields: {
+        employeeID: '1009',
+        costCenter: '00042',
+        metadata: '{"not":"json"}',
+      },
+    });
+  });
+
+  it('should resolve additionalProperties `$ref` schemas', () => {
+    const api = createOASDocument({
+      CustomFieldValue: { type: 'string' },
+      Request: {
+        type: 'object',
+        properties: {
+          custom_fields: {
+            type: 'object',
+            additionalProperties: { $ref: '#/components/schemas/CustomFieldValue' },
+          },
+        },
+      },
+    });
+
+    const schema: SchemaObject = { $ref: '#/components/schemas/Request' };
+    const payload = {
+      custom_fields: {
+        employeeID: '1009',
+      },
+    };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, api)).toStrictEqual({
+      custom_fields: {
+        employeeID: '1009',
+      },
+    });
+  });
+
+  it('should prefer named properties over additionalProperties for mixed object schemas', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        a: { type: 'number' },
+        b: { type: 'boolean' },
+      },
+      additionalProperties: { type: 'string' },
+    };
+
+    const payload = {
+      a: '123',
+      b: 'true',
+      employeeID: '1009',
+    };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      a: 123,
+      b: true,
+      employeeID: '1009',
+    });
+  });
+
   it('should parse string values when property has `format: json`', () => {
     const schema: SchemaObject = {
       type: 'object',

--- a/packages/oas-to-har/test/lib/utils.test.ts
+++ b/packages/oas-to-har/test/lib/utils.test.ts
@@ -290,6 +290,32 @@ describe('#parseJSONStringsInBodyWithSchema()', () => {
     });
   });
 
+  it('should coerce numerical additionalProperties values when additionalProperties is `type: number`', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        scores: {
+          type: 'object',
+          additionalProperties: { type: 'number' },
+        },
+      },
+    };
+
+    const payload = {
+      scores: {
+        first: '1009',
+        second: '3.5',
+      },
+    };
+
+    expect(parseJSONStringsInBodyWithSchema(payload, schema, emptyAPIDefinition)).toStrictEqual({
+      scores: {
+        first: 1009,
+        second: 3.5,
+      },
+    });
+  });
+
   it('should resolve additionalProperties `$ref` schemas', () => {
     const api = createOASDocument({
       CustomFieldValue: { type: 'string' },

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -787,6 +787,64 @@ describe('request body handling', () => {
         );
       });
 
+      it('should preserve numeric strings in schema-object additionalProperties', () => {
+        const spec = Oas.init({
+          openapi: '3.1.0',
+          paths: {
+            '/verification_sessions': {
+              post: {
+                requestBody: {
+                  required: true,
+                  content: {
+                    'application/json': {
+                      schema: {
+                        $ref: '#/components/schemas/CreateVerificationSessionRequest',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              CreateVerificationSessionRequest: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['project_id', 'custom_fields'],
+                properties: {
+                  project_id: {
+                    type: 'string',
+                  },
+                  custom_fields: {
+                    type: 'object',
+                    additionalProperties: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const har = oasToHar(spec, spec.operation('/verification_sessions', 'post'), {
+          body: {
+            project_id: 'project_zO4wUcLxRSzATTCzYxQBC1X9Raux',
+            custom_fields: {
+              employeeID: '1009',
+            },
+          },
+        });
+
+        expect(JSON.parse(har.log.entries[0].request.postData?.text || '')).toStrictEqual({
+          project_id: 'project_zO4wUcLxRSzATTCzYxQBC1X9Raux',
+          custom_fields: {
+            employeeID: '1009',
+          },
+        });
+      });
+
       it('should work for `$ref` pointers that require a lookup', () => {
         const spec = Oas.init({
           paths: {


### PR DESCRIPTION
| 🚥 Resolves CX-3311 |
| :------------------- |

## 🧰 Changes

Try It was coercing digits-only values inside `additionalProperties` maps from strings into numbers when generating the HAR/cURL request body.

The root cause was in the JSON request body serialization path. We already used named `properties` schemas to decide whether a string should stay a string or be parsed as JSON. But for dynamic object keys, like `custom_fields.employeeID`, we weren't using the schema from `additionalProperties`.

So a schema like this:

```json
{
  "custom_fields": {
    "type": "object",
    "additionalProperties": {
      "type": "string"
    }
  }
}
```

still fell back to loose JSON parsing for `employeeID`. Since `JSON.parse("1009")` returns `1009`, the generated request body sent a number instead of the string required by the OpenAPI schema.

This updates `oas-to-har` to treat schema-object `additionalProperties` as the schema for dynamic keys. Named properties still take precedence, but unknown keys now honor `additionalProperties` when it defines a schema or `$ref`.

## 🧬 QA & Testing

OAS: [cx-3311-custom-fields-string-values.json](https://github.com/user-attachments/files/27439720/cx-3311-custom-fields-string-values.json)

- `additionalProperties: { type: "string" }` preserves digits-only values as strings.
<img width="1113" height="474" alt="image" src="https://github.com/user-attachments/assets/c82e40d6-ce52-4f6f-9ee1-e0dd43a69315" />


- `additionalProperties` with a `$ref` to a string schema preserves digits-only values as strings.
<img width="1128" height="488" alt="image" src="https://github.com/user-attachments/assets/5cb45b02-9444-405f-a1a5-ec8bb5da79ca" />

- named `properties` still take precedence over `additionalProperties`.
- mixed schemas still coerce named number/boolean properties correctly.
<img width="1107" height="573" alt="image" src="https://github.com/user-attachments/assets/801d7d8c-9dc6-4a74-832e-79f3d38c1d35" />


- existing `format: json` request body behavior still parses JSON strings where expected.
<img width="1125" height="677" alt="image" src="https://github.com/user-attachments/assets/466652ef-d8e5-4450-8f33-3a7e0e0c9c90" />
