### PR TITLE
refactor(oas): removing our dependency on `memoizee`

### DIFF
--- a/.changeset/hip-snakes-clean.md
+++ b/.changeset/hip-snakes-clean.md
@@ -2,4 +2,4 @@
 "oas": patch
 ---
 
-Remove depenency on `memoizee`
+Remove dependency on `memoizee`

--- a/.changeset/hip-snakes-clean.md
+++ b/.changeset/hip-snakes-clean.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Remove depenency on `memoizee`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4893,13 +4893,6 @@
         "@types/json-schema": "*"
       }
     },
-    "node_modules/@types/memoizee": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
-      "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
@@ -6442,19 +6435,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/d": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6675,63 +6655,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.64",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "esniff": "^2.0.1",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "node_modules/es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "license": "MIT"
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "ext": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -7010,21 +6938,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/esniff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -7118,16 +7031,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7190,15 +7093,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "license": "ISC",
-      "dependencies": {
-        "type": "^2.7.2"
       }
     },
     "node_modules/extendable-error": {
@@ -7969,12 +7863,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "license": "MIT"
     },
     "node_modules/is-regexp": {
       "version": "1.0.0",
@@ -9098,15 +8986,6 @@
       "devOptional": true,
       "license": "ISC"
     },
-    "node_modules/lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9247,25 +9126,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/memoizee": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
-      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.2",
-        "es5-ext": "^0.10.64",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/merge-stream": {
@@ -9494,12 +9354,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC"
     },
     "node_modules/nock": {
       "version": "14.0.11",
@@ -11350,19 +11204,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/timers-ext": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
-      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.64",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11633,12 +11474,6 @@
         "@turbo/windows-64": "2.9.16",
         "@turbo/windows-arm64": "2.9.16"
       }
-    },
-    "node_modules/type": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -12583,7 +12418,7 @@
       }
     },
     "packages/oas": {
-      "version": "36.0.0",
+      "version": "36.0.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^14.1.1",
@@ -12592,7 +12427,6 @@
         "json-schema-merge-allof": "^0.8.1",
         "jsonpath-plus": "^10.4.0",
         "jsonpointer": "^5.0.0",
-        "memoizee": "^0.4.16",
         "openapi-types": "^12.1.1",
         "path-to-regexp": "^8.4.2",
         "remove-undefined-objects": "^9.0.0"
@@ -12600,7 +12434,6 @@
       "devDependencies": {
         "@readme/oas-examples": "file:../oas-examples",
         "@types/json-schema-merge-allof": "^0.6.5",
-        "@types/memoizee": "^0.4.12",
         "@types/node": "^25.3.0",
         "jest-expect-jsonschema": "file:../jest-expect-jsonschema",
         "jest-expect-openapi": "file:../jest-expect-openapi",

--- a/packages/oas/package.json
+++ b/packages/oas/package.json
@@ -89,7 +89,6 @@
     "json-schema-merge-allof": "^0.8.1",
     "jsonpath-plus": "^10.4.0",
     "jsonpointer": "^5.0.0",
-    "memoizee": "^0.4.16",
     "openapi-types": "^12.1.1",
     "path-to-regexp": "^8.4.2",
     "remove-undefined-objects": "^9.0.0"
@@ -97,7 +96,6 @@
   "devDependencies": {
     "@readme/oas-examples": "file:../oas-examples",
     "@types/json-schema-merge-allof": "^0.6.5",
-    "@types/memoizee": "^0.4.12",
     "@types/node": "^25.3.0",
     "jest-expect-jsonschema": "file:../jest-expect-jsonschema",
     "jest-expect-openapi": "file:../jest-expect-openapi",

--- a/packages/oas/src/samples/index.ts
+++ b/packages/oas/src/samples/index.ts
@@ -7,7 +7,6 @@
 import type { OASDocument, SchemaObject } from '../types.js';
 
 import mergeJSONSchemaAllOf from 'json-schema-merge-allof';
-import memoize from 'memoizee';
 
 import { isRef } from '../types.js';
 import { dereferenceRef, dereferenceRefDeep } from '../utils.js';
@@ -71,7 +70,7 @@ const primitive = (schema: SchemaObject) => {
  *
  * @param schema JSON Schema to generate a sample for.
  */
-function sampleFromSchema(
+export default function sampleFromSchema(
   schema: SchemaObject,
   opts: {
     /**
@@ -289,7 +288,3 @@ function sampleFromResolvedSchema(
 
   return primitive(schema);
 }
-
-const memo: typeof sampleFromSchema = memoize(sampleFromSchema);
-
-export default memo;

--- a/packages/oas/test/samples/index.test.ts
+++ b/packages/oas/test/samples/index.test.ts
@@ -11,21 +11,6 @@ import { describe, expect, it } from 'vitest';
 import sampleFromSchema from '../../src/samples/index.js';
 
 describe('sampleFromSchema', () => {
-  it('should be memoized', async () => {
-    const schema: SchemaObject = {
-      type: 'string',
-      format: 'date-time',
-    };
-
-    const firstRun = sampleFromSchema(schema);
-
-    await new Promise(r => {
-      setTimeout(r, 200);
-    });
-
-    expect(sampleFromSchema(schema)).toStrictEqual(firstRun);
-  });
-
   it('returns object with no readonly fields for parameter', () => {
     const definition: SchemaObject = {
       type: 'object',


### PR DESCRIPTION
| 🚥 Resolves https://github.com/readmeio/oas/issues/1144 |
| :------------------- |

## 🧰 Changes

Refactors away the dependency on [memoizee](https://npm.im/memoizee) that `oas` had.

This dependency was originally pulled in when we forked this sample generation code from Swagger UI and they were using it for time-volatile sample values, something that didn't need to happen because these kinds of sample values are already memoized with the `primitives` configuration:

https://github.com/readmeio/oas/blob/901f37bc3995249e0490ffba35b69135d2b6843d/packages/oas/src/samples/index.ts#L21-L36