### PR TITLE
fix(oas): ignore reserved header parameters in schema output

### DIFF
--- a/.changeset/cx-3544-reserved-headers.md
+++ b/.changeset/cx-3544-reserved-headers.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Ignore reserved custom header parameters when generating JSON Schema for operations.

--- a/packages/oas/src/operation/transformers/get-parameters-as-json-schema.ts
+++ b/packages/oas/src/operation/transformers/get-parameters-as-json-schema.ts
@@ -17,6 +17,12 @@ import {
 } from '../../lib/refs.js';
 import { isRef } from '../../types.js';
 
+const RESERVED_HEADER_PARAMETERS = new Set(['accept', 'authorization', 'content-type']);
+
+function isReservedHeaderParameter(param: ParameterObject) {
+  return param.in === 'header' && RESERVED_HEADER_PARAMETERS.has(param.name.toLowerCase());
+}
+
 /**
  * The order of this object determines how they will be sorted in the compiled JSON Schema
  * representation.
@@ -177,7 +183,11 @@ export function getParametersAsJSONSchema(
 
         // This `as` actually *could* be a ref, but we don't want refs to pass through here, so
         // `.in` will never match `type`
-        const parameters = operationParams.filter(param => (param as ParameterObject).in === type);
+        const parameters = operationParams.filter(param => {
+          const parameter = param as ParameterObject;
+
+          return parameter.in === type && !isReservedHeaderParameter(parameter);
+        });
         if (parameters.length === 0) {
           return null;
         }

--- a/packages/oas/src/operation/transformers/get-parameters-as-json-schema.ts
+++ b/packages/oas/src/operation/transformers/get-parameters-as-json-schema.ts
@@ -181,12 +181,8 @@ export function getParametersAsJSONSchema(
       .map(type => {
         const required: string[] = [];
 
-        // This `as` actually *could* be a ref, but we don't want refs to pass through here, so
-        // `.in` will never match `type`
         const parameters = operationParams.filter(param => {
-          const parameter = param as ParameterObject;
-
-          return parameter.in === type && !isReservedHeaderParameter(parameter);
+          return param.in === type && !isReservedHeaderParameter(param);
         });
         if (parameters.length === 0) {
           return null;

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -98,6 +98,149 @@ describe('.getParametersAsJSONSchema()', () => {
     expect(createOasForOperation({}).operation('/', 'get').getParametersAsJSONSchema()).toBeNull();
   });
 
+  it('should ignore reserved custom header parameters case-insensitively', async () => {
+    const oas = createOasForOperation({
+      parameters: [
+        { in: 'header', name: 'Accept', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'accept', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'ACCEPT', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'Content-Type', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'content-type', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'CONTENT-TYPE', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'Authorization', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'authorization', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'AUTHORIZATION', required: true, schema: { type: 'string' } },
+        { in: 'header', name: 'X-Request-ID', required: true, schema: { type: 'string' } },
+      ],
+    });
+
+    const schemas = oas.operation('/', 'get').getParametersAsJSONSchema();
+
+    expect(schemas).toStrictEqual([
+      {
+        label: 'Headers',
+        type: 'header',
+        schema: {
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            'X-Request-ID': {
+              type: 'string',
+            },
+          },
+          required: ['X-Request-ID'],
+        },
+      },
+    ]);
+    await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+  });
+
+  it('should not ignore reserved names outside of header parameters', async () => {
+    const oas = createOasForOperation({
+      parameters: [
+        { in: 'path', name: 'Accept', required: true, schema: { type: 'string' } },
+        { in: 'query', name: 'Content-Type', required: true, schema: { type: 'string' } },
+        { in: 'cookie', name: 'Authorization', required: true, schema: { type: 'string' } },
+      ],
+    });
+
+    const schemas = oas.operation('/', 'get').getParametersAsJSONSchema();
+
+    expect(schemas).toStrictEqual([
+      {
+        label: 'Path Params',
+        type: 'path',
+        schema: {
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            Accept: {
+              type: 'string',
+            },
+          },
+          required: ['Accept'],
+        },
+      },
+      {
+        label: 'Query Params',
+        type: 'query',
+        schema: {
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            'Content-Type': {
+              type: 'string',
+            },
+          },
+          required: ['Content-Type'],
+        },
+      },
+      {
+        label: 'Cookie Params',
+        type: 'cookie',
+        schema: {
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            Authorization: {
+              type: 'string',
+            },
+          },
+          required: ['Authorization'],
+        },
+      },
+    ]);
+    await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+  });
+
+  it('should preserve request body schemas when ignoring reserved custom header parameters', async () => {
+    const oas = createOasForOperation({
+      parameters: [
+        {
+          in: 'header',
+          name: 'Content-Type',
+          schema: {
+            default: 'text/plain',
+            type: 'string',
+          },
+        },
+      ],
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const schemas = oas.operation('/', 'get').getParametersAsJSONSchema();
+
+    expect(schemas).toStrictEqual([
+      {
+        label: 'Body Params',
+        type: 'body',
+        schema: {
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    ]);
+    await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+  });
+
   describe('type sorting', () => {
     let operation: OperationObject;
 
@@ -1183,7 +1326,7 @@ describe('.getParametersAsJSONSchema()', () => {
         parameters: [
           {
             in: 'header',
-            name: 'Accept',
+            name: 'X-Accept',
             description: 'Expected response format.',
             schema: {
               type: 'string',
@@ -1201,7 +1344,7 @@ describe('.getParametersAsJSONSchema()', () => {
             $schema: 'http://json-schema.org/draft-04/schema#',
             type: 'object',
             properties: {
-              Accept: {
+              'X-Accept': {
                 description: 'Expected response format.',
                 type: 'string',
               },
@@ -1411,7 +1554,7 @@ describe('.getParametersAsJSONSchema()', () => {
           parameters: [
             {
               in: 'header',
-              name: 'Accept',
+              name: 'X-Accept',
               deprecated: true,
               schema: {
                 type: 'string',
@@ -1430,7 +1573,7 @@ describe('.getParametersAsJSONSchema()', () => {
               $schema: 'http://json-schema.org/draft-04/schema#',
               type: 'object',
               properties: {
-                Accept: {
+                'X-Accept': {
                   type: 'string',
                   deprecated: true,
                 },


### PR DESCRIPTION
| 🚥 Resolves CX-3544 |
| :------------------- |

## 🧰 Changes

API Explorer was rendering reserved header parameters like `Accept`, `Content-Type`, and `Authorization` when they were defined as custom `header` params in an OpenAPI file. Those names are reserved by OAS and should be ignored as custom header parameters.

This filters those reserved header params out of `getParametersAsJSONSchema()` so they don't show up as editable request fields or interfere with request body rendering.

Normal custom headers still render, and the reserved names are only ignored when they're defined as header parameters.

## 🧬 QA & Testing

Added coverage for the CX-3544 cases:

- reserved header params are ignored case-insensitively
- normal headers like `X-Request-ID` still render
- reserved names in non-header locations still render
- request body schemas are preserved when a reserved `Content-Type` header param is ignored