### PR TITLE
fix(oas): preserve schema shape when allOf merge throws on a nested conflict

### DIFF
--- a/.changeset/rm-4285-allof-merge-fallback.md
+++ b/.changeset/rm-4285-allof-merge-fallback.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+When an `allOf` merge throws on an irreconcilable nested conflict (eg. `properties.foo.type` being `array` in one branch and `object` in another), the previous fallback deleted the entire `allOf` and left the schema with no `type` or `properties` — leaving downstream renderers nothing to display. The fallback now does a best-effort shallow merge of each branch's `properties` (last branch wins on conflicting keys), unions `required`, and infers `type: object` when the result has properties, so consumers still see most of the schema's shape.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -901,14 +901,40 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
       try {
         schema = mergeJSONSchemaAllOf(schema as JSONSchema, mergeAllOfSchemasOptions) as SchemaObject;
       } catch {
-        // If we can't merge the `allOf` for whatever reason (like if one item is a `string` and
-        // the other is a `object`) then we should completely remove it from the schema and continue
-        // with whatever we've got. Why? If we don't, any tooling that's ingesting this will need
-        // to account for the incompatible `allOf` and it may be subject to more breakages than
-        // just not having it present would be.
-        const { ...schemaWithoutAllOf } = schema;
-        schema = schemaWithoutAllOf as SchemaObject;
-        delete schema.allOf;
+        // The merge can throw on irreconcilable conflicts (eg. `properties.foo.type` being `array`
+        // in one branch and `object` in another). Dropping the entire `allOf` here would leave the
+        // schema with no `type` / `properties` at all, and downstream renderers would have nothing
+        // to show. Instead, do a best-effort shallow merge of each branch's `properties` (later
+        // branches win on conflict) and union `required`, so consumers still see most of the shape.
+        const branches = (schema.allOf as SchemaObject[]) ?? [];
+        const { allOf: _allOf, ...rest } = schema as SchemaObject & { allOf?: SchemaObject[] };
+        const fallback: SchemaObject = { ...rest };
+        const mergedProperties: Record<string, SchemaObject> = {
+          ...(fallback as { properties?: Record<string, SchemaObject> }).properties,
+        };
+        const requiredSet = new Set<string>(Array.isArray(fallback.required) ? (fallback.required as string[]) : []);
+        for (const branch of branches) {
+          if (!branch || typeof branch !== 'object' || isRef(branch)) continue;
+          if (fallback.type === undefined && 'type' in branch && branch.type !== undefined) {
+            fallback.type = branch.type;
+          }
+          if (branch.properties && typeof branch.properties === 'object') {
+            for (const [key, value] of Object.entries(branch.properties)) {
+              mergedProperties[key] = value as SchemaObject;
+            }
+          }
+          if (Array.isArray(branch.required)) {
+            for (const required of branch.required) requiredSet.add(required);
+          }
+        }
+        if (Object.keys(mergedProperties).length > 0) {
+          (fallback as { properties?: unknown }).properties = mergedProperties;
+          if (fallback.type === undefined) fallback.type = 'object';
+        }
+        if (requiredSet.size > 0) {
+          (fallback as SchemaObject & { required?: string[] }).required = [...requiredSet];
+        }
+        schema = fallback;
       }
 
       // This is a little messy but because `json-schema-merge-allof` doesn't support attaching a

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -921,7 +921,11 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
           if (fallback.title === undefined && typeof branch.title === 'string' && branch.title.length > 0) {
             fallback.title = branch.title;
           }
-          if (typeof branch.description === 'string' && branch.description.length > 0) {
+          if (
+            fallback.description === undefined &&
+            typeof branch.description === 'string' &&
+            branch.description.length > 0
+          ) {
             fallback.description = branch.description;
           }
           if (branch.properties && typeof branch.properties === 'object') {

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -918,6 +918,12 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
           if (fallback.type === undefined && 'type' in branch && branch.type !== undefined) {
             fallback.type = branch.type;
           }
+          if (fallback.title === undefined && typeof branch.title === 'string' && branch.title.length > 0) {
+            fallback.title = branch.title;
+          }
+          if (typeof branch.description === 'string' && branch.description.length > 0) {
+            fallback.description = branch.description;
+          }
           if (branch.properties && typeof branch.properties === 'object') {
             for (const [key, value] of Object.entries(branch.properties)) {
               mergedProperties[key] = value as SchemaObject;

--- a/packages/oas/test/__datasets__/issues/RM-4285.json
+++ b/packages/oas/test/__datasets__/issues/RM-4285.json
@@ -1,0 +1,81 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Repro: allOf merge conflict on a nested property erases the entire response schema",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/items": {
+      "post": {
+        "responses": {
+          "201": {
+            "description": "Item successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Bundle": {
+        "type": "object",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "Base": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Bundle" },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "expected to be deduped — also defined in ItemResponse inline branch, inline wins"
+              },
+              "name": {
+                "type": "string",
+                "description": "only defined here in Base — expected to pass through to the merged output"
+              },
+              "created_by": {
+                "type": "string",
+                "format": "uuid",
+                "description": "only defined here in Base — expected to pass through to the merged output"
+              }
+            }
+          }
+        ]
+      },
+      "ItemResponse": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Base" },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "readOnly": true,
+                "description": "expected to be deduped — overrides Base.id with this uuid version"
+              },
+              "documents": {
+                "$ref": "#/components/schemas/Bundle",
+                "description": "expected to be deduped — conflicts with Bundle.documents (array vs object). This conflict is what causes the strict merge to throw; the fallback keeps this inline version"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -10,6 +10,11 @@ import requestbodyExampleQuirksSpec from '../__datasets__/requestbody-example-qu
 import { createOasForOperation } from '../__fixtures__/create-oas.js';
 import { generateJSONSchemaFixture } from '../__fixtures__/json-schema.js';
 
+const objBranch = (properties: Record<string, SchemaObject>, required?: string[]): SchemaObject =>
+  ({ type: 'object', properties, ...(required ? { required } : null) }) as SchemaObject;
+const metaWithFoo = (fooType: 'string' | 'number'): SchemaObject =>
+  objBranch({ meta: objBranch({ foo: { type: fooType } }) });
+
 describe('toJSONSchema()', () => {
   let petstore: Oas;
 
@@ -710,7 +715,7 @@ describe('toJSONSchema()', () => {
       );
     });
 
-    it.each([['allOf'], ['anyOf'], ['oneOf']])('should not add a missing `type` on an `%s` schema', polyType => {
+    it.each([['anyOf'], ['oneOf']])('should not add a missing `type` on an `%s` schema', polyType => {
       const schema: SchemaObject = {
         [polyType]: [
           {
@@ -731,23 +736,96 @@ describe('toJSONSchema()', () => {
       expect(toJSONSchema(schema).type).toBeUndefined();
     });
 
+    it('should infer a `type` on an `allOf` schema when the fallback fires with properties', () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            title: 'range_query_specs',
+            type: 'object',
+            properties: {
+              gt: { type: 'integer' },
+            },
+          },
+          { type: 'integer' },
+        ],
+      };
+
+      expect(toJSONSchema(schema)).toStrictEqual({
+        type: 'object',
+        properties: {
+          gt: { type: 'integer' },
+        },
+      });
+    });
+
     describe('quirks', () => {
-      it("should eliminate an `allOf` from a schema if it can't be merged", () => {
+      it("should fall back to a best-effort merge when an `allOf` can't be merged", () => {
         const schema: SchemaObject = {
           title: 'allOf with incompatible schemas',
-          allOf: [
-            {
-              type: 'string',
-            },
-            {
-              type: 'integer',
-            },
-          ],
+          allOf: [{ type: 'string' }, { type: 'integer' }],
         };
 
         expect(toJSONSchema(schema)).toStrictEqual({
           title: 'allOf with incompatible schemas',
+          type: 'string',
         });
+      });
+
+      it("should fall back to a shallow property merge when an `allOf`'s nested properties conflict", () => {
+        const sharedAsObject = objBranch({ nested: { type: 'string' } });
+        const schema = {
+          allOf: [
+            objBranch({ value: { type: 'string' }, shared: { type: 'array', items: { type: 'string' } } }, ['value']),
+            objBranch({ extra: { type: 'boolean' }, shared: sharedAsObject }, ['extra']),
+          ],
+        } as SchemaObject;
+
+        expect(toJSONSchema(schema)).toStrictEqual({
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+            extra: { type: 'boolean' },
+            shared: sharedAsObject,
+          },
+          required: ['value', 'extra'],
+        });
+      });
+
+      it('should deep-merge nested object properties when branches share a key with the same outer type', () => {
+        const schema = {
+          allOf: [
+            objBranch({ meta: objBranch({ foo: { type: 'string' } }) }),
+            objBranch({ meta: objBranch({ bar: { type: 'number' } }) }),
+          ],
+        } as SchemaObject;
+
+        expect(toJSONSchema(schema)).toStrictEqual(
+          objBranch({
+            meta: objBranch({
+              foo: { type: 'string' },
+              bar: { type: 'number' },
+            }),
+          }),
+        );
+      });
+
+      it('should fall back to a shallow merge when a nested scalar `type` differs (last branch wins)', () => {
+        const schema = {
+          allOf: [metaWithFoo('string'), metaWithFoo('number')],
+        } as SchemaObject;
+
+        expect(toJSONSchema(schema)).toStrictEqual(objBranch({ meta: objBranch({ foo: { type: 'number' } }) }));
+      });
+
+      it('should keep the first value when a non-throwing keyword like `format` differs between branches', () => {
+        const schema = {
+          allOf: [
+            objBranch({ id: { type: 'string', format: 'uuid' } }),
+            objBranch({ id: { type: 'string', format: 'date-time' } }),
+          ],
+        } as SchemaObject;
+
+        expect(toJSONSchema(schema)).toStrictEqual(objBranch({ id: { type: 'string', format: 'uuid' } }));
       });
 
       it('should hoist `properties` into a same-level `oneOf` and transform each option into an `allOf`', () => {

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -751,6 +751,7 @@ describe('toJSONSchema()', () => {
       };
 
       expect(toJSONSchema(schema)).toStrictEqual({
+        title: 'range_query_specs',
         type: 'object',
         properties: {
           gt: { type: 'integer' },

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -818,6 +818,34 @@ describe('toJSONSchema()', () => {
         expect(toJSONSchema(schema)).toStrictEqual(objBranch({ meta: objBranch({ foo: { type: 'number' } }) }));
       });
 
+      it('should keep the first `title` when multiple branches set one in the fallback path', () => {
+        const schema: SchemaObject = {
+          allOf: [
+            { title: 'first', type: 'string' },
+            { title: 'second', type: 'integer' },
+          ],
+        };
+
+        expect(toJSONSchema(schema)).toStrictEqual({
+          title: 'first',
+          type: 'string',
+        });
+      });
+
+      it('should keep the first `description` when multiple branches set one in the fallback path', () => {
+        const schema: SchemaObject = {
+          allOf: [
+            { description: 'first', type: 'string' },
+            { description: 'second', type: 'integer' },
+          ],
+        };
+
+        expect(toJSONSchema(schema)).toStrictEqual({
+          description: 'first',
+          type: 'string',
+        });
+      });
+
       it('should keep the first value when a non-throwing keyword like `format` differs between branches', () => {
         const schema = {
           allOf: [

--- a/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
@@ -15,6 +15,7 @@ import discriminatorAllOfInheritance from '../../__datasets__/discriminator-allo
 import invalidComponentSchemaNamesSpec from '../../__datasets__/invalid-component-schema-names.json' with { type: 'json' };
 import cx3171 from '../../__datasets__/issues/CX-3171.json' with { type: 'json' };
 import cx3205 from '../../__datasets__/issues/CX-3205.json' with { type: 'json' };
+import rm4285 from '../../__datasets__/issues/RM-4285.json' with { type: 'json' };
 import petDiscriminatorAllOf from '../../__datasets__/pet-discriminator-allof.json' with { type: 'json' };
 import responseDuplicateEnums from '../../__datasets__/response-duplicate-enums.json' with { type: 'json' };
 import responseEnumsSpec from '../../__datasets__/response-enums.json' with { type: 'json' };
@@ -988,6 +989,24 @@ describe('.getResponseAsJSONSchema()', () => {
         });
 
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it('should fall back to a shallow property merge when an allOf has irreconcilable conflicts', () => {
+        const oas = Oas.init(structuredClone(rm4285));
+        const operation = oas.operation('/items', 'post');
+
+        const schemas = operation.getResponseAsJSONSchema('201');
+
+        expect(schemas?.[0].type).toBe('object');
+
+        const resolved = (schemas?.[0].schema as any)?.components?.schemas?.ItemResponse;
+        expect(resolved).toBeDefined();
+        expect(resolved.type).toBe('object');
+
+        expect(Object.keys(resolved.properties).toSorted()).toStrictEqual(['created_by', 'documents', 'id', 'name']);
+        expect(resolved.properties.id).toMatchObject({ type: 'string', format: 'uuid', readOnly: true });
+        expect(resolved.properties.name).toMatchObject({ type: 'string' });
+        expect(resolved.properties.created_by).toMatchObject({ type: 'string', format: 'uuid' });
       });
     });
   });


### PR DESCRIPTION
| 🚥 Resolves RM-4285 |
| :------------------- |

## 🧰 Changes

When `toJSONSchema` runs an `allOf` through `json-schema-merge-allof` and the merger throws on an irreconcilable conflict (eg. `properties.documents.type` being `array` in one branch and `object` in another, as in the customer spec behind RM-4285), the previous `catch` block deleted the entire `allOf` and returned the wrapper schema with no `type` or `properties` at all and leaves the plain "json" placeholder

This replaces that lossy fallback in with a best-effort shallow merge.

> The change is additive on the success path, only the throw fallback is touched

## 🧬 QA & Testing

Use this doc: [minimal-repro.json](https://github.com/user-attachments/files/28334976/minimal-repro.json)


https://github.com/user-attachments/assets/4e521de8-eb82-40c9-b772-3bb8f60047f9



