### PR TITLE
feat(oas): support OAuth client credential defaults in x-default

### DIFF
--- a/.changeset/cool-oauth-defaults.md
+++ b/.changeset/cool-oauth-defaults.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Support OAuth client credential defaults in `x-default` security schemes without treating them as access token defaults.

--- a/packages/oas/src/lib/get-auth.ts
+++ b/packages/oas/src/lib/get-auth.ts
@@ -1,10 +1,24 @@
-import type { AuthForHAR, KeyedSecuritySchemeObject, OASDocument, User } from '../types.js';
+import type {
+  AuthForHAR,
+  KeyedSecuritySchemeObject,
+  OASDocument,
+  SecuritySchemeDefaultAuthPrimitive,
+  User,
+} from '../types.js';
 
 import { isRef } from '../types.js';
 
 import { dereferenceRef } from './refs.js';
 
 type authKey = unknown | { password: number | string; user: number | string } | null;
+
+function getPrimitiveDefaultAuth(scheme: KeyedSecuritySchemeObject): SecuritySchemeDefaultAuthPrimitive | null {
+  // For OAuth, primitive `x-default` values are token defaults. Object-shaped defaults
+  // are reserved for API Explorer client credentials and should not be sent as auth.
+  return typeof scheme['x-default'] === 'number' || typeof scheme['x-default'] === 'string'
+    ? scheme['x-default']
+    : null;
+}
 
 /**
  * @param user User to retrieve retrieve an auth key for.
@@ -13,6 +27,8 @@ type authKey = unknown | { password: number | string; user: number | string } | 
 function getKey(user: User, scheme: KeyedSecuritySchemeObject): authKey {
   switch (scheme.type) {
     case 'oauth2':
+      return user[scheme._key] || user.apiKey || getPrimitiveDefaultAuth(scheme) || null;
+
     case 'apiKey':
       return user[scheme._key] || user.apiKey || scheme['x-default'] || null;
 

--- a/packages/oas/src/types.ts
+++ b/packages/oas/src/types.ts
@@ -55,6 +55,25 @@ export interface DataForHAR {
 
 export type AuthForHAR = Record<string, number | string | { pass?: string; user?: string }>;
 
+export type SecuritySchemeDefaultAuthPrimitive = number | string;
+
+export interface BasicAuthDefault {
+  pass?: SecuritySchemeDefaultAuthPrimitive;
+  user?: SecuritySchemeDefaultAuthPrimitive;
+}
+
+export interface OAuthClientCredentialsDefault {
+  client_id?: SecuritySchemeDefaultAuthPrimitive;
+  client_secret?: SecuritySchemeDefaultAuthPrimitive;
+  clientId?: SecuritySchemeDefaultAuthPrimitive;
+  clientSecret?: SecuritySchemeDefaultAuthPrimitive;
+}
+
+export type SecuritySchemeDefaultAuth =
+  | SecuritySchemeDefaultAuthPrimitive
+  | BasicAuthDefault
+  | OAuthClientCredentialsDefault;
+
 export interface User {
   [key: string]: unknown;
   keys?: {
@@ -288,7 +307,7 @@ export type KeyedSecuritySchemeObject = SecuritySchemeObject & {
 
   // `x-default` is our custom extension for specifying auth defaults.
   // https://docs.readme.com/docs/openapi-extensions#authentication-defaults
-  'x-default'?: number | string | { pass?: number | string; user?: number | string };
+  'x-default'?: SecuritySchemeDefaultAuth;
 };
 
 /**

--- a/packages/oas/test/lib/get-auth.test.ts
+++ b/packages/oas/test/lib/get-auth.test.ts
@@ -94,6 +94,24 @@ describe('#getByScheme', () => {
     expect(getByScheme(topLevelUser, { type: 'oauth2', flows: {}, _key: 'authscheme' })).toBe('123456');
   });
 
+  it('should return default property for oauth', () => {
+    expect(getByScheme({}, { type: 'oauth2', flows: {}, _key: 'authscheme', 'x-default': 'default' })).toBe('default');
+  });
+
+  it('should not return OAuth client credential defaults as an auth token', () => {
+    expect(
+      getByScheme(
+        {},
+        {
+          type: 'oauth2',
+          flows: {},
+          _key: 'authscheme',
+          'x-default': { client_id: 'default-client-id', client_secret: 'default-client-secret' },
+        },
+      ),
+    ).toBeNull();
+  });
+
   it('should return apiKey property for apiKey', () => {
     expect(getByScheme(topLevelUser, { type: 'oauth2', flows: {}, _key: 'authscheme' })).toBe('123456');
   });


### PR DESCRIPTION
| 🚥 Resolves CX-2723 | 
| :------------------- | 

## 🧰 Changes

Adds OAS support for OAuth client credential defaults in `x-default`.

This PR widens the `x-default` security scheme type so OAuth schemes can define client credential defaults:

```yaml
x-default:
  client_id: default-client-id
  client_secret: default-client-secret
```

It also keeps OAuth token defaults and OAuth client credential defaults separate. Primitive `x-default` values still behave as auth token defaults, while object-shaped OAuth defaults are treated as API Explorer client credential metadata and are not returned by `getAuth()` as an auth token.

The paired ReadMe app change is in [readmeio/readme#19277](https://github.com/readmeio/readme/pull/19277), which consumes these defaults to prefill the OAuth client ID and client secret fields.

## 🧬 QA & Testing

Screen recording:

https://github.com/user-attachments/assets/46c494bb-2b75-4761-b9db-98a9737e8f1e

Expected behavior:

- An OAuth scheme with a primitive `x-default` still returns that value from `getAuth()` as the OAuth auth/token default.
- An OAuth scheme with object-shaped `x-default` client credentials does not return that object from `getAuth()` as an auth token.
- The object-shaped `x-default` remains available on the security scheme for the ReadMe app to read.
- When paired with [readmeio/readme#19277](https://github.com/readmeio/readme/pull/19277), `client_id` and `client_secret` prefill the OAuth client ID and client secret fields in API Explorer.
- Existing user-provided auth still takes precedence over `x-default`.