### PR TITLE
fix(oas): fix readOnly/writeOnly filtering when behind $ref or alongside allOf

### DIFF
--- a/.changeset/respect-readonly-writeonly-across-refs-and-allof.md
+++ b/.changeset/respect-readonly-writeonly-across-refs-and-allof.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Fixed `hideReadOnlyProperties` and `hideWriteOnlyProperties` filtering for properties whose flag sits behind a bare `$ref` (a common OpenAPI 3.0 workaround, since the spec forbids those flags as siblings of `$ref`) or that are declared alongside an `allOf` on the same schema. In both cases the property's converted form became empty but was leaking through the merge as either a `$ref` pointer or an empty `{}` placeholder, fooling the deletion guard into preserving it.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -793,12 +793,33 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
         for (const prop of Object.keys(schema.properties)) {
           const val = schema.properties[prop];
           if (Array.isArray(val) || (typeof val === 'object' && val !== null)) {
-            preprocessed[prop] = toJSONSchema(val as SchemaObject, {
+            const converted = toJSONSchema(val as SchemaObject, {
               ...polyOptions,
               currentLocation: `${currentLocation}/${encodePointer(prop)}`,
               prevDefaultSchemas,
               prevExampleSchemas,
             });
+
+            // Drop the property entirely when it was non-empty originally but came back empty —
+            // i.e. `hideReadOnlyProperties` / `hideWriteOnlyProperties` filtered it away. Carrying
+            // an empty placeholder past the `allOf` merge causes the later deletion guard to think
+            // the prop was always empty and skip the delete. Also drop a bare `$ref` whose cached
+            // resolution is empty (same reason).
+            if (hideReadOnlyProperties || hideWriteOnlyProperties) {
+              let resolvedRefIsEmpty = false;
+              if (isRef(converted) && usedSchemas) {
+                const cached = usedSchemas.get(converted.$ref);
+                if (cached && !isRef(cached) && !isPendingSchema(cached) && Object.keys(cached).length === 0) {
+                  resolvedRefIsEmpty = true;
+                }
+              }
+              const originallyNonEmpty = Object.keys(val as SchemaObject).length > 0;
+              if (originallyNonEmpty && (!Object.keys(converted).length || resolvedRefIsEmpty)) {
+                continue;
+              }
+            }
+
+            preprocessed[prop] = converted;
           } else {
             preprocessed[prop] = val;
           }

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -1302,13 +1302,26 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
 
             // If this property is read or write only then we should fully hide it from its parent schema.
             let propShouldBeUpdated = true;
-            if ((hideReadOnlyProperties || hideWriteOnlyProperties) && !Object.keys(newPropSchema).length) {
-              // We should only delete this schema if it wasn't already empty though. We do this
-              // because we (un)fortunately have handling in our API Explorer form system for
-              // schemas that are devoid of any `type` declaration.
-              if (Object.keys(schema.properties[prop]).length > 0) {
-                delete schema.properties[prop];
-                propShouldBeUpdated = false;
+            if (hideReadOnlyProperties || hideWriteOnlyProperties) {
+              // When the property is a bare `$ref` whose resolved schema was filtered away the recursive call
+              // returns the `$ref` pointer rather than `{}`. Look up the cached resolution so we can drop the
+              // property here too.
+              let resolvedRefIsEmpty = false;
+              if (isRef(newPropSchema) && usedSchemas) {
+                const cached = usedSchemas.get(newPropSchema.$ref);
+                if (cached && !isRef(cached) && !isPendingSchema(cached) && Object.keys(cached).length === 0) {
+                  resolvedRefIsEmpty = true;
+                }
+              }
+
+              if (!Object.keys(newPropSchema).length || resolvedRefIsEmpty) {
+                // We should only delete this schema if it wasn't already empty though. We do this
+                // because we (un)fortunately have handling in our API Explorer form system for
+                // schemas that are devoid of any `type` declaration.
+                if (Object.keys(schema.properties[prop]).length > 0) {
+                  delete schema.properties[prop];
+                  propShouldBeUpdated = false;
+                }
               }
             }
 

--- a/packages/oas/test/__datasets__/issues/CX-3256.json
+++ b/packages/oas/test/__datasets__/issues/CX-3256.json
@@ -1,0 +1,82 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "readOnly alongside allOf + properties",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/broken": {
+      "post": {
+        "operationId": "broken",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MixedSchema" }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    },
+    "/works": {
+      "post": {
+        "operationId": "works",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Child" }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Created" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Base": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" }
+        }
+      },
+      "MixedSchema": {
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/Base" }
+        ],
+        "properties": {
+          "serverGeneratedId": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
+      },
+      "FlatBase": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "serverGeneratedId": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
+      },
+      "Child": {
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/FlatBase" }
+        ],
+        "properties": {
+          "extraField": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/__datasets__/issues/CX-3256.json
+++ b/packages/oas/test/__datasets__/issues/CX-3256.json
@@ -75,9 +75,7 @@
 
       "ReadOnlyMixedWithAllOfBody": {
         "type": "object",
-        "allOf": [
-          { "$ref": "#/components/schemas/SharedBase" }
-        ],
+        "allOf": [{ "$ref": "#/components/schemas/SharedBase" }],
         "properties": {
           "serverGeneratedId": {
             "type": "string",
@@ -98,9 +96,7 @@
       },
       "ReadOnlyInheritedBody": {
         "type": "object",
-        "allOf": [
-          { "$ref": "#/components/schemas/ReadOnlyFlatBase" }
-        ],
+        "allOf": [{ "$ref": "#/components/schemas/ReadOnlyFlatBase" }],
         "properties": {
           "extraField": { "type": "string" }
         }
@@ -108,9 +104,7 @@
 
       "WriteOnlyMixedWithAllOfBody": {
         "type": "object",
-        "allOf": [
-          { "$ref": "#/components/schemas/SharedBase" }
-        ],
+        "allOf": [{ "$ref": "#/components/schemas/SharedBase" }],
         "properties": {
           "password": {
             "type": "string",

--- a/packages/oas/test/__datasets__/issues/CX-3256.json
+++ b/packages/oas/test/__datasets__/issues/CX-3256.json
@@ -1,55 +1,82 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "readOnly alongside allOf + properties",
-    "version": "1.0.0"
+    "title": "readOnly/writeOnly alongside allOf + properties",
+    "version": "1.0.0",
+    "description": "When a schema simultaneously uses `allOf` (for inheritance) and `properties` at the same level, the readOnly/writeOnly filter on a sibling property used to be dropped during the allOf preprocess step. Each path below isolates one variant of that pattern."
   },
   "paths": {
-    "/broken": {
+    "/readonly-mixed-with-allof": {
       "post": {
-        "operationId": "broken",
+        "operationId": "readOnlyMixedWithAllOf",
+        "summary": "bug case: schema uses allOf AND defines a readOnly sibling property",
+        "description": "`ReadOnlyMixedWithAllOfBody` extends `SharedBase` via `allOf` and adds a sibling property `serverGeneratedId` marked `readOnly: true`. Expected with `hideReadOnlyProperties: true`: the merged schema exposes `name` (inherited from SharedBase) and drops `serverGeneratedId`. Pre-fix observed: `serverGeneratedId` survived as an empty `{}` because the allOf preprocess step stored the filtered placeholder, which then fooled the post-merge deletion guard into thinking the property was always empty and should be left alone.",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/MixedSchema" }
+              "schema": { "$ref": "#/components/schemas/ReadOnlyMixedWithAllOfBody" }
             }
           }
         },
-        "responses": {
-          "201": { "description": "Created" }
-        }
+        "responses": { "201": { "description": "Created" } }
       }
     },
-    "/works": {
+    "/readonly-inherited-via-allof": {
       "post": {
-        "operationId": "works",
+        "operationId": "readOnlyInheritedViaAllOf",
+        "summary": "control case: readOnly in a flat base, inherited via allOf (already worked pre-fix)",
+        "description": "`ReadOnlyInheritedBody` extends `ReadOnlyFlatBase` via `allOf`. The readOnly property `serverGeneratedId` lives on the flat base, not as a sibling-of-allOf. Expected with `hideReadOnlyProperties: true`: the merged schema exposes `name` (from the base) and `extraField` (own), and drops `serverGeneratedId`. This case already worked pre-fix; the path is included to guard against regressions in the inheritance-via-allOf path.",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Child" }
+              "schema": { "$ref": "#/components/schemas/ReadOnlyInheritedBody" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Created" } }
+      }
+    },
+    "/writeonly-mixed-with-allof": {
+      "post": {
+        "operationId": "writeOnlyMixedWithAllOf",
+        "summary": "symmetric mirror of /readonly-mixed-with-allof using writeOnly instead",
+        "description": "`WriteOnlyMixedWithAllOfBody` extends `SharedBase` via `allOf` and adds a sibling property `password` marked `writeOnly: true`. Expected with `hideWriteOnlyProperties: true` (which the response-side caller passes): the merged schema exposes `name` and drops `password` from the rendered response panel. Symmetric to the readOnly case — same fix path, opposite flag.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/WriteOnlyMixedWithAllOfBody" }
             }
           }
         },
         "responses": {
-          "201": { "description": "Created" }
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WriteOnlyMixedWithAllOfBody" }
+              }
+            }
+          }
         }
       }
     }
   },
   "components": {
     "schemas": {
-      "Base": {
+      "SharedBase": {
         "type": "object",
         "properties": {
           "name": { "type": "string" }
         }
       },
-      "MixedSchema": {
+
+      "ReadOnlyMixedWithAllOfBody": {
         "type": "object",
         "allOf": [
-          { "$ref": "#/components/schemas/Base" }
+          { "$ref": "#/components/schemas/SharedBase" }
         ],
         "properties": {
           "serverGeneratedId": {
@@ -58,7 +85,8 @@
           }
         }
       },
-      "FlatBase": {
+
+      "ReadOnlyFlatBase": {
         "type": "object",
         "properties": {
           "name": { "type": "string" },
@@ -68,13 +96,26 @@
           }
         }
       },
-      "Child": {
+      "ReadOnlyInheritedBody": {
         "type": "object",
         "allOf": [
-          { "$ref": "#/components/schemas/FlatBase" }
+          { "$ref": "#/components/schemas/ReadOnlyFlatBase" }
         ],
         "properties": {
           "extraField": { "type": "string" }
+        }
+      },
+
+      "WriteOnlyMixedWithAllOfBody": {
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/SharedBase" }
+        ],
+        "properties": {
+          "password": {
+            "type": "string",
+            "writeOnly": true
+          }
         }
       }
     }

--- a/packages/oas/test/__datasets__/issues/CX-3359.json
+++ b/packages/oas/test/__datasets__/issues/CX-3359.json
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "readOnly behind a $ref",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/items": {
+      "post": {
+        "operationId": "createItem",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Item"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/items-inline": {
+      "post": {
+        "operationId": "createItemInline",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["amount"],
+                "properties": {
+                  "amount": { "type": "number" },
+                  "direction": {
+                    "type": "string",
+                    "enum": ["foo", "bar"],
+                    "readOnly": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Item": {
+        "type": "object",
+        "required": ["amount"],
+        "properties": {
+          "amount": { "type": "number" },
+          "direction": { "$ref": "#/components/schemas/Direction" }
+        }
+      },
+      "Direction": {
+        "type": "string",
+        "enum": ["foo", "bar"],
+        "readOnly": true
+      }
+    }
+  }
+}

--- a/packages/oas/test/__datasets__/issues/CX-3359.json
+++ b/packages/oas/test/__datasets__/issues/CX-3359.json
@@ -49,6 +49,22 @@
           "200": { "description": "OK" }
         }
       }
+    },
+    "/items-chained-ref": {
+      "post": {
+        "operationId": "createItemChainedRef",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ChainedItem" }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
     }
   },
   "components": {
@@ -64,6 +80,19 @@
       "Direction": {
         "type": "string",
         "enum": ["foo", "bar"],
+        "readOnly": true
+      },
+      "ChainedItem": {
+        "type": "object",
+        "properties": {
+          "amount": { "type": "number" },
+          "deep": { "$ref": "#/components/schemas/ChainA" }
+        }
+      },
+      "ChainA": { "$ref": "#/components/schemas/ChainB" },
+      "ChainB": { "$ref": "#/components/schemas/ChainC" },
+      "ChainC": {
+        "type": "string",
         "readOnly": true
       }
     }

--- a/packages/oas/test/__datasets__/issues/CX-3359.json
+++ b/packages/oas/test/__datasets__/issues/CX-3359.json
@@ -1,31 +1,32 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "readOnly behind a $ref",
-    "version": "1.0.0"
+    "title": "readOnly/writeOnly behind a $ref",
+    "version": "1.0.0",
+    "description": "OpenAPI 3.0 forbids `readOnly`/`writeOnly` as siblings of `$ref`, so generators place those flags on the referenced schema itself. Each path below isolates one variant of that pattern."
   },
   "paths": {
-    "/items": {
+    "/readonly-via-ref": {
       "post": {
-        "operationId": "createItem",
+        "operationId": "readOnlyViaRef",
+        "summary": "bug case: property is a bare $ref to a schema marked readOnly: true",
+        "description": "`direction` is a bare $ref to `ReadOnlyDirection`, which is marked `readOnly: true` on the schema itself. Expected with `hideReadOnlyProperties: true`: `direction` is dropped from the request form, only `amount` remains. Pre-fix observed: `direction` leaked through as an editable field because the property held a $ref pointer (not `{}`) and the parent's deletion guard missed it.",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Item"
-              }
+              "schema": { "$ref": "#/components/schemas/ReadOnlyViaRefBody" }
             }
           }
         },
-        "responses": {
-          "200": { "description": "OK" }
-        }
+        "responses": { "200": { "description": "OK" } }
       }
     },
-    "/items-inline": {
+    "/readonly-inline": {
       "post": {
-        "operationId": "createItemInline",
+        "operationId": "readOnlyInline",
+        "summary": "control case: readOnly declared inline on the property (already worked pre-fix)",
+        "description": "`direction` declares `readOnly: true` inline on the property itself (no $ref indirection). Expected with `hideReadOnlyProperties: true`: `direction` is dropped, only `amount` remains. This path guards against regressions in the original inline-readOnly path while the bare-$ref fix was added.",
         "requestBody": {
           "required": true,
           "content": {
@@ -45,55 +46,92 @@
             }
           }
         },
-        "responses": {
-          "200": { "description": "OK" }
-        }
+        "responses": { "200": { "description": "OK" } }
       }
     },
-    "/items-chained-ref": {
+    "/readonly-via-chained-ref": {
       "post": {
-        "operationId": "createItemChainedRef",
+        "operationId": "readOnlyViaChainedRef",
+        "summary": "regression guard: property's $ref points to a chain of $refs ending in a readOnly schema",
+        "description": "`deep` resolves through ChainLink1 → ChainLink2 → ChainTarget (marked `readOnly: true`). Expected with `hideReadOnlyProperties: true`: `deep` is dropped, only `amount` remains. This locks in that the fix follows the cached resolution even when the $ref chain is multiple hops deep (dereferencing already follows the chain; the cache stores the final empty value, not an intermediate pointer).",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ChainedItem" }
+              "schema": { "$ref": "#/components/schemas/ReadOnlyChainedBody" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/writeonly-via-ref": {
+      "post": {
+        "operationId": "writeOnlyViaRef",
+        "summary": "symmetric mirror of /readonly-via-ref using writeOnly instead",
+        "description": "`password` is a bare $ref to `WriteOnlySecret`, which is marked `writeOnly: true` on the schema itself. Expected with `hideWriteOnlyProperties: true` (which the response-side caller passes): `password` is dropped from the rendered response panel, only `username` remains. Symmetric to the readOnly case — same fix path, opposite flag.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/WriteOnlyViaRefBody" }
             }
           }
         },
         "responses": {
-          "200": { "description": "OK" }
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WriteOnlyViaRefBody" }
+              }
+            }
+          }
         }
       }
     }
   },
   "components": {
     "schemas": {
-      "Item": {
+      "ReadOnlyViaRefBody": {
         "type": "object",
         "required": ["amount"],
         "properties": {
           "amount": { "type": "number" },
-          "direction": { "$ref": "#/components/schemas/Direction" }
+          "direction": { "$ref": "#/components/schemas/ReadOnlyDirection" }
         }
       },
-      "Direction": {
+      "ReadOnlyDirection": {
         "type": "string",
         "enum": ["foo", "bar"],
         "readOnly": true
       },
-      "ChainedItem": {
+
+      "ReadOnlyChainedBody": {
         "type": "object",
         "properties": {
           "amount": { "type": "number" },
-          "deep": { "$ref": "#/components/schemas/ChainA" }
+          "deep": { "$ref": "#/components/schemas/ReadOnlyChainLink1" }
         }
       },
-      "ChainA": { "$ref": "#/components/schemas/ChainB" },
-      "ChainB": { "$ref": "#/components/schemas/ChainC" },
-      "ChainC": {
+      "ReadOnlyChainLink1": { "$ref": "#/components/schemas/ReadOnlyChainLink2" },
+      "ReadOnlyChainLink2": { "$ref": "#/components/schemas/ReadOnlyChainTarget" },
+      "ReadOnlyChainTarget": {
         "type": "string",
         "readOnly": true
+      },
+
+      "WriteOnlyViaRefBody": {
+        "type": "object",
+        "required": ["username"],
+        "properties": {
+          "username": { "type": "string" },
+          "password": { "$ref": "#/components/schemas/WriteOnlySecret" }
+        }
+      },
+      "WriteOnlySecret": {
+        "type": "string",
+        "writeOnly": true
       }
     }
   }

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -30,9 +30,11 @@ import cx3195 from '../../__datasets__/issues/CX-3195.json' with { type: 'json' 
 import cx3205Alt from '../../__datasets__/issues/CX-3205-alt.json' with { type: 'json' };
 import cx3213 from '../../__datasets__/issues/CX-3213.json' with { type: 'json' };
 import cx3218 from '../../__datasets__/issues/CX-3218.json' with { type: 'json' };
+import cx3256 from '../../__datasets__/issues/CX-3256.json' with { type: 'json' };
 import cx3276 from '../../__datasets__/issues/CX-3276.json' with { type: 'json' };
 import cx3280 from '../../__datasets__/issues/CX-3280.json' with { type: 'json' };
 import cx3312 from '../../__datasets__/issues/CX-3312.json' with { type: 'json' };
+import cx3359 from '../../__datasets__/issues/CX-3359.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
@@ -2363,6 +2365,67 @@ describe('.getParametersAsJSONSchema()', () => {
         });
 
         expect(schemas?.[0].schema.properties).toHaveProperty('missing type (on completely empty schema)');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should hide a property whose bare `$ref` resolves to a schema marked `readOnly: true`', async () => {
+        const oas = Oas.init(structuredClone(cx3359));
+        const operation = oas.operation('/items', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
+        const itemSchema = (schemas?.[0].schema as any).components.schemas.Item;
+
+        expect(itemSchema.properties).not.toHaveProperty('direction');
+        expect(itemSchema.properties).toHaveProperty('amount');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should keep hiding inline `readOnly` properties (control case for the bare-$ref fix)', async () => {
+        const oas = Oas.init(structuredClone(cx3359));
+        const operation = oas.operation('/items-inline', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
+        const bodySchema = schemas?.[0].schema as any;
+
+        expect(bodySchema.properties).not.toHaveProperty('direction');
+        expect(bodySchema.properties).toHaveProperty('amount');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should hide a property whose `$ref` chain ultimately resolves to a `readOnly` schema', async () => {
+        const oas = Oas.init(structuredClone(cx3359));
+        const operation = oas.operation('/items-chained-ref', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
+        const chainedItem = (schemas?.[0].schema as any).components.schemas.ChainedItem;
+
+        expect(chainedItem.properties).not.toHaveProperty('deep');
+        expect(chainedItem.properties).toHaveProperty('amount');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should hide a `readOnly` property declared alongside `allOf` siblings on the same schema', async () => {
+        const oas = Oas.init(structuredClone(cx3256));
+        const operation = oas.operation('/broken', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
+        const mixedSchema = (schemas?.[0].schema as any).components.schemas.MixedSchema;
+
+        expect(mixedSchema.properties).not.toHaveProperty('serverGeneratedId');
+        expect(mixedSchema.properties).toHaveProperty('name');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should keep hiding inherited `readOnly` properties from a flat base via `allOf`', async () => {
+        const oas = Oas.init(structuredClone(cx3256));
+        const operation = oas.operation('/works', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
+        const childSchema = (schemas?.[0].schema as any).components.schemas.Child;
+
+        expect(childSchema.properties).not.toHaveProperty('serverGeneratedId');
+        expect(childSchema.properties).toHaveProperty('name');
+        expect(childSchema.properties).toHaveProperty('extraField');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
     });

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -2370,19 +2370,19 @@ describe('.getParametersAsJSONSchema()', () => {
 
       it('should hide a property whose bare `$ref` resolves to a schema marked `readOnly: true`', async () => {
         const oas = Oas.init(structuredClone(cx3359));
-        const operation = oas.operation('/items', 'post');
+        const operation = oas.operation('/readonly-via-ref', 'post');
 
         const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
-        const itemSchema = (schemas?.[0].schema as any).components.schemas.Item;
+        const bodySchema = (schemas?.[0].schema as any).components.schemas.ReadOnlyViaRefBody;
 
-        expect(itemSchema.properties).not.toHaveProperty('direction');
-        expect(itemSchema.properties).toHaveProperty('amount');
+        expect(bodySchema.properties).not.toHaveProperty('direction');
+        expect(bodySchema.properties).toHaveProperty('amount');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
 
       it('should keep hiding inline `readOnly` properties (control case for the bare-$ref fix)', async () => {
         const oas = Oas.init(structuredClone(cx3359));
-        const operation = oas.operation('/items-inline', 'post');
+        const operation = oas.operation('/readonly-inline', 'post');
 
         const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
         const bodySchema = schemas?.[0].schema as any;
@@ -2394,38 +2394,38 @@ describe('.getParametersAsJSONSchema()', () => {
 
       it('should hide a property whose `$ref` chain ultimately resolves to a `readOnly` schema', async () => {
         const oas = Oas.init(structuredClone(cx3359));
-        const operation = oas.operation('/items-chained-ref', 'post');
+        const operation = oas.operation('/readonly-via-chained-ref', 'post');
 
         const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
-        const chainedItem = (schemas?.[0].schema as any).components.schemas.ChainedItem;
+        const bodySchema = (schemas?.[0].schema as any).components.schemas.ReadOnlyChainedBody;
 
-        expect(chainedItem.properties).not.toHaveProperty('deep');
-        expect(chainedItem.properties).toHaveProperty('amount');
+        expect(bodySchema.properties).not.toHaveProperty('deep');
+        expect(bodySchema.properties).toHaveProperty('amount');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
 
       it('should hide a `readOnly` property declared alongside `allOf` siblings on the same schema', async () => {
         const oas = Oas.init(structuredClone(cx3256));
-        const operation = oas.operation('/broken', 'post');
+        const operation = oas.operation('/readonly-mixed-with-allof', 'post');
 
         const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
-        const mixedSchema = (schemas?.[0].schema as any).components.schemas.MixedSchema;
+        const bodySchema = (schemas?.[0].schema as any).components.schemas.ReadOnlyMixedWithAllOfBody;
 
-        expect(mixedSchema.properties).not.toHaveProperty('serverGeneratedId');
-        expect(mixedSchema.properties).toHaveProperty('name');
+        expect(bodySchema.properties).not.toHaveProperty('serverGeneratedId');
+        expect(bodySchema.properties).toHaveProperty('name');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
 
       it('should keep hiding inherited `readOnly` properties from a flat base via `allOf`', async () => {
         const oas = Oas.init(structuredClone(cx3256));
-        const operation = oas.operation('/works', 'post');
+        const operation = oas.operation('/readonly-inherited-via-allof', 'post');
 
         const schemas = operation.getParametersAsJSONSchema({ hideReadOnlyProperties: true });
-        const childSchema = (schemas?.[0].schema as any).components.schemas.Child;
+        const bodySchema = (schemas?.[0].schema as any).components.schemas.ReadOnlyInheritedBody;
 
-        expect(childSchema.properties).not.toHaveProperty('serverGeneratedId');
-        expect(childSchema.properties).toHaveProperty('name');
-        expect(childSchema.properties).toHaveProperty('extraField');
+        expect(bodySchema.properties).not.toHaveProperty('serverGeneratedId');
+        expect(bodySchema.properties).toHaveProperty('name');
+        expect(bodySchema.properties).toHaveProperty('extraField');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
     });
@@ -2471,6 +2471,30 @@ describe('.getParametersAsJSONSchema()', () => {
             },
           },
         ]);
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should hide a property whose bare `$ref` resolves to a schema marked `writeOnly: true`', async () => {
+        const oas = Oas.init(structuredClone(cx3359));
+        const operation = oas.operation('/writeonly-via-ref', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideWriteOnlyProperties: true });
+        const bodySchema = (schemas?.[0].schema as any).components.schemas.WriteOnlyViaRefBody;
+
+        expect(bodySchema.properties).not.toHaveProperty('password');
+        expect(bodySchema.properties).toHaveProperty('username');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should hide a `writeOnly` property declared alongside `allOf` siblings on the same schema', async () => {
+        const oas = Oas.init(structuredClone(cx3256));
+        const operation = oas.operation('/writeonly-mixed-with-allof', 'post');
+
+        const schemas = operation.getParametersAsJSONSchema({ hideWriteOnlyProperties: true });
+        const bodySchema = (schemas?.[0].schema as any).components.schemas.WriteOnlyMixedWithAllOfBody;
+
+        expect(bodySchema.properties).not.toHaveProperty('password');
+        expect(bodySchema.properties).toHaveProperty('name');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
     });


### PR DESCRIPTION
| 🚥 Resolves CX-3359, CX-3256 |
| :------------------- |

## 🧰 Changes

When a property is defined via `$ref` or via an `allOf`, we sometimes fail to properly drop properties who are labelled as `readOnly` or `writeOnly`. This PR ensures that even when referenced via `ref$` or `allOf`, we still respect that and drop the appropriate properties

> [!NOTE]
the ticket description is more aimed towards `readOnly` properties but i also extended the work in this PR to also affect `writeOnly` properties

## 🧬 QA & Testing

Use these 2 test files
[cx-3359.json](https://github.com/user-attachments/files/27579750/cx-3359.json)
[cx-3256.json](https://github.com/user-attachments/files/27579751/cx-3256.json)

Some screenshots

CX-3359 | CX-3256
-- | --
<img width="3003" height="1648" alt="Screenshot 2026-05-11 at 12 15 55" src="https://github.com/user-attachments/assets/5d402659-498b-489d-a6b8-d04763b1b35b" /> | <img width="2996" height="1644" alt="Screenshot 2026-05-11 at 12 26 33" src="https://github.com/user-attachments/assets/0e4567e7-6d0a-4c9f-81be-27a9d7a4e6d9" />

