### PR TITLE
fix(oas-to-snippet): disable curl globbing for literal query params

### DIFF
--- a/.changeset/fuzzy-curl-globoff.md
+++ b/.changeset/fuzzy-curl-globoff.md
@@ -1,0 +1,5 @@
+---
+'@readme/oas-to-snippet': patch
+---
+
+Add `--globoff` to generated cURL snippets when raw URL glob characters are present.

--- a/packages/oas-to-snippet/src/index.ts
+++ b/packages/oas-to-snippet/src/index.ts
@@ -10,6 +10,26 @@ import generateHar from '@readme/oas-to-har';
 
 import { getClientInstallationInstructions, getLanguageConfig, getSupportedLanguages } from './languages.js';
 
+type HarForSnippet = HarRequest | ReturnType<typeof generateHar>;
+
+function containsCurlGlobSyntax(value: string) {
+  return value.includes('[') || value.includes(']') || value.includes('{') || value.includes('}');
+}
+
+function hasCurlGlobSyntax(har: HarForSnippet) {
+  const requests = 'log' in har ? har.log.entries.map(entry => entry.request) : [har];
+
+  return requests.some(request => {
+    if (typeof request.url === 'string' && containsCurlGlobSyntax(request.url)) {
+      return true;
+    }
+
+    return request.queryString?.some(
+      ({ name, value }) => containsCurlGlobSyntax(name) || containsCurlGlobSyntax(value),
+    );
+  });
+}
+
 export default function oasToSnippet(
   oas: Oas,
   operation: Operation,
@@ -112,8 +132,15 @@ export default function oasToSnippet(
     harIsAlreadyEncoded: !opts.harOverride,
   });
 
-  let targetOpts = config.httpsnippet.targets[target].opts || {};
+  let targetOpts = { ...config.httpsnippet.targets[target].opts };
   const highlightMode = config.highlight;
+
+  if (language === 'shell' && target === 'curl' && hasCurlGlobSyntax(har)) {
+    // Generated snippets represent one literal request, so raw `[]` and `{}` should not be
+    // interpreted by cURL as URL glob syntax.
+    // https://everything.curl.dev/cmdline/urls/globbing.html
+    targetOpts.globOff = true;
+  }
 
   plugins.forEach(plugin => {
     addClientPlugin(plugin);

--- a/packages/oas-to-snippet/test/index.test.ts
+++ b/packages/oas-to-snippet/test/index.test.ts
@@ -175,6 +175,45 @@ describe('oas-to-snippet', () => {
      --data-urlencode 'b=1,2,3'`);
   });
 
+  it('should disable curl globbing for query params that contain bracket syntax', () => {
+    const oas = Oas.init({
+      paths: {
+        '/public-api/resources/charge-points/v2.0': {
+          get: {
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                style: 'deepObject',
+                explode: true,
+                schema: {
+                  type: 'object',
+                  properties: {
+                    desiredSecurityProfileStatus: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const { code } = oasToSnippet(
+      oas,
+      oas.operation('/public-api/resources/charge-points/v2.0', 'get'),
+      { query: { filter: { desiredSecurityProfileStatus: 'applied' } } },
+      {},
+      'shell',
+    );
+
+    expect(code).toBe(`curl --request GET \\
+     --globoff \\
+     --url 'https://example.com/public-api/resources/charge-points/v2.0?filter[desiredSecurityProfileStatus]=applied'`);
+  });
+
   it('should have special indents in curl snippets for JSON payloads', () => {
     const oas = Oas.init({
       paths: {


### PR DESCRIPTION
| 🚥 Resolves RM-10215 |
| :------------------- |

## 🧰 Changes

Fixes generated cURL snippets for query params that render with raw bracket syntax. cURL treats `[]` and `{}` as [URL globbing syntax](https://everything.curl.dev/cmdline/urls/globbing.html), so copied snippets could fail before the request was sent.

Since generated snippets represent one literal request, this adds `--globoff` when the request URL or query params contain cURL glob characters. This keeps the URL readable without URL-encoding or backslash-escaping the query param names.

Note that `--globoff` won't appear when url doesn't have raw brackets even though it's harmless.  

## 🧬 QA & Testing

<img width="474" height="728" alt="image" src="https://github.com/user-attachments/assets/57774c71-7c4f-4afe-91e4-77aface3fd44" />


```
curl --request GET \
     --globoff \
     --url 'https://httpbin.org/anything?filter[desiredSecurityProfileStatus]=pending'
     
{
  "args": {
    "filter[desiredSecurityProfileStatus]": "pending"
  }, 
  "data": "", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept": "*/*", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/8.7.1", 
    "X-Amzn-Trace-Id": "Root=1-6a2bae60-3ace9f8b6861c8cb410e21e9"
  }, 
  "json": null, 
  "method": "GET", 
  "origin": "", 
  "url": "https://httpbin.org/anything?filter[desiredSecurityProfileStatus]=pending"
}
```