### PR TITLE
fix: support `example` keyword with `$ref` pointers

### DIFF
--- a/.changeset/fifty-falcons-sink.md
+++ b/.changeset/fifty-falcons-sink.md
@@ -1,5 +1,5 @@
 ---
-"oas": major
+"oas": minor
 ---
 
 Add support for `example` keyword with `$ref` pointers

--- a/.changeset/fifty-falcons-sink.md
+++ b/.changeset/fifty-falcons-sink.md
@@ -1,0 +1,5 @@
+---
+"oas": major
+---
+
+Add support for `example` keyword with `$ref` pointers

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -762,6 +762,15 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
       // level as `$ref` however is invalid in JSON Schema and should be ignored.
       const { $ref: _$ref, properties: _propertiesWithRef, ...siblings } = schema as Record<string, unknown>;
       if (Object.keys(siblings).length > 0) {
+        // An `example` sibling (common when a parameter-level `example` is merged onto a `$ref`
+        // schema) never reaches the `isSchema` normalization branch below, so normalize it here:
+        // promote primitives to the JSON Schema `examples` array and drop non-primitives.
+        if ('example' in siblings) {
+          if (isPrimitive(siblings.example)) {
+            siblings.examples = [siblings.example];
+          }
+          delete siblings.example;
+        }
         return { ...resolved, ...siblings };
       }
 

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -1674,22 +1674,6 @@ describe('toJSONSchema()', () => {
       });
     });
 
-    // it.only('if multiple examples are present in `examples` it should always use the first in the list', () => {
-    //   const oas = Oas.init(structuredClone(requestbodyExampleQuirksSpec));
-    //   const operation = oas.operation('/anything', 'post');
-
-    //   const schema = operation.getParametersAsJSONSchema();
-
-    //   expect(schema?.[0].schema.properties).toStrictEqual({
-    //     paymentMethodId: {
-    //       type: 'string',
-    //       examples: ['brazil.5e98df1f-1701-499b-a739-4e5e70d51c9b'],
-    //     },
-    //     amount: { type: 'string', examples: [25000] },
-    //     currency: { type: 'string', examples: ['brazil.BRL'] },
-    //   });
-    // });
-
     describe('quirks', () => {
       it('should catch thrown jsonpointer errors', () => {
         const oas = new Oas({

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -498,10 +498,10 @@ describe('toJSONSchema()', () => {
 
       it('should normalize a primitive `example` sibling alongside a $ref to `examples`', () => {
         const usedSchemas = new Map();
-        const result = toJSONSchema(
-          { $ref: '#/components/schemas/Pet', example: 'fido' } as unknown as SchemaObject,
-          { definition, usedSchemas },
-        );
+        const result = toJSONSchema({ $ref: '#/components/schemas/Pet', example: 'fido' } as unknown as SchemaObject, {
+          definition,
+          usedSchemas,
+        });
 
         expect(result).toStrictEqual({
           $ref: '#/components/schemas/Pet',
@@ -511,10 +511,10 @@ describe('toJSONSchema()', () => {
 
       it('should normalize a numeric `example` sibling alongside a $ref to `examples`', () => {
         const usedSchemas = new Map();
-        const result = toJSONSchema(
-          { $ref: '#/components/schemas/Pet', example: 42 } as unknown as SchemaObject,
-          { definition, usedSchemas },
-        );
+        const result = toJSONSchema({ $ref: '#/components/schemas/Pet', example: 42 } as unknown as SchemaObject, {
+          definition,
+          usedSchemas,
+        });
 
         expect(result).toStrictEqual({
           $ref: '#/components/schemas/Pet',

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -496,6 +496,43 @@ describe('toJSONSchema()', () => {
         expect(cached).toHaveProperty('type', 'object');
       });
 
+      it('should normalize a primitive `example` sibling alongside a $ref to `examples`', () => {
+        const usedSchemas = new Map();
+        const result = toJSONSchema(
+          { $ref: '#/components/schemas/Pet', example: 'fido' } as unknown as SchemaObject,
+          { definition, usedSchemas },
+        );
+
+        expect(result).toStrictEqual({
+          $ref: '#/components/schemas/Pet',
+          examples: ['fido'],
+        });
+      });
+
+      it('should normalize a numeric `example` sibling alongside a $ref to `examples`', () => {
+        const usedSchemas = new Map();
+        const result = toJSONSchema(
+          { $ref: '#/components/schemas/Pet', example: 42 } as unknown as SchemaObject,
+          { definition, usedSchemas },
+        );
+
+        expect(result).toStrictEqual({
+          $ref: '#/components/schemas/Pet',
+          examples: [42],
+        });
+      });
+
+      it('should not promote a non-primitive `example` sibling alongside a $ref', () => {
+        const usedSchemas = new Map();
+        const result = toJSONSchema(
+          { $ref: '#/components/schemas/Pet', example: { name: 'fido' } } as unknown as SchemaObject,
+          { definition, usedSchemas },
+        );
+
+        expect(result).not.toHaveProperty('examples');
+        expect(result).not.toHaveProperty('example');
+      });
+
       it('should inline a bare `$ref` when the same component was already converted in this pass', () => {
         const usedSchemas = new Map();
         const result = toJSONSchema(
@@ -1636,6 +1673,22 @@ describe('toJSONSchema()', () => {
         currency: { type: 'string', examples: ['brazil.BRL'] },
       });
     });
+
+    // it.only('if multiple examples are present in `examples` it should always use the first in the list', () => {
+    //   const oas = Oas.init(structuredClone(requestbodyExampleQuirksSpec));
+    //   const operation = oas.operation('/anything', 'post');
+
+    //   const schema = operation.getParametersAsJSONSchema();
+
+    //   expect(schema?.[0].schema.properties).toStrictEqual({
+    //     paymentMethodId: {
+    //       type: 'string',
+    //       examples: ['brazil.5e98df1f-1701-499b-a739-4e5e70d51c9b'],
+    //     },
+    //     amount: { type: 'string', examples: [25000] },
+    //     currency: { type: 'string', examples: ['brazil.BRL'] },
+    //   });
+    // });
 
     describe('quirks', () => {
       it('should catch thrown jsonpointer errors', () => {


### PR DESCRIPTION
| 🚥 Resolves CX-3542 |
| :------------------- |

## 🧰 Changes
If a parameter uses a `$ref` pointer and has an `example` keyword, we currently don't do anything with it. The changes here converts it to the `examples` keyword since the singular version is deprecated and use of it is discouraged.

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
