### PR TITLE
fix(oas-to-har): serialize request bodies using selected content type

### DIFF
--- a/.changeset/cx-3418-oas-to-har-form-content-types.md
+++ b/.changeset/cx-3418-oas-to-har-form-content-types.md
@@ -1,0 +1,5 @@
+---
+"@readme/oas-to-har": patch
+---
+
+Serialize request bodies according to the selected `content-type` header when operations define multiple request body media types.

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -446,18 +446,24 @@ export default function oasToHar(
 
   let requestBody: SchemaWrapper | undefined;
   if (operation.hasRequestBody()) {
-    requestBody = operation.getParametersAsJSONSchema()?.find(payload => {
+    const isFormUrlEncoded = matchesMimeType.formUrlEncoded(contentType);
+    const matchesRequestBodyType = (payload: SchemaWrapper) => {
       // `formData` is used in our API Explorer for `application/x-www-form-urlencoded` endpoints
       // and if you have an operation with that, it will only ever have a `formData`. `body` is
       // used for all other payload shapes.
-      return payload.type === (operation.isFormUrlEncoded() ? 'formData' : 'body');
-    });
+      return payload.type === (isFormUrlEncoded ? 'formData' : 'body');
+    };
+
+    requestBody =
+      operation.getParametersAsJSONSchema({ contentType })?.find(matchesRequestBodyType) ||
+      operation.getParametersAsJSONSchema()?.find(matchesRequestBodyType);
   }
 
   if (requestBody?.schema && Object.keys(requestBody.schema).length) {
     const requestBodySchema = requestBody.schema;
 
-    if (operation.isFormUrlEncoded()) {
+    const isFormUrlEncoded = matchesMimeType.formUrlEncoded(contentType);
+    if (isFormUrlEncoded) {
       if (Object.keys(formData.formData || {}).length) {
         const cleanFormData = removeUndefinedObjects(formData.formData, { preserveNullishArrays: true });
 
@@ -479,8 +485,8 @@ export default function oasToHar(
       formData.body !== undefined &&
       (isPrimitive(formData.body) || Object.keys(formData.body).length)
     ) {
-      const isMultipart = operation.isMultipart();
-      const isJSON = operation.isJson();
+      const isMultipart = matchesMimeType.multipart(contentType);
+      const isJSON = matchesMimeType.json(contentType);
 
       if (isMultipart || isJSON) {
         try {
@@ -536,7 +542,7 @@ export default function oasToHar(
             if (cleanBody !== undefined) {
               let multipartParams: ParameterObject[] = [];
 
-              const multipartContent = operation.getRequestBody('multipart/form-data');
+              const multipartContent = operation.getRequestBody(contentType);
               if (multipartContent) {
                 multipartParams = multipartBodyToFormatterParams(
                   formData.body,

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -454,9 +454,7 @@ export default function oasToHar(
       return payload.type === (isFormUrlEncoded ? 'formData' : 'body');
     };
 
-    requestBody =
-      operation.getParametersAsJSONSchema({ contentType })?.find(matchesRequestBodyType) ||
-      operation.getParametersAsJSONSchema()?.find(matchesRequestBodyType);
+    requestBody = operation.getParametersAsJSONSchema({ contentType })?.find(matchesRequestBodyType);
   }
 
   if (requestBody?.schema && Object.keys(requestBody.schema).length) {

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -541,6 +541,62 @@ describe('request body handling', () => {
           });
         });
 
+        it('should serialize as `multipart/form-data` when selected after a JSON request body', () => {
+          const spec = Oas.init({
+            paths: {
+              '/requestBody': {
+                post: {
+                  requestBody: {
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            jsonOnly: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                      'multipart/form-data': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            callbackUrl: {
+                              type: 'string',
+                            },
+                            multipartOnly: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+            body: {
+              callbackUrl: 'https://consumer.example.com/webhooks/events',
+              multipartOnly: 'multipart parent request value',
+            },
+            header: {
+              'content-type': 'multipart/form-data',
+            },
+          });
+
+          expect(har.log.entries[0].request.postData).toStrictEqual({
+            mimeType: 'multipart/form-data',
+            params: [
+              { name: 'callbackUrl', value: 'https://consumer.example.com/webhooks/events' },
+              { name: 'multipartOnly', value: 'multipart parent request value' },
+            ],
+          });
+        });
+
         it('should preserve nested object paths in `multipart/form-data` request bodies without explicit encoding', () => {
           const spec = Oas.init({
             openapi: '3.1.0',
@@ -1374,6 +1430,62 @@ describe('request body handling', () => {
         { name: 'a', value: 'test' },
         { name: 'b', value: '1,2,3' },
       ]);
+    });
+
+    it('should serialize as `application/x-www-form-urlencoded` when selected after a JSON request body', () => {
+      const spec = Oas.init({
+        paths: {
+          '/requestBody': {
+            post: {
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        jsonOnly: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                  'application/x-www-form-urlencoded': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        callbackUrl: {
+                          type: 'string',
+                        },
+                        urlEncodedOnly: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const har = oasToHar(spec, spec.operation('/requestBody', 'post'), {
+        formData: {
+          callbackUrl: 'https://consumer.example.com/webhooks/events',
+          urlEncodedOnly: 'urlencoded parent request value',
+        },
+        header: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      expect(har.log.entries[0].request.postData).toStrictEqual({
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          { name: 'callbackUrl', value: 'https://consumer.example.com/webhooks/events' },
+          { name: 'urlEncodedOnly', value: 'urlencoded parent request value' },
+        ],
+      });
     });
 
     it('should stringify falsy primitive values in `application/x-www-form-urlencoded` params', () => {

--- a/packages/oas-to-har/test/requestBody.test.ts
+++ b/packages/oas-to-har/test/requestBody.test.ts
@@ -1756,13 +1756,15 @@ describe('request body handling', () => {
       await expect(har).toBeAValidHAR();
 
       // `content-type: application/json` would normally appear here if there were no
-      // `x-readme.headers`, but since there is we should default to that so as to we don't double
-      // up on `content-type` headers.
+      // `x-readme.headers`, but since there is one already we shouldn't double up on
+      // `content-type` headers.
       expect(har.log.entries[0].request.headers).toStrictEqual([
         { name: 'content-type', value: 'multipart/form-data' },
       ]);
 
-      expect(har.log.entries[0].request.postData?.mimeType).toBe('multipart/form-data');
+      // The static header does not correspond to any request body content in the OAS, so we should
+      // not fall back to serializing the JSON schema as multipart form data.
+      expect(har.log.entries[0].request.postData).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
| 🚥 Resolves CX-3418 |
| :---------------- |

## 🧰 Changes

Fixes a request serialization bug where operations with multiple request body content types could render the right form fields, but still serialize the body using the default JSON content type.

The selected `content-type` header now drives request body schema selection and serialization.

## 🧬 QA & Testing

- JSON + multipart request body: select `multipart/form-data` after JSON and confirm entered form fields are emitted as multipart HAR params.
- JSON + urlencoded request body: select `application/x-www-form-urlencoded` after JSON and confirm entered form fields are emitted as urlencoded HAR params.

https://github.com/user-attachments/assets/94be244a-5b8e-4e09-9e12-4006f922e276


