### PR TITLE
fix(oas): resolve nested refs in schema examples

### DIFF
--- a/.changeset/resolve-schema-example-refs.md
+++ b/.changeset/resolve-schema-example-refs.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Resolve nested `$ref` pointers in schema-level examples when generating response samples.

--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -10,7 +10,7 @@ import mergeJSONSchemaAllOf from 'json-schema-merge-allof';
 import memoize from 'memoizee';
 
 import { isRef } from '../types.js';
-import { dereferenceRef } from '../utils.js';
+import { dereferenceRef, dereferenceRefDeep } from '../utils.js';
 
 import { deeplyStripKey, isFunc, normalizeArray, objectify, usesPolymorphism } from './utils.js';
 
@@ -196,11 +196,13 @@ function sampleFromResolvedSchema(
   const { includeReadOnly, includeWriteOnly } = opts;
 
   if (example !== undefined) {
-    return deeplyStripKey(example, '$$ref', (val: unknown): val is string => {
+    const cleanedExample = deeplyStripKey(example, '$$ref', (val: unknown): val is string => {
       // do a couple of quick sanity tests to ensure the value
       // looks like a $$ref that swagger-client generates.
       return typeof val === 'string' && val.indexOf('#') > -1;
     });
+
+    return dereferenceRefDeep(cleanedExample, opts.definition, seenRefs);
   }
 
   if (!type) {

--- a/packages/oas/test/__datasets__/issues/CX-3408.json
+++ b/packages/oas/test/__datasets__/issues/CX-3408.json
@@ -1,0 +1,101 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Schema example nested ref repro",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/inspections/{inspectionId}": {
+      "get": {
+        "summary": "Get inspection",
+        "operationId": "getInspection",
+        "parameters": [
+          {
+            "name": "inspectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inspection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Inspection"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Inspection": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/Photo"
+                }
+              ]
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "id": "430",
+          "photos": [
+            {
+              "$ref": "#/components/schemas/Photo/example"
+            }
+          ],
+          "created_at": "2014-04-01T19:00:00.000Z"
+        }
+      },
+      "Photo": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": ["photo"]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "field": {
+            "type": ["object", "null"],
+            "properties": {
+              "id": {
+                "type": ["string", "null"]
+              },
+              "label": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "example": {
+          "object": "photo",
+          "url": "https://media.example.com/inspections/430/images/1c4bdd32-aa80-4355-a6aa-c56ed4c4102d",
+          "field": null
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/operation/lib/get-response-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-response-examples.test.ts
@@ -9,6 +9,7 @@ import circularSpec from '../../__datasets__/circular.json' with { type: 'json' 
 import deprecatedSpec from '../../__datasets__/deprecated.json' with { type: 'json' };
 import cx3172 from '../../__datasets__/issues/CX-3172.json' with { type: 'json' };
 import cx3191 from '../../__datasets__/issues/CX-3191.json' with { type: 'json' };
+import cx3408 from '../../__datasets__/issues/CX-3408.json' with { type: 'json' };
 import operationExamplesSpec from '../../__datasets__/operation-examples.json' with { type: 'json' };
 import readonlyWriteonlySpec from '../../__datasets__/readonly-writeonly.json' with { type: 'json' };
 import { jsonStringifyClean } from '../../__fixtures__/json-stringify-clean.js';
@@ -562,6 +563,78 @@ describe('.getResponseExamples()', () => {
                         last_name: 'Lovelace',
                       },
                     ],
+                  },
+                ],
+              },
+            },
+          ]);
+        });
+
+        it('should deeply resolve nested `$ref` pointers in schema-level examples', () => {
+          const oas = Oas.init(structuredClone(cx3408));
+          const operation = oas.operation('/inspections/{inspectionId}', 'get');
+
+          expect(operation.getResponseExamples()).toStrictEqual([
+            {
+              status: '200',
+              mediaTypes: {
+                'application/json': [
+                  {
+                    value: {
+                      id: '430',
+                      photos: [
+                        {
+                          object: 'photo',
+                          url: 'https://media.example.com/inspections/430/images/1c4bdd32-aa80-4355-a6aa-c56ed4c4102d',
+                          field: null,
+                        },
+                      ],
+                      created_at: '2014-04-01T19:00:00.000Z',
+                    },
+                  },
+                ],
+              },
+            },
+          ]);
+        });
+
+        it('should preserve unresolved `$ref` pointers in schema-level examples', () => {
+          const oas = Oas.init(structuredClone(cx3408));
+          const inspectionSchema = oas.api.components?.schemas?.Inspection;
+
+          if (typeof inspectionSchema === 'object' && inspectionSchema && !('$ref' in inspectionSchema)) {
+            inspectionSchema.example = {
+              id: '430',
+              photos: [
+                {
+                  $ref: 'https://example.com/schemas/Photo.json#/example',
+                },
+                {
+                  $ref: '#/components/schemas/MissingPhoto/example',
+                },
+              ],
+            };
+          }
+
+          const operation = oas.operation('/inspections/{inspectionId}', 'get');
+
+          expect(operation.getResponseExamples()).toStrictEqual([
+            {
+              status: '200',
+              mediaTypes: {
+                'application/json': [
+                  {
+                    value: {
+                      id: '430',
+                      photos: [
+                        {
+                          $ref: 'https://example.com/schemas/Photo.json#/example',
+                        },
+                        {
+                          $ref: '#/components/schemas/MissingPhoto/example',
+                        },
+                      ],
+                    },
                   },
                 ],
               },


### PR DESCRIPTION
| 🚥 Resolves CX-3408 |
| :------------------- |

## 🧰 Changes

Schema-level response examples can include nested `$ref` pointers, but we were only stripping swagger-client `$$ref` metadata from that path. That meant API Explorer could render unresolved `$ref` objects inside generated response examples, even though media-type examples already handled this case.

This updates schema sample generation to deeply resolve `$ref` pointers after cleaning `$$ref` metadata. If a pointer cannot be resolved, we preserve the original `$ref` value instead of dropping it.

## 🧬 QA & Testing

Verified the CX-3408 fixture returns a resolved photo object inside the generated `Inspection` response example.

Also covered unresolved refs so external or missing pointers stay visible as `$ref` objects instead of being replaced with bad sample data.

<img width="463" height="258" alt="image" src="https://github.com/user-attachments/assets/91e7fc76-81e5-4c91-b3a3-dc16bbfb6e1a" />
