### PR TITLE
test(oas-to-har): cover optional auth alternatives

### DIFF
--- a/packages/oas-to-har/test/__datasets__/security.json
+++ b/packages/oas-to-har/test/__datasets__/security.json
@@ -46,6 +46,11 @@
       "post": {
         "security": [{ "auth_header": [], "auth_headerAlt": [] }]
       }
+    },
+    "/optional-auth-or": {
+      "post": {
+        "security": [{}, { "auth_header": [] }]
+      }
     }
   },
   "components": {

--- a/packages/oas-to-har/test/auth.test.ts
+++ b/packages/oas-to-har/test/auth.test.ts
@@ -162,6 +162,24 @@ describe('auth handling', () => {
     ]);
   });
 
+  it('should work for optional auth alternatives', () => {
+    expect(
+      oasToHar(
+        spec,
+        spec.operation('/optional-auth-or', 'post'),
+        {},
+        {
+          auth_header: 'value',
+        },
+      ).log.entries[0].request.headers,
+    ).toStrictEqual([
+      {
+        name: 'x-auth-header',
+        value: 'value',
+      },
+    ]);
+  });
+
   it('should not set non-existent values', () => {
     const har = oasToHar(spec, spec.operation('/header', 'post'), {}, {});
 


### PR DESCRIPTION
## Summary

- Add an OAS-to-HAR fixture route whose operation allows anonymous access or API key auth.
- Assert supplied header auth is still serialized when one security alternative is empty.

## Validation

- Git diff whitespace check passed.
- Targeted Vitest run could not start because this temporary checkout has no installed Vitest dependency.
