### PR TITLE
feat(oas): add `status-url` ReadMe extension

### DIFF
--- a/.changeset/rm-17218-status-url-extension.md
+++ b/.changeset/rm-17218-status-url-extension.md
@@ -1,5 +1,0 @@
----
-"oas": minor
----
-
-Add support for the `status-url` ReadMe extension (`x-readme.status-url`). This customer-declared health/status URL is surfaced to AI agents as the RFC 9727 `status` link relation in the project's `/.well-known/api-catalog` (RM-17218).

--- a/.changeset/rm-17218-status-url-extension.md
+++ b/.changeset/rm-17218-status-url-extension.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+Add support for the `status-url` ReadMe extension (`x-readme.status-url`). This customer-declared health/status URL is surfaced to AI agents as the RFC 9727 `status` link relation in the project's `/.well-known/api-catalog` (RM-17218).

--- a/.changeset/status-url-extension.md
+++ b/.changeset/status-url-extension.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+Add support for the `status-url` ReadMe extension (`x-readme.status-url`). This customer-declared health/status URL is surfaced to AI agents as the RFC 9727 `status` link relation in the project's `/.well-known/api-catalog`.

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -220,6 +220,21 @@ export const SIMPLE_MODE = 'simple-mode';
  */
 export const DISABLE_TAG_SORTING = 'disable-tag-sorting';
 
+/**
+ * A customer-declared health/status URL for the API. When present, it's surfaced to AI agents as
+ * the RFC 9727 `status` link relation in the project's `/.well-known/api-catalog`.
+ *
+ * @see {@link https://docs.readme.com/main/docs/openapi-extensions}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9727}
+ * @example
+ * {
+ *  "x-readme": {
+ *    "status-url": "https://status.example.com"
+ *  }
+ * }
+ */
+export const STATUS_URL = 'status-url';
+
 export interface Extensions {
   [CODE_SAMPLES]:
     | {
@@ -298,6 +313,7 @@ export interface Extensions {
   [PROXY_ENABLED]: boolean;
   [SAMPLES_LANGUAGES]: string[];
   [SIMPLE_MODE]: boolean;
+  [STATUS_URL]: string | undefined;
 }
 
 export const extensionDefaults: Extensions = {
@@ -312,6 +328,7 @@ export const extensionDefaults: Extensions = {
   [PROXY_ENABLED]: true,
   [SAMPLES_LANGUAGES]: ['shell', 'node', 'ruby', 'php', 'python', 'java', 'csharp'],
   [SIMPLE_MODE]: true,
+  [STATUS_URL]: undefined,
 };
 
 /**

--- a/packages/oas/test/extensions.test.ts
+++ b/packages/oas/test/extensions.test.ts
@@ -15,6 +15,7 @@ describe('extension defaults', () => {
     ['PROXY_ENABLED'],
     ['SAMPLES_LANGUAGES'],
     ['SIMPLE_MODE'],
+    ['STATUS_URL'],
   ])('%s should have a default value', extension => {
     expect(extensions.extensionDefaults).toHaveProperty(extensions[extension]);
   });
@@ -60,6 +61,17 @@ describe('#getExtension', () => {
       });
 
       expect(oas.getExtension(extensions.SAMPLES_LANGUAGES)).toStrictEqual(['swift']);
+    });
+
+    it('should locate a `status-url` set under `x-readme`', () => {
+      const oas = Oas.init({
+        ...petstore,
+        'x-readme': {
+          [extensions.STATUS_URL]: 'https://status.example.com',
+        },
+      });
+
+      expect(oas.getExtension(extensions.STATUS_URL)).toBe('https://status.example.com');
     });
 
     it('should locate an extensions listed at the root', () => {


### PR DESCRIPTION
| 🚥 Resolves RM-17218 |
| :------------------- |

## 🧰 Changes

In efforts to implement [RFC-9727](https://www.rfc-editor.org/info/rfc9727/), we want to define a new custom `status-url` extension under the `x-readme` convention so we can keep track of the health URLs of OAS files.

```jsonc
{
  "x-readme": {
    "status-url": "https://status.example.com"
  }
}
```

The goal is to eventually surface these as the RFC 9727 `status` link relation in a project's `/.well-known/api-catalog`, so agents have a way to _'health-check'_ APIs without us needing to do it for them. This PR only defines the extension and its default (`undefined`); surfacing it is separate follow-up work.

## 🧬 QA & Testing

Covered by unit tests in `packages/oas/test/extensions.test.ts`: asserts the extension has a default value and that `getExtension` locates it under `x-readme`.
