### PR TITLE
feat(oas): support x-default for basic auth

### DIFF
--- a/.changeset/tender-basic-auth.md
+++ b/.changeset/tender-basic-auth.md
@@ -1,0 +1,5 @@
+---
+'oas': minor
+---
+
+Add support for using `x-default` to prefill HTTP Basic auth credentials.

--- a/packages/oas/src/lib/get-auth.ts
+++ b/packages/oas/src/lib/get-auth.ts
@@ -18,7 +18,13 @@ function getKey(user: User, scheme: KeyedSecuritySchemeObject): authKey {
 
     case 'http':
       if (scheme.scheme === 'basic') {
-        return user[scheme._key] || { user: user.user || null, pass: user.pass || null };
+        return (
+          user[scheme._key] ||
+          (user.user || user.pass ? { user: user.user || null, pass: user.pass || null } : scheme['x-default']) || {
+            user: null,
+            pass: null,
+          }
+        );
       }
 
       if (scheme.scheme === 'bearer') {

--- a/packages/oas/src/types.ts
+++ b/packages/oas/src/types.ts
@@ -288,7 +288,7 @@ export type KeyedSecuritySchemeObject = SecuritySchemeObject & {
 
   // `x-default` is our custom extension for specifying auth defaults.
   // https://docs.readme.com/docs/openapi-extensions#authentication-defaults
-  'x-default'?: number | string;
+  'x-default'?: number | string | { pass?: number | string; user?: number | string };
 };
 
 /**

--- a/packages/oas/test/lib/get-auth.test.ts
+++ b/packages/oas/test/lib/get-auth.test.ts
@@ -130,6 +130,37 @@ describe('#getByScheme', () => {
     });
   });
 
+  it('should return default user/pass properties for basic auth', () => {
+    expect(
+      getByScheme(
+        {},
+        {
+          type: 'http',
+          scheme: 'basic',
+          _key: 'authscheme',
+          'x-default': { user: 'default-user', pass: 'default-pass' },
+        },
+      ),
+    ).toStrictEqual({
+      user: 'default-user',
+      pass: 'default-pass',
+    });
+  });
+
+  it('should prefer user data over default user/pass properties for basic auth', () => {
+    expect(
+      getByScheme(topLevelUser, {
+        type: 'http',
+        scheme: 'basic',
+        _key: 'authscheme',
+        'x-default': { user: 'default-user', pass: 'default-pass' },
+      }),
+    ).toStrictEqual({
+      user: 'user',
+      pass: 'pass',
+    });
+  });
+
   it('should return first item from keys array if no app selected', () => {
     expect(getByScheme(keysUser, { type: 'oauth2', flows: {}, _key: 'authscheme' })).toBe('123456');
   });


### PR DESCRIPTION
| 🚥 Resolves RM-42 |
| :------------------- |

## 🧰 Changes

Adds support for using `x-default` with HTTP Basic auth schemes. `oas.getAuth()` can now use an object-shaped default like `{ "user": "...", "pass": "..." }` to prefill Basic auth credentials when no user-provided auth is available. Cookie auth already flows through the existing `apiKey` `x-default` path, so this only adds the missing Basic auth object handling.

User-provided credentials still take precedence over the spec default, so existing custom-login/user-data behavior should keep winning when present.

## 🧬 QA & Testing

- Confirmed that the extension is supported for the new shape and user input takes precedence
[rm-42-x-default-auth-httpbin.json](https://github.com/user-attachments/files/28955981/rm-42-x-default-auth-httpbin.json)

https://github.com/user-attachments/assets/49c19f7a-e758-490b-92da-ae2d0bd584be


