### PR TITLE
fix(oas-normalize): improved handling for invalid URLs

### DIFF
--- a/.changeset/chubby-steaks-turn.md
+++ b/.changeset/chubby-steaks-turn.md
@@ -1,0 +1,5 @@
+---
+"oas-normalize": patch
+---
+
+Improved handling for when a URL to retrieve an API definition returns a non-200 HTTP status code or invalid JSON.

--- a/packages/oas-normalize/src/index.ts
+++ b/packages/oas-normalize/src/index.ts
@@ -67,6 +67,10 @@ export default class OASNormalize {
 
     const resolve = (obj: Parameters<typeof stringToJSON>[0]) => {
       const ret = stringToJSON(obj);
+      if (!ret) {
+        throw new Error(`Unable to retrieve API definition, it does not appear to be valid JSON.`);
+      }
+
       this.cache.load = ret;
       return ret;
     };
@@ -86,7 +90,13 @@ export default class OASNormalize {
           throw new Error(`Sorry, we cannot access ${url}.`);
         }
 
-        const resp = await fetch(url, options).then(res => res.text());
+        const resp = await fetch(url, options).then(res => {
+          if (!res.ok) {
+            throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+          }
+
+          return res.text();
+        });
         return resolve(resp);
       }
 

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -91,6 +91,24 @@ describe('OASNormalize', () => {
           await expect(o.load()).rejects.toThrow(`Sorry, we cannot access http://10.0.0.1/api-${version}.json`);
         });
 
+        it('should throw on a URL returning a non-200 status', async () => {
+          nock('https://example.com').get(`/404.json`).reply(404);
+
+          const o = new OASNormalize(`https://example.com/404.json`);
+
+          await expect(o.validate()).rejects.toThrow('Failed to fetch https://example.com/404.json: Not Found');
+        });
+
+        it('should throw on a URL returning an invalid API definition', async () => {
+          nock('https://example.com').get(`/invalid-json.json`).reply(200);
+
+          const o = new OASNormalize(`https://example.com/invalid-json.json`);
+
+          await expect(o.validate()).rejects.toThrow(
+            'Unable to retrieve API definition, it does not appear to be valid JSON.',
+          );
+        });
+
         it('should support URLs with basic auth', async () => {
           nock('https://@example.com', {
             reqheaders: {


### PR DESCRIPTION
## 🧰 Changes

This adds some improved checks into `oas-normalize` for when a URL it's attempting to access returns a non-200 HTTP status code, or otherwise does not contain JSON.