### PR TITLE
fix(oas-normalize): dont allow unsafe URLs to be accessed

### DIFF
--- a/.changeset/wicked-turkeys-prove.md
+++ b/.changeset/wicked-turkeys-prove.md
@@ -1,0 +1,6 @@
+---
+"oas-normalize": minor
+"@readme/openapi-parser": minor
+---
+
+Resolve an oversight in `oas-normalize` where it did not use `@readme/openapi-parser`'s HTTP fetching mechanisms, had its own, and could load private URLs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12418,7 +12418,7 @@
       }
     },
     "packages/oas": {
-      "version": "36.0.3",
+      "version": "37.0.0",
       "license": "MIT",
       "dependencies": {
         "@readme/openapi-parser": "^6.1.3",
@@ -12446,7 +12446,7 @@
     },
     "packages/oas-examples": {
       "name": "@readme/oas-examples",
-      "version": "8.2.1",
+      "version": "8.2.2",
       "license": "MIT",
       "devDependencies": {
         "@readme/openapi-parser": "file:../parser",
@@ -12482,11 +12482,11 @@
     },
     "packages/oas-to-har": {
       "name": "@readme/oas-to-har",
-      "version": "36.0.0",
+      "version": "37.0.0",
       "license": "ISC",
       "dependencies": {
         "@readme/data-urls": "^4.0.3",
-        "oas": "^36.0.0",
+        "oas": "^37.0.0",
         "qs": "^6.15.2",
         "remove-undefined-objects": "^9.0.0"
       },
@@ -12505,11 +12505,11 @@
     },
     "packages/oas-to-snippet": {
       "name": "@readme/oas-to-snippet",
-      "version": "36.0.0",
+      "version": "37.0.0",
       "license": "MIT",
       "dependencies": {
         "@readme/httpsnippet": "^11.3.0",
-        "@readme/oas-to-har": "^36.0.0"
+        "@readme/oas-to-har": "^37.0.0"
       },
       "devDependencies": {
         "@readme/oas-examples": "file:../oas-examples",

--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -5,6 +5,7 @@ import type { OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import fs from 'node:fs';
 
 import { bundle, compileErrors, dereference, validate } from '@readme/openapi-parser';
+import { isUnsafeURL } from '@readme/openapi-parser/lib/urls';
 import postmanToOpenAPI from '@readme/postman-to-openapi';
 import converter from 'swagger2openapi';
 
@@ -81,6 +82,10 @@ export default class OASNormalize {
 
       case 'url': {
         const { url, options } = prepareURL(this.file);
+        if (isUnsafeURL(url)) {
+          throw new Error(`Sorry, we cannot access ${url}.`);
+        }
+
         const resp = await fetch(url, options).then(res => res.text());
         return resolve(resp);
       }

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -83,6 +83,14 @@ describe('OASNormalize', () => {
           await expect(o.load()).resolves.toStrictEqual(json);
         });
 
+        it('should not support private IPs', async () => {
+          nock('http://10.0.0.1').get(`/api-${version}.json`).reply(200, json);
+
+          const o = new OASNormalize(`http://10.0.0.1/api-${version}.json`);
+
+          await expect(o.load()).rejects.toThrow(`Sorry, we cannot access http://10.0.0.1/api-${version}.json`);
+        });
+
         it('should support URLs with basic auth', async () => {
           nock('https://@example.com', {
             reqheaders: {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -15,6 +15,10 @@
       "require": "./dist/lib/assertions.cjs",
       "import": "./dist/lib/assertions.js"
     },
+    "./lib/urls": {
+      "require": "./dist/lib/urls.cjs",
+      "import": "./dist/lib/urls.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/index.cjs",

--- a/packages/parser/src/lib/urls.ts
+++ b/packages/parser/src/lib/urls.ts
@@ -1,0 +1,11 @@
+import { isUnsafeUrl } from '@apidevtools/json-schema-ref-parser';
+
+/**
+ * Determine if a given URL is unsafe.
+ *
+ * An unsafe URL is one that is not publicly accessible (no private IPs, private ports, etc.)
+ *
+ */
+export function isUnsafeURL(url: string): boolean {
+  return isUnsafeUrl(url);
+}

--- a/packages/parser/test/lib/urls.test.ts
+++ b/packages/parser/test/lib/urls.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUnsafeURL } from '../../src/lib/urls.js';
+
+describe('#isUnsafeURL', () => {
+  it.each([
+    '',
+    '   ',
+    'javascript:alert(1)', // oxlint-disable-line no-script-url
+    'vbscript:msgbox(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'file:///etc/passwd',
+    'http://localhost/',
+    'http://127.0.0.1/',
+    'http://192.168.1.1/',
+    'http://10.0.0.1/',
+    'http://172.16.0.1/',
+    'http://169.254.0.1/',
+    'http://service.local/',
+    'http://redis:6379/',
+    'https://example.com:8080/',
+    'http://db.example.com:27017',
+    'http://::1',
+    'https://fc00::1',
+    'http://fe80::1',
+    'https://::ffff:127.0.0.1',
+  ])('should treat `%s` as unsafe', url => {
+    expect(isUnsafeURL(url)).toBe(true);
+  });
+
+  it.each([
+    'https://example.com/',
+    'https://api.github.com/repos',
+    'http://2001:4860:4860::8888',
+    '/schemas/pet.json',
+    './schemas/pet.json',
+    '../schemas/pet.json',
+  ])('should treat `%s` as safe', url => {
+    expect(isUnsafeURL(url)).toBe(false);
+  });
+});

--- a/packages/parser/tsup.config.ts
+++ b/packages/parser/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig(options => ({
   ...options,
   ...config,
 
-  entry: ['src/index.ts', 'src/lib/assertions.ts'],
+  entry: ['src/index.ts', 'src/lib/assertions.ts', 'src/lib/urls.ts'],
   silent: !options.watch,
 }));


### PR DESCRIPTION
## 🧰 Changes

This resolves an oversight in `oas-normalize` where it did not use `@readme/openapi-parser`'s HTTP fetching mechanisms, had its own, and could load private URLs.

Instead of using `@readme/openapi-parser`'s HTTP fetching mechanism, which would have required a pretty large overhaul to `oas-normalize` I'm instead exposing the unsafe URL method that we have access to via [@apidevtools/json-schema-ref-parser](https://npm.im/@apidevtools/json-schema-ref-parser) (and writing our own tests for it).
