### PR TITLE
fix(oas): isolate default lookup across sibling schemas

### DIFF
--- a/.changeset/quiet-default-lineage.md
+++ b/.changeset/quiet-default-lineage.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Isolate default lookup while traversing sibling schemas so inline object defaults from one property do not apply to siblings with matching nested property names.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -1293,7 +1293,10 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
             const newPropSchema = toJSONSchema(schema.properties[prop] as SchemaObject, {
               ...polyOptions,
               currentLocation: `${currentLocation}/${encodePointer(prop)}`,
-              prevDefaultSchemas,
+              // Keep parent defaults visible to this child, but isolate mutations that happen while
+              // walking its descendants. Otherwise a default pushed by one sibling can be found by
+              // later siblings with the same nested property name.
+              prevDefaultSchemas: [...prevDefaultSchemas],
               prevExampleSchemas,
             });
 

--- a/packages/oas/test/lib/openapi-to-json-schema/default.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema/default.test.ts
@@ -189,6 +189,60 @@ describe('`default` support in `openapi-to-json-schema`', () => {
       });
     });
 
+    it('should not apply nested object defaults across sibling schemas with matching property names', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          field_a: {
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  activate_after: {
+                    type: 'integer',
+                    description: 'activate_after inside SubSchemaA',
+                  },
+                },
+              },
+              {
+                type: 'object',
+                default: {
+                  activate_after: 1209,
+                },
+              },
+            ],
+          },
+          field_b: {
+            type: 'object',
+            properties: {
+              activate_after: {
+                type: 'integer',
+                description: 'activate_after inside SubSchemaB',
+              },
+            },
+          },
+          field_c: {
+            type: 'object',
+            properties: {
+              timeout: {
+                type: 'integer',
+                description: 'field_c.timeout',
+              },
+            },
+          },
+        },
+      };
+
+      const compiled = toJSONSchema(schema);
+      const fieldA = compiled.properties?.field_a as SchemaObject;
+      const fieldB = compiled.properties?.field_b as SchemaObject;
+      const fieldC = compiled.properties?.field_c as SchemaObject;
+
+      expect((fieldA.properties?.activate_after as SchemaObject).default).toBe(1209);
+      expect(fieldB.properties?.activate_after).not.toHaveProperty('default');
+      expect(fieldC.properties?.timeout).not.toHaveProperty('default');
+    });
+
     // While it would be nice to be able to do this sort of default dereferencing for polymrphic
     // schemas there are way too many weird edge cases that crop up as a result of this.
     it('should not support being able to dereference a default into a `oneOf`', () => {

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -1622,6 +1622,94 @@ describe('.getParametersAsJSONSchema()', () => {
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
+
+      it('should not apply nested object defaults across sibling request body refs with matching property names', async () => {
+        const oas = createOasForOperation(
+          {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    $ref: '#/components/schemas/TestRequest',
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+          {
+            schemas: {
+              TestRequest: {
+                type: 'object',
+                properties: {
+                  field_a: {
+                    allOf: [
+                      {
+                        $ref: '#/components/schemas/SubSchemaA',
+                      },
+                      {
+                        type: 'object',
+                        default: {
+                          activate_after: 1209,
+                        },
+                      },
+                    ],
+                  },
+                  field_b: {
+                    $ref: '#/components/schemas/SubSchemaB',
+                  },
+                  field_c: {
+                    $ref: '#/components/schemas/SubSchemaC',
+                  },
+                },
+              },
+              SubSchemaA: {
+                type: 'object',
+                properties: {
+                  activate_after: {
+                    type: 'integer',
+                    description: 'activate_after inside SubSchemaA',
+                  },
+                },
+              },
+              SubSchemaB: {
+                type: 'object',
+                properties: {
+                  activate_after: {
+                    type: 'integer',
+                    description: 'activate_after inside SubSchemaB',
+                  },
+                },
+              },
+              SubSchemaC: {
+                type: 'object',
+                properties: {
+                  timeout: {
+                    type: 'integer',
+                    description: 'field_c.timeout',
+                  },
+                },
+              },
+            },
+          },
+        );
+
+        const schemas = oas.operation('/', 'get').getParametersAsJSONSchema();
+        const bodySchema = schemas?.find(s => s.type === 'body')?.schema;
+        const requestSchema = bodySchema?.components?.schemas?.TestRequest as SchemaObject;
+        const subSchemaB = bodySchema?.components?.schemas?.SubSchemaB as SchemaObject;
+        const subSchemaC = bodySchema?.components?.schemas?.SubSchemaC as SchemaObject;
+        const fieldA = requestSchema.properties?.field_a as SchemaObject;
+
+        expect((fieldA.properties?.activate_after as SchemaObject).default).toBe(1209);
+        expect(subSchemaB.properties?.activate_after).not.toHaveProperty('default');
+        expect(subSchemaC.properties?.timeout).not.toHaveProperty('default');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
     });
 
     describe('polymorphism', () => {


### PR DESCRIPTION
| 🚥 Resolves CX-3277 |
| :------------------- |

## 🧰 Changes

Fixes object default propagation when request body schemas have sibling properties with matching nested field names.

Previously, defaults discovered while traversing one sibling schema could leak into the next sibling because the default lookup stack was shared across sibling traversal. This meant an inline `allOf` default on `field_a.activate_after` could also show up on `field_b.activate_after` if both subschemas used the same nested property name.

This keeps parent object defaults available to descendants, but isolates traversal state between siblings so defaults only apply within the correct schema path.

## 🧬 QA & Testing

Runtime smoke check:

```bash
node - <<'NODE'
const OasModule = require('oas');
const Oas = OasModule.default || OasModule;
const oas = new Oas({
  openapi: '3.0.3',
  info: { title: 'CX-3277', version: '1.0.0' },
  paths: {
    '/': {
      post: {
        requestBody: {
          content: {
            'application/json': {
              schema: { $ref: '#/components/schemas/TestRequest' },
            },
          },
        },
        responses: { 200: { description: 'OK' } },
      },
    },
  },
  components: {
    schemas: {
      TestRequest: {
        type: 'object',
        properties: {
          field_a: {
            allOf: [
              { $ref: '#/components/schemas/SubSchemaA' },
              { type: 'object', default: { activate_after: 1209 } },
            ],
          },
          field_b: { $ref: '#/components/schemas/SubSchemaB' },
        },
      },
      SubSchemaA: { type: 'object', properties: { activate_after: { type: 'integer' } } },
      SubSchemaB: { type: 'object', properties: { activate_after: { type: 'integer' } } },
    },
  },
});
const body = oas.operation('/', 'post').getParametersAsJSONSchema()[0].schema.components.schemas;
console.log({
  fieldA: body.TestRequest.properties.field_a.properties.activate_after.default,
  fieldBHasDefault: Object.hasOwn(body.SubSchemaB.properties.activate_after, 'default'),
});
NODE
```

Expected output:

```js
{ fieldA: 1209, fieldBHasDefault: false }
```
