### PR TITLE
perf(oas): analyze a single operation without reducing the definition first

### DIFF
--- a/.changeset/quiet-otters-analyze.md
+++ b/.changeset/quiet-otters-analyze.md
@@ -1,5 +1,5 @@
 ---
-"oas": minor
+"oas": major
 ---
 
-Add `analyzeOperation()` and `analyzeWebhookOperation()` to the analyzer, allowing a single operation or webhook to be analyzed directly against a full API definition without needing to reduce it down first. Dereferencing and JSONPath scanning are now cached per definition, so analyzing many operations out of the same definition no longer repeats that work for each one.
+Refactor `oas/analyzer` to support analyzing a single operation or webhook directly against a full API definition without needing to reduce it down first. `general.dereferencedFileSize` and `general.rawFileSize` are no longer supported.

--- a/.changeset/quiet-otters-analyze.md
+++ b/.changeset/quiet-otters-analyze.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+Add `analyzeOperation()` and `analyzeWebhookOperation()` to the analyzer, allowing a single operation or webhook to be analyzed directly against a full API definition without needing to reduce it down first. Dereferencing and JSONPath scanning are now cached per definition, so analyzing many operations out of the same definition no longer repeats that work for each one.

--- a/.changeset/quiet-otters-analyze.md
+++ b/.changeset/quiet-otters-analyze.md
@@ -2,4 +2,10 @@
 "oas": major
 ---
 
-Refactor `oas/analyzer` to support analyzing a single operation or webhook directly against a full API definition without needing to reduce it down first. `general.dereferencedFileSize` and `general.rawFileSize` are no longer supported.
+Refactor `oas/analyzer` to support analyzing a single operation or webhook directly against a full API definition without needing to reduce it down first.
+
+Breaking changes:
+
+* `dereferencedFileSize` and `rawFileSize` are no longer supported.
+* `oas/analyzer` no longer exports individual query functions, instead you can supply your specific queries as an array of strings to the `analyzer` function.
+* The object that `oas/analyzer` returns has also been reshaped to no longer have a `general` and `openapi` top-level key, everything is now flattened out.

--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -268,6 +268,15 @@ import analyzer from 'oas/analyzer';
 console.log(await analyzer(petstore));
 ```
 
+You can also supply a specific set of queries to run by supplying an array of strings to the `analyzer` function.
+
+```ts
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import analyzer from 'oas/analyzer';
+
+console.log(await analyzer(petstore, ['polymorphism', 'xml]));
+```
+
 ##### General
 
 <!-- prettier-ignore-start -->
@@ -291,9 +300,12 @@ console.log(await analyzer(petstore));
 | `links` | Does your API use [links](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object)? |
 | `style` | Do any parameters in your API require [style](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#user-content-parameterstyle) serialization?
 | `polymorphism` | Does your API use [polymorphism](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#composition-and-inheritance-polymorphism) (`anyOf`, `oneOf`, `allOf`)? |
+| `references` | Does your API use `$ref` pointers? |
 | `serverVariables` | Does your API use [server variables](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object)? |
 | `webhooks` | Does your API use [webhooks](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasWebhooks)?
-| `xml` | Does any parameter or schema in your API use the [XML object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object) for declaring how a schema should be treated in XML? |
+| `xmlRequests` | Does any parameter or schema in your API use the [XML object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object) for declaring how a schema should be treated in an XML request body? |
+| `xmlResponses` | Does any parameter or schema in your API use the [XML object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object) for declaring how a schema should be treated in an XML response? |
+| `xmlSchemas` | Does any parameter or schema in your API use the [XML object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object) for declaring how a schema should be treated in XML? |
 <!-- prettier-ignore-end -->
 
 #### Reducer

--- a/packages/oas/README.md
+++ b/packages/oas/README.md
@@ -273,10 +273,8 @@ console.log(await analyzer(petstore));
 <!-- prettier-ignore-start -->
 | Metric | Description |
 | :--- | :--- |
-| `dereferencedFileSize` | Size of the definition after resolving all references. |
 | `mediaTypes` | What are the different media type shapes that your API operations support? |
 | `operationTotal` | The total amount of operations in your definition. |
-| `rawFileSize` | Size of the definition in its raw form. |
 | `securityTypes` | The different types of security that your API contains. |
 <!-- prettier-ignore-end -->
 

--- a/packages/oas/src/analyzer/dereference.ts
+++ b/packages/oas/src/analyzer/dereference.ts
@@ -129,3 +129,29 @@ export async function dereferenceOas(
       throw err;
     });
 }
+
+/**
+ * `dereferenceOas()` caches its result against whatever object reference it's given, but callers
+ * that care about not mutating their original definition (like the analyzer) have historically had
+ * to pass in a fresh `structuredClone()` on every call — which means that cache is only ever a hit
+ * within a single call, never across separate analyses of the same definition.
+ *
+ * This wraps that up: it clones the given definition exactly once and reuses that same clone (and
+ * therefore `dereferenceOas()`'s cached result for it) for every subsequent call with the same
+ * original definition reference. This is what lets the analyzer dereference a large API definition
+ * a single time and reuse that work across an analysis of every operation within it, instead of
+ * re-dereferencing the whole thing per-operation.
+ *
+ * @param definition An OpenAPI definition to dereference.
+ */
+export function dereferenceOasShared(definition: OASDocument): Promise<DereferenceOasResult> {
+  let clone = sharedClones.get(definition);
+  if (!clone) {
+    clone = structuredClone(definition);
+    sharedClones.set(definition, clone);
+  }
+
+  return dereferenceOas(clone);
+}
+
+const sharedClones = new WeakMap<OASDocument, OASDocument>();

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -1,6 +1,6 @@
 import type { OAS31Document, OASDocument } from '../types.js';
 import type { OperationScope } from './scope.js';
-import type { OASAnalysis } from './types.js';
+import type { AnalyzerQuery, OASAnalysis } from './types.js';
 
 import { toPointer } from '../lib/refs.js';
 import { isOpenAPI31 } from '../types.js';
@@ -9,7 +9,6 @@ import { dereferenceOasShared } from './dereference.js';
 import {
   additionalProperties as analyzeAdditionalProperties,
   callbacks as analyzeCallbacks,
-  circularRefs as analyzeCircularRefs,
   commonParameters as analyzeCommonParameters,
   discriminators as analyzeDiscriminators,
   links as analyzeLinks,
@@ -27,26 +26,6 @@ import {
 } from './queries/openapi.js';
 import { computeOperationScope, computeWebhookScope, isPointerInScope } from './scope.js';
 
-export {
-  analyzeAdditionalProperties,
-  analyzeCallbacks,
-  analyzeCircularRefs,
-  analyzeCommonParameters,
-  analyzeDiscriminators,
-  analyzeLinks,
-  analyzeMediaTypes,
-  analyzeParameterSerialization,
-  analyzePolymorphism,
-  analyzeReferences,
-  analyzeSecurityTypes,
-  analyzeServerVariables,
-  analyzeTotalOperations,
-  analyzeWebhooks,
-  analyzeXMLRequests,
-  analyzeXMLResponses,
-  analyzeXMLSchemas,
-};
-
 /**
  * Run every analyzer query against a definition, optionally narrowed down to a single operation or
  * webhook's `OperationScope`.
@@ -58,145 +37,212 @@ export {
  * operations out of the same definition only pays the full-document cost once.
  *
  */
-async function buildAnalysis(definition: OASDocument, scope?: OperationScope): Promise<OASAnalysis> {
-  const { circularRefs: dereferencedCircularRefs } = await dereferenceOasShared(definition);
+async function buildAnalysis(
+  definition: OASDocument,
+  query?: AnalyzerQuery[],
+  scope?: OperationScope,
+): Promise<OASAnalysis> {
+  const analysis: OASAnalysis = {};
 
-  const additionalProperties = analyzeAdditionalProperties(definition, scope);
-  const callbacks = analyzeCallbacks(definition, scope);
-  const circularRefs = (
-    scope
-      ? dereferencedCircularRefs.filter(ref => isPointerInScope(toPointer(ref), scope))
-      : [...dereferencedCircularRefs]
-  ).toSorted();
-  const commonParameters = analyzeCommonParameters(definition, scope);
-  const discriminators = analyzeDiscriminators(definition, scope);
-  const links = analyzeLinks(definition, scope);
-  const parameterSerialization = analyzeParameterSerialization(definition, scope);
-  const polymorphism = analyzePolymorphism(definition, scope);
-  const references = analyzeReferences(definition, scope);
-  const serverVariables = analyzeServerVariables(definition);
-  const xmlSchemas = analyzeXMLSchemas(definition, scope);
-  const xmlRequests = analyzeXMLRequests(definition, scope);
-  const xmlResponses = analyzeXMLResponses(definition, scope);
-  const webhooks = analyzeWebhooks(definition, scope);
+  if (!query || query.includes('mediaTypes')) {
+    analysis.mediaTypes = {
+      name: 'Media Type',
+      found: analyzeMediaTypes(definition, scope),
+    };
+  }
 
-  const analysis: OASAnalysis = {
-    general: {
-      mediaTypes: {
-        name: 'Media Type',
-        found: analyzeMediaTypes(definition, scope),
-      },
-      operationTotal: {
-        name: 'Operation',
-        // A scoped analysis is, by definition, looking at exactly one operation.
-        found: scope ? 1 : analyzeTotalOperations(definition),
-      },
-      securityTypes: {
-        name: 'Security Type',
-        found: analyzeSecurityTypes(definition, scope),
-      },
-    },
-    openapi: {
-      additionalProperties: {
-        present: !!additionalProperties.length,
-        locations: additionalProperties,
-      },
-      callbacks: {
-        present: !!callbacks.length,
-        locations: callbacks,
-      },
-      circularRefs: {
-        present: !!circularRefs.length,
-        locations: circularRefs,
-      },
-      commonParameters: {
-        present: !!commonParameters.length,
-        locations: commonParameters,
-      },
-      discriminators: {
-        present: !!discriminators.length,
-        locations: discriminators,
-      },
-      links: {
-        present: !!links.length,
-        locations: links,
-      },
-      style: {
-        present: !!parameterSerialization.length,
-        locations: parameterSerialization,
-      },
-      polymorphism: {
-        present: !!polymorphism.length,
-        locations: polymorphism,
-      },
-      references: {
-        present: !!references.length,
-        locations: references,
-      },
-      serverVariables: {
-        present: !!serverVariables.length,
-        locations: serverVariables,
-      },
-      xmlRequests: {
-        present: !!xmlRequests.length,
-        locations: xmlRequests,
-      },
-      xmlResponses: {
-        present: !!xmlResponses.length,
-        locations: xmlResponses,
-      },
-      xmlSchemas: {
-        present: !!xmlSchemas.length,
-        locations: xmlSchemas,
-      },
-      webhooks: {
-        present: !!webhooks.length,
-        locations: webhooks,
-      },
-    },
-  };
+  if (!query || query.includes('operationTotal')) {
+    analysis.operationTotal = {
+      name: 'Operation',
+      // A scoped analysis is, by definition, looking at exactly one operation.
+      found: scope ? 1 : analyzeTotalOperations(definition),
+    };
+  }
+
+  if (!query || query.includes('securityTypes')) {
+    analysis.securityTypes = {
+      name: 'Security Type',
+      found: analyzeSecurityTypes(definition, scope),
+    };
+  }
+
+  if (!query || query.includes('additionalProperties')) {
+    const additionalProperties = analyzeAdditionalProperties(definition, scope);
+    analysis.additionalProperties = {
+      present: !!additionalProperties.length,
+      locations: additionalProperties,
+    };
+  }
+
+  if (!query || query.includes('callbacks')) {
+    const callbacks = analyzeCallbacks(definition, scope);
+    analysis.callbacks = {
+      present: !!callbacks.length,
+      locations: callbacks,
+    };
+  }
+
+  if (!query || query.includes('circularRefs')) {
+    const { circularRefs: dereferencedCircularRefs } = await dereferenceOasShared(definition);
+    const circularRefs = (
+      scope
+        ? dereferencedCircularRefs.filter(ref => isPointerInScope(toPointer(ref), scope))
+        : [...dereferencedCircularRefs]
+    ).toSorted();
+
+    analysis.circularRefs = {
+      present: !!circularRefs.length,
+      locations: circularRefs,
+    };
+  }
+
+  if (!query || query.includes('commonParameters')) {
+    const commonParameters = analyzeCommonParameters(definition, scope);
+    analysis.commonParameters = {
+      present: !!commonParameters.length,
+      locations: commonParameters,
+    };
+  }
+
+  if (!query || query.includes('discriminators')) {
+    const discriminators = analyzeDiscriminators(definition, scope);
+    analysis.discriminators = {
+      present: !!discriminators.length,
+      locations: discriminators,
+    };
+  }
+
+  if (!query || query.includes('links')) {
+    const links = analyzeLinks(definition, scope);
+    analysis.links = {
+      present: !!links.length,
+      locations: links,
+    };
+  }
+
+  if (!query || query.includes('style')) {
+    const parameterSerialization = analyzeParameterSerialization(definition, scope);
+    analysis.style = {
+      present: !!parameterSerialization.length,
+      locations: parameterSerialization,
+    };
+  }
+
+  if (!query || query.includes('polymorphism')) {
+    const polymorphism = analyzePolymorphism(definition, scope);
+    analysis.polymorphism = {
+      present: !!polymorphism.length,
+      locations: polymorphism,
+    };
+  }
+
+  if (!query || query.includes('references')) {
+    const references = analyzeReferences(definition, scope);
+    analysis.references = {
+      present: !!references.length,
+      locations: references,
+    };
+  }
+
+  if (!query || query.includes('serverVariables')) {
+    const serverVariables = analyzeServerVariables(definition);
+    analysis.serverVariables = {
+      present: !!serverVariables.length,
+      locations: serverVariables,
+    };
+  }
+
+  if (!query || query.includes('xmlRequests')) {
+    const xmlRequests = analyzeXMLRequests(definition, scope);
+    analysis.xmlRequests = {
+      present: !!xmlRequests.length,
+      locations: xmlRequests,
+    };
+  }
+
+  if (!query || query.includes('xmlResponses')) {
+    const xmlResponses = analyzeXMLResponses(definition, scope);
+    analysis.xmlResponses = {
+      present: !!xmlResponses.length,
+      locations: xmlResponses,
+    };
+  }
+
+  if (!query || query.includes('xmlSchemas')) {
+    const xmlSchemas = analyzeXMLSchemas(definition, scope);
+    analysis.xmlSchemas = {
+      present: !!xmlSchemas.length,
+      locations: xmlSchemas,
+    };
+  }
+
+  if (!query || query.includes('xmlSchemas')) {
+    const webhooks = analyzeWebhooks(definition, scope);
+    analysis.webhooks = {
+      present: !!webhooks.length,
+      locations: webhooks,
+    };
+  }
 
   return analysis;
 }
 
 /**
- * Analyze a given OpenAPI or Swagger definition for any OpenAPI or JSON Schema feature uses it
- * may contain or utilize.
+ * Analyze a given OpenAPI or Swagger definition for any, or a specific, OpenAPI or JSON Schema
+ * feature uses it may contain or utilize.
  *
  */
-export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
-  return buildAnalysis(definition);
+export async function analyzer(definition: OASDocument, query?: AnalyzerQuery[]): Promise<OASAnalysis> {
+  return buildAnalysis(definition, query);
 }
 
 /**
- * Analyze a single operation within a given OpenAPI definition for any OpenAPI or JSON Schema
- * feature uses that it, or anything it references, may contain or utilize.
+ * Analyze a single operation within a given OpenAPI definition for any, or a specific, OpenAPI or
+ * JSON Schema feature uses that it, or anything it references, may contain or utilize.
  *
  * When analyzing many operations out of the same definition, pass the *same* `definition`
  * reference to every call — the expensive dereferencing and document-wide JSONPath scans that this
  * relies on are cached against that reference, so only the first call pays for them.
  *
  */
-export async function analyzeOperation(definition: OASDocument, path: string, method: string): Promise<OASAnalysis> {
+export async function analyzeOperation(
+  definition: OASDocument,
+  {
+    path,
+    method,
+    query,
+  }: {
+    path: string;
+    method: string;
+    query?: AnalyzerQuery[];
+  },
+): Promise<OASAnalysis> {
   const scope = computeOperationScope(definition, path, method);
-  return buildAnalysis(definition, scope);
+  return buildAnalysis(definition, query, scope);
 }
 
 /**
- * Analyze a single webhook operation within a given OpenAPI 3.1 definition for any OpenAPI or JSON
- * Schema feature uses that it, or anything it references, may contain or utilize.
+ * Analyze a single webhook operation within a given OpenAPI 3.1 definition for any, or a specific,
+ * OpenAPI or JSON Schema feature uses that it, or anything it references, may contain or utilize.
  *
  * @see {@link analyzeOperation}
  */
 export async function analyzeWebhookOperation(
   definition: OASDocument,
-  webhookName: string,
-  method: string,
+  {
+    webhookName,
+    method,
+    query,
+  }: {
+    webhookName: string;
+    method: string;
+    query?: AnalyzerQuery[];
+  },
 ): Promise<OASAnalysis> {
   if (!isOpenAPI31(definition)) {
     throw new TypeError('The supplied definition is not a OpenAPI 3.1 definition.');
   }
 
   const scope = computeWebhookScope(definition satisfies OAS31Document, webhookName, method);
-  return buildAnalysis(definition, scope);
+  return buildAnalysis(definition, query, scope);
 }

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -9,7 +9,6 @@ import {
   circularRefs as analyzeCircularRefs,
   commonParameters as analyzeCommonParameters,
   discriminators as analyzeDiscriminators,
-  fileSize as analyzeFileSize,
   links as analyzeLinks,
   mediaTypes as analyzeMediaTypes,
   parameterSerialization as analyzeParameterSerialization,
@@ -23,13 +22,7 @@ import {
   xmlResponses as analyzeXMLResponses,
   xmlSchemas as analyzeXMLSchemas,
 } from './queries/openapi.js';
-import {
-  computeOperationScope,
-  computeWebhookScope,
-  estimateScopedSize,
-  isPointerInScope,
-  toPointer,
-} from './scope.js';
+import { computeOperationScope, computeWebhookScope, isPointerInScope, toPointer } from './scope.js';
 
 export {
   analyzeAdditionalProperties,
@@ -37,7 +30,6 @@ export {
   analyzeCircularRefs,
   analyzeCommonParameters,
   analyzeDiscriminators,
-  analyzeFileSize,
   analyzeLinks,
   analyzeMediaTypes,
   analyzeParameterSerialization,
@@ -52,9 +44,6 @@ export {
   analyzeXMLSchemas,
 };
 
-export type { OperationScope };
-export { computeOperationScope, computeWebhookScope };
-
 /**
  * Run every analyzer query against a definition, optionally narrowed down to a single operation or
  * webhook's `OperationScope`.
@@ -67,7 +56,7 @@ export { computeOperationScope, computeWebhookScope };
  *
  */
 async function buildAnalysis(definition: OASDocument, scope?: OperationScope): Promise<OASAnalysis> {
-  const { api: dereferencedApi, circularRefs: dereferencedCircularRefs } = await dereferenceOasShared(definition);
+  const { circularRefs: dereferencedCircularRefs } = await dereferenceOasShared(definition);
 
   const additionalProperties = analyzeAdditionalProperties(definition, scope);
   const callbacks = analyzeCallbacks(definition, scope);
@@ -88,23 +77,8 @@ async function buildAnalysis(definition: OASDocument, scope?: OperationScope): P
   const xmlResponses = analyzeXMLResponses(definition, scope);
   const webhooks = analyzeWebhooks(definition, scope);
 
-  // When we're scoped to a single operation, computing "the size of the file" doesn't mean much;
-  // instead we estimate the size of just what that operation (and anything it references) uses.
-  // This is intentionally an estimate rather than a byte-exact reduced document — see
-  // `estimateScopedSize()`.
-  const { raw: rawFileSize, dereferenced: dereferencedFileSize } = scope
-    ? {
-        raw: Number((estimateScopedSize(definition, scope) / (1024 * 1024)).toFixed(2)),
-        dereferenced: Number((estimateScopedSize(dereferencedApi, scope) / (1024 * 1024)).toFixed(2)),
-      }
-    : analyzeFileSize(definition, dereferencedApi);
-
   const analysis: OASAnalysis = {
     general: {
-      dereferencedFileSize: {
-        name: 'Dereferenced File Size',
-        found: dereferencedFileSize,
-      },
       mediaTypes: {
         name: 'Media Type',
         found: analyzeMediaTypes(definition, scope),
@@ -113,10 +87,6 @@ async function buildAnalysis(definition: OASDocument, scope?: OperationScope): P
         name: 'Operation',
         // A scoped analysis is, by definition, looking at exactly one operation.
         found: scope ? 1 : analyzeTotalOperations(definition),
-      },
-      rawFileSize: {
-        name: 'Raw File Size',
-        found: rawFileSize,
       },
       securityTypes: {
         name: 'Security Type',
@@ -199,19 +169,10 @@ export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
  * Analyze a single operation within a given OpenAPI definition for any OpenAPI or JSON Schema
  * feature uses that it, or anything it references, may contain or utilize.
  *
- * Unlike `analyzer()`, this doesn't require the definition to be reduced down to just this
- * operation first: it looks at the operation itself, any path-level common parameters, and
- * whatever's transitively reachable from either of those by way of `$ref` pointers, and reports
- * only on that. `additionalProperties`, `references`, `polymorphism`, and everything else that's
- * normally a whole-document check are all scoped down to what this specific operation uses.
- *
  * When analyzing many operations out of the same definition, pass the *same* `definition`
  * reference to every call — the expensive dereferencing and document-wide JSONPath scans that this
  * relies on are cached against that reference, so only the first call pays for them.
  *
- * @param definition The API definition that the operation lives within.
- * @param path The path that the operation is a part of.
- * @param method The HTTP method of the operation.
  */
 export async function analyzeOperation(definition: OASDocument, path: string, method: string): Promise<OASAnalysis> {
   const scope = computeOperationScope(definition, path, method);
@@ -223,9 +184,6 @@ export async function analyzeOperation(definition: OASDocument, path: string, me
  * Schema feature uses that it, or anything it references, may contain or utilize.
  *
  * @see {@link analyzeOperation}
- * @param definition The API definition that the webhook lives within.
- * @param webhookName The name of the webhook.
- * @param method The HTTP method of the webhook operation.
  */
 export async function analyzeWebhookOperation(
   definition: OASDocument,

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -1,6 +1,9 @@
-import type { OASDocument } from '../types.js';
+import type { OAS31Document, OASDocument } from '../types.js';
 import type { OperationScope } from './scope.js';
 import type { OASAnalysis } from './types.js';
+
+import { toPointer } from '../lib/refs.js';
+import { isOpenAPI31 } from '../types.js';
 
 import { dereferenceOasShared } from './dereference.js';
 import {
@@ -22,7 +25,7 @@ import {
   xmlResponses as analyzeXMLResponses,
   xmlSchemas as analyzeXMLSchemas,
 } from './queries/openapi.js';
-import { computeOperationScope, computeWebhookScope, isPointerInScope, toPointer } from './scope.js';
+import { computeOperationScope, computeWebhookScope, isPointerInScope } from './scope.js';
 
 export {
   analyzeAdditionalProperties,
@@ -190,6 +193,10 @@ export async function analyzeWebhookOperation(
   webhookName: string,
   method: string,
 ): Promise<OASAnalysis> {
-  const scope = computeWebhookScope(definition, webhookName, method);
+  if (!isOpenAPI31(definition)) {
+    throw new TypeError('The supplied definition is not a OpenAPI 3.1 definition.');
+  }
+
+  const scope = computeWebhookScope(definition satisfies OAS31Document, webhookName, method);
   return buildAnalysis(definition, scope);
 }

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -1,7 +1,8 @@
 import type { OASDocument } from '../types.js';
+import type { OperationScope } from './scope.js';
 import type { OASAnalysis } from './types.js';
 
-import { dereferenceOas } from './dereference.js';
+import { dereferenceOasShared } from './dereference.js';
 import {
   additionalProperties as analyzeAdditionalProperties,
   callbacks as analyzeCallbacks,
@@ -22,6 +23,13 @@ import {
   xmlResponses as analyzeXMLResponses,
   xmlSchemas as analyzeXMLSchemas,
 } from './queries/openapi.js';
+import {
+  computeOperationScope,
+  computeWebhookScope,
+  estimateScopedSize,
+  isPointerInScope,
+  toPointer,
+} from './scope.js';
 
 export {
   analyzeAdditionalProperties,
@@ -44,30 +52,52 @@ export {
   analyzeXMLSchemas,
 };
 
+export type { OperationScope };
+export { computeOperationScope, computeWebhookScope };
+
 /**
- * Analyze a given OpenAPI or Swagger definition for any OpenAPI or JSON Schema feature uses it
- * may contain or utilize.
+ * Run every analyzer query against a definition, optionally narrowed down to a single operation or
+ * webhook's `OperationScope`.
+ *
+ * This is the shared implementation behind `analyzer()`, `analyzeOperation()`, and
+ * `analyzeWebhookOperation()`. Dereferencing (the most expensive step here) is cached against the
+ * original `definition` reference via `dereferenceOasShared()`, and every JSONPath scan that the
+ * individual queries run is cached against it as well, so calling this repeatedly for many
+ * operations out of the same definition only pays the full-document cost once.
  *
  */
-export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
-  const clonedDefinition = structuredClone(definition);
-  const { api: dereferencedApi, circularRefs: dereferencedCircularRefs } = await dereferenceOas(clonedDefinition);
+async function buildAnalysis(definition: OASDocument, scope?: OperationScope): Promise<OASAnalysis> {
+  const { api: dereferencedApi, circularRefs: dereferencedCircularRefs } = await dereferenceOasShared(definition);
 
-  const additionalProperties = analyzeAdditionalProperties(definition);
-  const callbacks = analyzeCallbacks(definition);
-  const circularRefs = [...dereferencedCircularRefs].toSorted();
-  const commonParameters = analyzeCommonParameters(definition);
-  const discriminators = analyzeDiscriminators(definition);
-  const { raw: rawFileSize, dereferenced: dereferencedFileSize } = analyzeFileSize(definition, dereferencedApi);
-  const links = analyzeLinks(definition);
-  const parameterSerialization = analyzeParameterSerialization(definition);
-  const polymorphism = analyzePolymorphism(definition);
-  const references = analyzeReferences(definition);
+  const additionalProperties = analyzeAdditionalProperties(definition, scope);
+  const callbacks = analyzeCallbacks(definition, scope);
+  const circularRefs = (
+    scope
+      ? dereferencedCircularRefs.filter(ref => isPointerInScope(toPointer(ref), scope))
+      : [...dereferencedCircularRefs]
+  ).toSorted();
+  const commonParameters = analyzeCommonParameters(definition, scope);
+  const discriminators = analyzeDiscriminators(definition, scope);
+  const links = analyzeLinks(definition, scope);
+  const parameterSerialization = analyzeParameterSerialization(definition, scope);
+  const polymorphism = analyzePolymorphism(definition, scope);
+  const references = analyzeReferences(definition, scope);
   const serverVariables = analyzeServerVariables(definition);
-  const xmlSchemas = analyzeXMLSchemas(definition);
-  const xmlRequests = analyzeXMLRequests(definition);
-  const xmlResponses = analyzeXMLResponses(definition);
-  const webhooks = analyzeWebhooks(definition);
+  const xmlSchemas = analyzeXMLSchemas(definition, scope);
+  const xmlRequests = analyzeXMLRequests(definition, scope);
+  const xmlResponses = analyzeXMLResponses(definition, scope);
+  const webhooks = analyzeWebhooks(definition, scope);
+
+  // When we're scoped to a single operation, computing "the size of the file" doesn't mean much;
+  // instead we estimate the size of just what that operation (and anything it references) uses.
+  // This is intentionally an estimate rather than a byte-exact reduced document — see
+  // `estimateScopedSize()`.
+  const { raw: rawFileSize, dereferenced: dereferencedFileSize } = scope
+    ? {
+        raw: Number((estimateScopedSize(definition, scope) / (1024 * 1024)).toFixed(2)),
+        dereferenced: Number((estimateScopedSize(dereferencedApi, scope) / (1024 * 1024)).toFixed(2)),
+      }
+    : analyzeFileSize(definition, dereferencedApi);
 
   const analysis: OASAnalysis = {
     general: {
@@ -77,11 +107,12 @@ export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
       },
       mediaTypes: {
         name: 'Media Type',
-        found: analyzeMediaTypes(definition),
+        found: analyzeMediaTypes(definition, scope),
       },
       operationTotal: {
         name: 'Operation',
-        found: analyzeTotalOperations(definition),
+        // A scoped analysis is, by definition, looking at exactly one operation.
+        found: scope ? 1 : analyzeTotalOperations(definition),
       },
       rawFileSize: {
         name: 'Raw File Size',
@@ -89,7 +120,7 @@ export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
       },
       securityTypes: {
         name: 'Security Type',
-        found: analyzeSecurityTypes(definition),
+        found: analyzeSecurityTypes(definition, scope),
       },
     },
     openapi: {
@@ -153,4 +184,54 @@ export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
   };
 
   return analysis;
+}
+
+/**
+ * Analyze a given OpenAPI or Swagger definition for any OpenAPI or JSON Schema feature uses it
+ * may contain or utilize.
+ *
+ */
+export async function analyzer(definition: OASDocument): Promise<OASAnalysis> {
+  return buildAnalysis(definition);
+}
+
+/**
+ * Analyze a single operation within a given OpenAPI definition for any OpenAPI or JSON Schema
+ * feature uses that it, or anything it references, may contain or utilize.
+ *
+ * Unlike `analyzer()`, this doesn't require the definition to be reduced down to just this
+ * operation first: it looks at the operation itself, any path-level common parameters, and
+ * whatever's transitively reachable from either of those by way of `$ref` pointers, and reports
+ * only on that. `additionalProperties`, `references`, `polymorphism`, and everything else that's
+ * normally a whole-document check are all scoped down to what this specific operation uses.
+ *
+ * When analyzing many operations out of the same definition, pass the *same* `definition`
+ * reference to every call — the expensive dereferencing and document-wide JSONPath scans that this
+ * relies on are cached against that reference, so only the first call pays for them.
+ *
+ * @param definition The API definition that the operation lives within.
+ * @param path The path that the operation is a part of.
+ * @param method The HTTP method of the operation.
+ */
+export async function analyzeOperation(definition: OASDocument, path: string, method: string): Promise<OASAnalysis> {
+  const scope = computeOperationScope(definition, path, method);
+  return buildAnalysis(definition, scope);
+}
+
+/**
+ * Analyze a single webhook operation within a given OpenAPI 3.1 definition for any OpenAPI or JSON
+ * Schema feature uses that it, or anything it references, may contain or utilize.
+ *
+ * @see {@link analyzeOperation}
+ * @param definition The API definition that the webhook lives within.
+ * @param webhookName The name of the webhook.
+ * @param method The HTTP method of the webhook operation.
+ */
+export async function analyzeWebhookOperation(
+  definition: OASDocument,
+  webhookName: string,
+  method: string,
+): Promise<OASAnalysis> {
+  const scope = computeWebhookScope(definition, webhookName, method);
+  return buildAnalysis(definition, scope);
 }

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -2,9 +2,10 @@ import type { OASDocument } from '../../types.js';
 import type { OperationScope } from '../scope.js';
 import type { JSONPathResult } from '../util.js';
 
+import { toPointer } from '../../lib/refs.js';
 import { dereferenceOas } from '../dereference.js';
 import { queryCached } from '../query-cache.js';
-import { isAncestorOfScope, isPointerInScope, toPointer } from '../scope.js';
+import { isAncestorOfScope, isPointerInScope } from '../scope.js';
 import { refizePointer } from '../util.js';
 
 /**

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -85,37 +85,6 @@ export function discriminators(definition: OASDocument, scope?: OperationScope):
 }
 
 /**
- * Calculate the size of the raw and dereferenced OpenAPI file in MB.
- *
- * If a dereferenced API definition is too large to be stringified the file size will be returned
- * as NaN.
- *
- */
-export function fileSize(
-  definition: OASDocument,
-  definitionDereferenced: OASDocument,
-): { raw: number; dereferenced: number | typeof NaN } {
-  const originalSizeInBytes = Buffer.from(JSON.stringify(definition)).length;
-  const raw = Number((originalSizeInBytes / (1024 * 1024)).toFixed(2));
-
-  let dereferenced: number;
-  try {
-    const dereferencedSizeInBytes = Buffer.from(JSON.stringify(definitionDereferenced)).length;
-    dereferenced = Number((dereferencedSizeInBytes / (1024 * 1024)).toFixed(2));
-  } catch (err) {
-    // If the dereferenced API definition is too large to be stringified then we don't have a safer
-    // way to estimate its size that wouldn't sacrifice accuracy so we'll just return NaN.
-    if (err instanceof RangeError) {
-      dereferenced = NaN;
-    } else {
-      throw err;
-    }
-  }
-
-  return { raw, dereferenced };
-}
-
-/**
  * Determine if a given API definition utilizes `links`.
  *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object}

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -107,7 +107,18 @@ export function links(definition: OASDocument, scope?: OperationScope): string[]
 export function mediaTypes(definition: OASDocument, scope?: OperationScope): string[] {
   const results = Array.from(
     new Set(
-      filterByScope(queryCached(['$..paths..content'], definition), scope).flatMap(res => {
+      filterByScope(
+        queryCached(
+          [
+            '$..paths..content',
+            '$.components.requestBodies..content',
+            '$.components.responses..content',
+            '$.webhooks..content',
+          ],
+          definition,
+        ),
+        scope,
+      ).flatMap(res => {
         // This'll transform `results`, which looks like `[['application/json'], ['text/xml']]`
         // into `['application/json', 'text/xml']`.
         return Object.keys(res.value);

--- a/packages/oas/src/analyzer/queries/openapi.ts
+++ b/packages/oas/src/analyzer/queries/openapi.ts
@@ -1,7 +1,25 @@
 import type { OASDocument } from '../../types.js';
+import type { OperationScope } from '../scope.js';
+import type { JSONPathResult } from '../util.js';
 
 import { dereferenceOas } from '../dereference.js';
-import { query, refizePointer } from '../util.js';
+import { queryCached } from '../query-cache.js';
+import { isAncestorOfScope, isPointerInScope, toPointer } from '../scope.js';
+import { refizePointer } from '../util.js';
+
+/**
+ * Narrow a set of JSONPath results down to only the ones that fall within a given operation's
+ * scope. When no scope is supplied every result is considered in scope, which preserves the
+ * whole-document behavior these queries have always had.
+ *
+ */
+function filterByScope(results: JSONPathResult[], scope?: OperationScope): JSONPathResult[] {
+  if (!scope) {
+    return results;
+  }
+
+  return results.filter(res => isPointerInScope(res.pointer, scope));
+}
 
 /**
  * Determine if a given API definition uses the `additionalProperties` schema property.
@@ -9,8 +27,10 @@ import { query, refizePointer } from '../util.js';
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
-export function additionalProperties(definition: OASDocument): string[] {
-  return query(['$..additionalProperties'], definition).map(res => refizePointer(res.pointer));
+export function additionalProperties(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(queryCached(['$..additionalProperties'], definition), scope).map(res =>
+    refizePointer(res.pointer),
+  );
 }
 
 /**
@@ -19,10 +39,11 @@ export function additionalProperties(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object}
  */
-export function callbacks(definition: OASDocument): string[] {
-  return query(['$.components.callbacks', '$.paths.*[?(@.callbacks)].callbacks'], definition).map(res =>
-    refizePointer(res.pointer),
-  );
+export function callbacks(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(
+    queryCached(['$.components.callbacks', '$.paths.*[?(@.callbacks)].callbacks'], definition),
+    scope,
+  ).map(res => refizePointer(res.pointer));
 }
 
 /**
@@ -31,12 +52,12 @@ export function callbacks(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
-export async function circularRefs(definition: OASDocument): Promise<string[]> {
+export async function circularRefs(definition: OASDocument, scope?: OperationScope): Promise<string[]> {
   // Dereferencing will update the passed in variable, which we don't want to do, so we
   // instantiated `Oas` with a clone.
   const { circularRefs: refs } = await dereferenceOas(structuredClone(definition));
 
-  const results = [...refs];
+  const results = scope ? refs.filter(ref => isPointerInScope(toPointer(ref), scope)) : [...refs];
   results.sort();
   return results;
 }
@@ -47,8 +68,10 @@ export async function circularRefs(definition: OASDocument): Promise<string[]> {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-item-object}
  */
-export function commonParameters(definition: OASDocument): string[] {
-  return query(['$..paths[*].parameters'], definition).map(res => refizePointer(res.pointer));
+export function commonParameters(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(queryCached(['$..paths[*].parameters'], definition), scope).map(res =>
+    refizePointer(res.pointer),
+  );
 }
 
 /**
@@ -57,8 +80,8 @@ export function commonParameters(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminator-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#discriminator-object}
  */
-export function discriminators(definition: OASDocument): string[] {
-  return query(['$..discriminator'], definition).map(res => refizePointer(res.pointer));
+export function discriminators(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(queryCached(['$..discriminator'], definition), scope).map(res => refizePointer(res.pointer));
 }
 
 /**
@@ -98,8 +121,10 @@ export function fileSize(
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#link-object}
  */
-export function links(definition: OASDocument): string[] {
-  return query(['$.components.links', '$.paths..responses.*.links'], definition).map(res => refizePointer(res.pointer));
+export function links(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(queryCached(['$.components.links', '$.paths..responses.*.links'], definition), scope).map(res =>
+    refizePointer(res.pointer),
+  );
 }
 
 /**
@@ -109,10 +134,10 @@ export function links(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#request-body-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#request-body-object}
  */
-export function mediaTypes(definition: OASDocument): string[] {
+export function mediaTypes(definition: OASDocument, scope?: OperationScope): string[] {
   const results = Array.from(
     new Set(
-      query(['$..paths..content'], definition).flatMap(res => {
+      filterByScope(queryCached(['$..paths..content'], definition), scope).flatMap(res => {
         // This'll transform `results`, which looks like `[['application/json'], ['text/xml']]`
         // into `['application/json', 'text/xml']`.
         return Object.keys(res.value);
@@ -130,8 +155,10 @@ export function mediaTypes(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object}
  */
-export function parameterSerialization(definition: OASDocument): string[] {
-  return query(['$..parameters[*].style^'], definition).map(res => refizePointer(res.pointer));
+export function parameterSerialization(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(queryCached(['$..parameters[*].style^'], definition), scope).map(res =>
+    refizePointer(res.pointer),
+  );
 }
 
 /**
@@ -140,9 +167,13 @@ export function parameterSerialization(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object}
  */
-export function polymorphism(definition: OASDocument): string[] {
+export function polymorphism(definition: OASDocument, scope?: OperationScope): string[] {
   const results = Array.from(
-    new Set(query(['$..allOf^', '$..anyOf^', '$..oneOf^'], definition).map(res => refizePointer(res.pointer))),
+    new Set(
+      filterByScope(queryCached(['$..allOf^', '$..anyOf^', '$..oneOf^'], definition), scope).map(res =>
+        refizePointer(res.pointer),
+      ),
+    ),
   );
 
   results.sort();
@@ -153,8 +184,8 @@ export function polymorphism(definition: OASDocument): string[] {
  * Determine if a given API definition utilizes `$ref` pointers.
  *
  */
-export function references(definition: OASDocument): string[] {
-  return query(['$..$ref^'], definition).map(res => refizePointer(res.pointer));
+export function references(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(queryCached(['$..$ref^'], definition), scope).map(res => refizePointer(res.pointer));
 }
 
 /**
@@ -163,18 +194,27 @@ export function references(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-scheme-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object}
  */
-export function securityTypes(definition: OASDocument): string[] {
-  return Array.from(new Set(query(['$.components.securitySchemes..type'], definition).map(res => res.value as string)));
+export function securityTypes(definition: OASDocument, scope?: OperationScope): string[] {
+  return Array.from(
+    new Set(
+      filterByScope(queryCached(['$.components.securitySchemes..type'], definition), scope).map(
+        res => res.value as string,
+      ),
+    ),
+  );
 }
 
 /**
  * Determine if a given API definition utilizes server variables.
  *
+ * Root-level `servers` apply to every operation unless a path or operation overrides them, so
+ * these are always considered in scope regardless of which operation is being analyzed.
+ *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object}
  */
 export function serverVariables(definition: OASDocument): string[] {
-  return query(['$.servers..variables^'], definition).map(res => refizePointer(res.pointer));
+  return queryCached(['$.servers..variables^'], definition).map(res => refizePointer(res.pointer));
 }
 
 /**
@@ -184,7 +224,7 @@ export function serverVariables(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#operation-object}
  */
 export function totalOperations(definition: OASDocument): number {
-  return query(['$..paths[*]'], definition).flatMap(res => Object.keys(res.value)).length;
+  return queryCached(['$..paths[*]'], definition).flatMap(res => Object.keys(res.value)).length;
 }
 
 /**
@@ -192,8 +232,19 @@ export function totalOperations(definition: OASDocument): number {
  *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#oasWebhooks}
  */
-export function webhooks(definition: OASDocument): string[] {
-  return query(['$.webhooks[*]'], definition).map(res => refizePointer(res.pointer));
+export function webhooks(definition: OASDocument, scope?: OperationScope): string[] {
+  const results = queryCached(['$.webhooks[*]'], definition);
+  if (!scope) {
+    return results.map(res => refizePointer(res.pointer));
+  }
+
+  // This query reports on an entire webhook (`/webhooks/newBooking`) rather than a specific
+  // method on it, so a scope's root pointer (`/webhooks/newBooking/post`) is a *descendant* of a
+  // matching result rather than the other way around. We still want to catch the normal case too,
+  // where an operation reaches into a webhook by way of a `$ref`.
+  return results
+    .filter(res => isPointerInScope(res.pointer, scope) || isAncestorOfScope(res.pointer, scope))
+    .map(res => refizePointer(res.pointer));
 }
 
 /**
@@ -203,17 +254,20 @@ export function webhooks(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
  */
-export function xmlRequests(definition: OASDocument): string[] {
-  return query(
-    [
-      "$..requestBody..['application/xml']",
-      "$..requestBody..['application/xml-external-parsed-entity']",
-      "$..requestBody..['application/xml-dtd']",
-      "$..requestBody..['text/xml']",
-      "$..requestBody..['text/xml-external-parsed-entity']",
-      '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
-    ],
-    definition,
+export function xmlRequests(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(
+    queryCached(
+      [
+        "$..requestBody..['application/xml']",
+        "$..requestBody..['application/xml-external-parsed-entity']",
+        "$..requestBody..['application/xml-dtd']",
+        "$..requestBody..['text/xml']",
+        "$..requestBody..['text/xml-external-parsed-entity']",
+        '$..requestBody.content[?(@property.match(/\\+xml$/i))]',
+      ],
+      definition,
+    ),
+    scope,
   ).map(res => refizePointer(res.pointer));
 }
 
@@ -224,17 +278,20 @@ export function xmlRequests(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#media-type-object}
  */
-export function xmlResponses(definition: OASDocument): string[] {
-  return query(
-    [
-      "$..responses..['application/xml']",
-      "$..responses..['application/xml-external-parsed-entity']",
-      "$..responses..['application/xml-dtd']",
-      "$..responses..['text/xml']",
-      "$..responses..['text/xml-external-parsed-entity']",
-      '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
-    ],
-    definition,
+export function xmlResponses(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(
+    queryCached(
+      [
+        "$..responses..['application/xml']",
+        "$..responses..['application/xml-external-parsed-entity']",
+        "$..responses..['application/xml-dtd']",
+        "$..responses..['text/xml']",
+        "$..responses..['text/xml-external-parsed-entity']",
+        '$..responses[*].content[?(@property.match(/\\+xml$/i))]',
+      ],
+      definition,
+    ),
+    scope,
   ).map(res => refizePointer(res.pointer));
 }
 
@@ -244,8 +301,9 @@ export function xmlResponses(definition: OASDocument): string[] {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xml-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#xml-object}
  */
-export function xmlSchemas(definition: OASDocument): string[] {
-  return query(['$.components.schemas..xml^', '$..parameters..xml^', '$..requestBody..xml^'], definition).map(res =>
-    refizePointer(res.pointer),
-  );
+export function xmlSchemas(definition: OASDocument, scope?: OperationScope): string[] {
+  return filterByScope(
+    queryCached(['$.components.schemas..xml^', '$..parameters..xml^', '$..requestBody..xml^'], definition),
+    scope,
+  ).map(res => refizePointer(res.pointer));
 }

--- a/packages/oas/src/analyzer/query-cache.ts
+++ b/packages/oas/src/analyzer/query-cache.ts
@@ -1,0 +1,44 @@
+import type { JSONPathResult } from './util.js';
+
+import { query } from './util.js';
+
+const cache = new WeakMap<object, Map<string, JSONPathResult[]>>();
+
+/**
+ * Every analyzer query in `queries/openapi.ts` runs one or more `$..`-style JSONPath scans across
+ * the *entire* API definition, regardless of which operation (if any) we're ultimately interested
+ * in. When analyzing a single operation that's cheap to do once, but when analyzing hundreds of
+ * operations out of the same definition — which is the whole point of being able to scope analysis
+ * to an operation instead of reducing the definition down first — re-running those same full-document
+ * scans for every single operation throws away all of that shared work.
+ *
+ * This cache runs each unique set of JSONPath queries against a given definition exactly once and
+ * hands back the same result array on every subsequent call, so callers can cheaply filter it down
+ * per-operation instead of re-scanning the whole document each time.
+ *
+ * Cache entries are keyed by object identity (via `WeakMap`), so this is only effective when
+ * callers reuse the same `definition` reference across calls — if you're handed a fresh clone every
+ * time there's nothing to reuse. It also means definitions are never manually evicted from the
+ * cache; they simply fall out of it once nothing else references them.
+ *
+ * @param queries JSONPath queries to run.
+ * @param definition The object to run them against.
+ */
+export function queryCached(queries: string[], definition: object): JSONPathResult[] {
+  let byQuery = cache.get(definition);
+  if (!byQuery) {
+    byQuery = new Map();
+    cache.set(definition, byQuery);
+  }
+
+  // A space can't appear within a JSONPath query, so it's a safe delimiter to join on for a cache key.
+  const cacheKey = queries.join(' ');
+
+  let results = byQuery.get(cacheKey);
+  if (!results) {
+    results = query(queries, definition);
+    byQuery.set(cacheKey, results);
+  }
+
+  return results;
+}

--- a/packages/oas/src/analyzer/scope.ts
+++ b/packages/oas/src/analyzer/scope.ts
@@ -1,8 +1,8 @@
-import type { OASDocument } from '../types.js';
+import type { OAS31Document, OASDocument } from '../types.js';
 
 import jsonPointer from 'jsonpointer';
 
-import { collectRefsInSchema, encodePointer } from '../lib/refs.js';
+import { collectRefsInSchema, encodePointer, toPointer } from '../lib/refs.js';
 import { supportedMethods } from '../utils.js';
 
 /**
@@ -48,16 +48,6 @@ export interface OperationScope {
 }
 
 /**
- * Normalize a `$ref` pointer (`#/components/schemas/Pet`) into a plain JSON pointer
- * (`/components/schemas/Pet`) so it can be compared against `jsonpath-plus` result pointers, which
- * never carry the leading `#`.
- *
- */
-export function toPointer($ref: string): string {
-  return $ref.startsWith('#') ? $ref.slice(1) : $ref;
-}
-
-/**
  * Case-insensitively find the real key for a given target within a list of keys. OpenAPI paths and
  * HTTP methods aren't case-sensitive as far as most tooling (including this) is concerned, but the
  * pointers we build need to match the casing that's actually in the document.
@@ -75,8 +65,6 @@ function resolveKey(keys: string[], target: string): string | undefined {
  * cloning, no mutation) and resolves each `$ref` lazily against the original definition instead of
  * requiring a prebuilt map of every possible reference.
  *
- * @param definition The API definition to resolve `$ref` pointers against.
- * @param seeds The `$ref` pointers to start walking from.
  */
 function accumulateReachableRefs(definition: OASDocument, seeds: Iterable<string>): Set<string> {
   const reachable = new Set<string>();
@@ -151,9 +139,6 @@ function collectSecuritySchemeRefs(security: unknown): string[] {
  * analyzer can report only on what that operation (and anything it references) actually uses,
  * without requiring the definition to be reduced down first.
  *
- * @param definition The API definition that the operation lives within.
- * @param path The path that the operation is a part of.
- * @param method The HTTP method of the operation.
  */
 export function computeOperationScope(definition: OASDocument, path: string, method: string): OperationScope {
   const pathKey = resolveKey(Object.keys(definition.paths || {}), path);
@@ -188,12 +173,9 @@ export function computeOperationScope(definition: OASDocument, path: string, met
 /**
  * Compute the `OperationScope` for a single webhook operation within an OpenAPI 3.1 definition.
  *
- * @param definition The API definition that the webhook lives within.
- * @param webhookName The name of the webhook.
- * @param method The HTTP method of the webhook operation.
  */
-export function computeWebhookScope(definition: OASDocument, webhookName: string, method: string): OperationScope {
-  const webhooks = ('webhooks' in definition ? definition.webhooks : undefined) as Record<string, any> | undefined;
+export function computeWebhookScope(definition: OAS31Document, webhookName: string, method: string): OperationScope {
+  const webhooks = ('webhooks' in definition ? definition.webhooks : {}) as NonNullable<OAS31Document['webhooks']>;
   const webhookKey = resolveKey(Object.keys(webhooks || {}), webhookName);
   if (!webhookKey) {
     throw new Error(`Webhook \`${webhookName}\` not found.`);
@@ -249,63 +231,3 @@ export function isPointerInScope(pointer: string, scope: OperationScope): boolea
 export function isAncestorOfScope(pointer: string, scope: OperationScope): boolean {
   return scope.rootPointer === pointer || scope.rootPointer.startsWith(`${pointer}/`);
 }
-
-/**
- * Estimate, in bytes, the size of everything that a given `OperationScope` touches within a JSON
- * object. This purposefully does not build a fully valid, standalone OpenAPI definition (that's
- * what `OpenAPIReducer` is for) — it's a fast approximation used to give a rough sense of how much
- * of the definition a single operation is pulling in.
- *
- * A large, shared component (a big `Envelope` schema, say) can be reachable from hundreds of
- * operations. Without caching, analyzing all of them would mean re-stringifying that same schema
- * hundreds of times over. We memoize the size of each pointer against the `root` object it was
- * computed from, so shared components are only ever serialized once no matter how many operations'
- * scopes reach them.
- *
- */
-export function estimateScopedSize(root: unknown, scope: OperationScope): number {
-  let sizeByPointer = scopedSizeCache.get(root as object);
-  if (!sizeByPointer) {
-    sizeByPointer = new Map();
-    scopedSizeCache.set(root as object, sizeByPointer);
-  }
-
-  const seen = new Set<string>();
-  let bytes = 0;
-
-  scope.anchors.forEach(pointer => {
-    if (seen.has(pointer)) {
-      return;
-    }
-
-    seen.add(pointer);
-
-    let size = sizeByPointer.get(pointer);
-    if (size === undefined) {
-      size = 0;
-
-      let value: unknown;
-      try {
-        value = jsonPointer.get(root as object, pointer);
-      } catch {
-        value = undefined;
-      }
-
-      if (value !== undefined) {
-        try {
-          size = Buffer.byteLength(JSON.stringify(value));
-        } catch {
-          // Circular or otherwise unstringifiable; treat it as zero rather than fail the estimate.
-        }
-      }
-
-      sizeByPointer.set(pointer, size);
-    }
-
-    bytes += size;
-  });
-
-  return bytes;
-}
-
-const scopedSizeCache = new WeakMap<object, Map<string, number>>();

--- a/packages/oas/src/analyzer/scope.ts
+++ b/packages/oas/src/analyzer/scope.ts
@@ -1,0 +1,311 @@
+import type { OASDocument } from '../types.js';
+
+import jsonPointer from 'jsonpointer';
+
+import { collectRefsInSchema, encodePointer } from '../lib/refs.js';
+import { supportedMethods } from '../utils.js';
+
+/**
+ * The set of JSON pointers (in plain `/foo/bar` form, without the leading `#`) that describe
+ * everything an operation or webhook touches: itself, any path-level (or webhook-level) common
+ * parameters, and every `$ref` pointer that's reachable from either of those.
+ *
+ * This is what allows the analyzer to be run against a full, undreduced API definition and still
+ * only report on what a single operation actually uses.
+ */
+export interface OperationScope {
+  /**
+   * `anchors`, each with a trailing `/` appended, precomputed once so `isPointerInScope()` isn't
+   * concatenating a new string per anchor on every single pointer it checks. Analyzing an
+   * operation can mean checking thousands of result pointers against this list, so avoiding a
+   * string allocation per comparison meaningfully adds up.
+   */
+  anchorPrefixes: string[];
+
+  /**
+   * A flattened, precomputed list of every pointer prefix that's considered "in scope". This is
+   * derived from `rootPointer`, `extraPointers`, and `reachableRefs` and exists purely so we don't
+   * have to rebuild it for every pointer comparison we do.
+   */
+  anchors: string[];
+
+  /**
+   * Pointers, beyond `rootPointer`, that should be treated as belonging to this operation (e.g. a
+   * path item's common `parameters`).
+   */
+  extraPointers: string[];
+
+  /**
+   * Every `$ref` pointer (in `#/...` form) that's transitively reachable from this operation.
+   */
+  reachableRefs: Set<string>;
+
+  /**
+   * The pointer to the operation (or webhook operation) itself, e.g. `/paths/~1pet/get` or
+   * `/webhooks/newBooking/post`.
+   */
+  rootPointer: string;
+}
+
+/**
+ * Normalize a `$ref` pointer (`#/components/schemas/Pet`) into a plain JSON pointer
+ * (`/components/schemas/Pet`) so it can be compared against `jsonpath-plus` result pointers, which
+ * never carry the leading `#`.
+ *
+ */
+export function toPointer($ref: string): string {
+  return $ref.startsWith('#') ? $ref.slice(1) : $ref;
+}
+
+/**
+ * Case-insensitively find the real key for a given target within a list of keys. OpenAPI paths and
+ * HTTP methods aren't case-sensitive as far as most tooling (including this) is concerned, but the
+ * pointers we build need to match the casing that's actually in the document.
+ *
+ */
+function resolveKey(keys: string[], target: string): string | undefined {
+  return keys.find(key => key === target) || keys.find(key => key.toLowerCase() === target.toLowerCase());
+}
+
+/**
+ * Starting from a seed set of `$ref` pointers, recursively follow every `$ref` that they, or
+ * anything they point to, contain and return the full set of pointers that are reachable.
+ *
+ * This intentionally mirrors the ref-walking that `OpenAPIReducer` does, but is read-only (no
+ * cloning, no mutation) and resolves each `$ref` lazily against the original definition instead of
+ * requiring a prebuilt map of every possible reference.
+ *
+ * @param definition The API definition to resolve `$ref` pointers against.
+ * @param seeds The `$ref` pointers to start walking from.
+ */
+function accumulateReachableRefs(definition: OASDocument, seeds: Iterable<string>): Set<string> {
+  const reachable = new Set<string>();
+  const queue = [...seeds];
+
+  while (queue.length) {
+    const ref = queue.shift() as string;
+    if (reachable.has(ref)) {
+      continue;
+    }
+
+    reachable.add(ref);
+
+    let resolved: unknown;
+    try {
+      resolved = jsonPointer.get(definition, toPointer(ref));
+    } catch {
+      // If the `$ref` doesn't resolve to anything (a malformed pointer, an external ref we didn't
+      // bundle, etc.) there's nothing further to walk from it.
+      continue;
+    }
+
+    if (resolved === undefined) {
+      continue;
+    }
+
+    collectRefsInSchema(resolved).forEach(nestedRef => {
+      if (!reachable.has(nestedRef)) {
+        queue.push(nestedRef);
+      }
+    });
+  }
+
+  return reachable;
+}
+
+function buildAnchors(
+  rootPointer: string,
+  extraPointers: string[],
+  reachableRefs: Set<string>,
+): Pick<OperationScope, 'anchorPrefixes' | 'anchors'> {
+  const anchors = [rootPointer, ...extraPointers];
+  reachableRefs.forEach(ref => anchors.push(toPointer(ref)));
+
+  return { anchors, anchorPrefixes: anchors.map(anchor => `${anchor}/`) };
+}
+
+/**
+ * Accumulate the `#/components/securitySchemes/*` refs that a given set of security requirements
+ * make use of.
+ *
+ */
+function collectSecuritySchemeRefs(security: unknown): string[] {
+  if (!Array.isArray(security)) {
+    return [];
+  }
+
+  const refs: string[] = [];
+  security.forEach(requirement => {
+    if (requirement && typeof requirement === 'object') {
+      Object.keys(requirement).forEach(scheme => {
+        refs.push(`#/components/securitySchemes/${scheme}`);
+      });
+    }
+  });
+
+  return refs;
+}
+
+/**
+ * Compute the `OperationScope` for a single operation within an API definition, so that the
+ * analyzer can report only on what that operation (and anything it references) actually uses,
+ * without requiring the definition to be reduced down first.
+ *
+ * @param definition The API definition that the operation lives within.
+ * @param path The path that the operation is a part of.
+ * @param method The HTTP method of the operation.
+ */
+export function computeOperationScope(definition: OASDocument, path: string, method: string): OperationScope {
+  const pathKey = resolveKey(Object.keys(definition.paths || {}), path);
+  if (!pathKey) {
+    throw new Error(`Path \`${path}\` not found.`);
+  }
+
+  const pathItem = (definition.paths as Record<string, any>)[pathKey] || {};
+  const methodKey = resolveKey(Object.keys(pathItem), method);
+  if (!methodKey || !supportedMethods.includes(methodKey.toLowerCase() as (typeof supportedMethods)[number])) {
+    throw new Error(`Operation \`${method} ${path}\` not found.`);
+  }
+
+  const operation = pathItem[methodKey];
+  const rootPointer = `/paths/${encodePointer(pathKey)}/${methodKey}`;
+  const extraPointers: string[] = [];
+  const seeds = new Set<string>(collectRefsInSchema(operation));
+
+  if (pathItem.parameters) {
+    extraPointers.push(`/paths/${encodePointer(pathKey)}/parameters`);
+    collectRefsInSchema(pathItem.parameters).forEach(ref => seeds.add(ref));
+  }
+
+  const security = 'security' in operation ? operation.security : definition.security;
+  collectSecuritySchemeRefs(security).forEach(ref => seeds.add(ref));
+
+  const reachableRefs = accumulateReachableRefs(definition, seeds);
+
+  return { rootPointer, extraPointers, reachableRefs, ...buildAnchors(rootPointer, extraPointers, reachableRefs) };
+}
+
+/**
+ * Compute the `OperationScope` for a single webhook operation within an OpenAPI 3.1 definition.
+ *
+ * @param definition The API definition that the webhook lives within.
+ * @param webhookName The name of the webhook.
+ * @param method The HTTP method of the webhook operation.
+ */
+export function computeWebhookScope(definition: OASDocument, webhookName: string, method: string): OperationScope {
+  const webhooks = ('webhooks' in definition ? definition.webhooks : undefined) as Record<string, any> | undefined;
+  const webhookKey = resolveKey(Object.keys(webhooks || {}), webhookName);
+  if (!webhookKey) {
+    throw new Error(`Webhook \`${webhookName}\` not found.`);
+  }
+
+  const webhook = (webhooks as Record<string, any>)[webhookKey] || {};
+  const methodKey = resolveKey(Object.keys(webhook), method);
+  if (!methodKey || !supportedMethods.includes(methodKey.toLowerCase() as (typeof supportedMethods)[number])) {
+    throw new Error(`Webhook operation \`${method} ${webhookName}\` not found.`);
+  }
+
+  const operation = webhook[methodKey];
+  const rootPointer = `/webhooks/${encodePointer(webhookKey)}/${methodKey}`;
+  const extraPointers: string[] = [];
+  const seeds = new Set<string>(collectRefsInSchema(operation));
+
+  if (webhook.parameters) {
+    extraPointers.push(`/webhooks/${encodePointer(webhookKey)}/parameters`);
+    collectRefsInSchema(webhook.parameters).forEach(ref => seeds.add(ref));
+  }
+
+  const security = 'security' in operation ? operation.security : definition.security;
+  collectSecuritySchemeRefs(security).forEach(ref => seeds.add(ref));
+
+  const reachableRefs = accumulateReachableRefs(definition, seeds);
+
+  return { rootPointer, extraPointers, reachableRefs, ...buildAnchors(rootPointer, extraPointers, reachableRefs) };
+}
+
+/**
+ * Determine if a given JSON pointer (as returned by `jsonpath-plus`, without a leading `#`) falls
+ * within a given `OperationScope`.
+ *
+ */
+export function isPointerInScope(pointer: string, scope: OperationScope): boolean {
+  const { anchors, anchorPrefixes } = scope;
+  for (let i = 0; i < anchors.length; i += 1) {
+    if (pointer === anchors[i] || pointer.startsWith(anchorPrefixes[i])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Determine if a given `OperationScope`'s root is nested *within* a given pointer. This is the
+ * inverse of `isPointerInScope()` and exists for the handful of queries (like our `webhooks` one)
+ * that report on a coarser pointer than the specific operation we're scoped to, e.g. reporting on
+ * `/webhooks/newBooking` as a whole when we're scoped to `/webhooks/newBooking/post`.
+ *
+ */
+export function isAncestorOfScope(pointer: string, scope: OperationScope): boolean {
+  return scope.rootPointer === pointer || scope.rootPointer.startsWith(`${pointer}/`);
+}
+
+/**
+ * Estimate, in bytes, the size of everything that a given `OperationScope` touches within a JSON
+ * object. This purposefully does not build a fully valid, standalone OpenAPI definition (that's
+ * what `OpenAPIReducer` is for) — it's a fast approximation used to give a rough sense of how much
+ * of the definition a single operation is pulling in.
+ *
+ * A large, shared component (a big `Envelope` schema, say) can be reachable from hundreds of
+ * operations. Without caching, analyzing all of them would mean re-stringifying that same schema
+ * hundreds of times over. We memoize the size of each pointer against the `root` object it was
+ * computed from, so shared components are only ever serialized once no matter how many operations'
+ * scopes reach them.
+ *
+ */
+export function estimateScopedSize(root: unknown, scope: OperationScope): number {
+  let sizeByPointer = scopedSizeCache.get(root as object);
+  if (!sizeByPointer) {
+    sizeByPointer = new Map();
+    scopedSizeCache.set(root as object, sizeByPointer);
+  }
+
+  const seen = new Set<string>();
+  let bytes = 0;
+
+  scope.anchors.forEach(pointer => {
+    if (seen.has(pointer)) {
+      return;
+    }
+
+    seen.add(pointer);
+
+    let size = sizeByPointer.get(pointer);
+    if (size === undefined) {
+      size = 0;
+
+      let value: unknown;
+      try {
+        value = jsonPointer.get(root as object, pointer);
+      } catch {
+        value = undefined;
+      }
+
+      if (value !== undefined) {
+        try {
+          size = Buffer.byteLength(JSON.stringify(value));
+        } catch {
+          // Circular or otherwise unstringifiable; treat it as zero rather than fail the estimate.
+        }
+      }
+
+      sizeByPointer.set(pointer, size);
+    }
+
+    bytes += size;
+  });
+
+  return bytes;
+}
+
+const scopedSizeCache = new WeakMap<object, Map<string, number>>();

--- a/packages/oas/src/analyzer/types.ts
+++ b/packages/oas/src/analyzer/types.ts
@@ -10,10 +10,8 @@ export interface OASAnalysisGeneral {
 
 export interface OASAnalysis {
   general: {
-    dereferencedFileSize: OASAnalysisGeneral;
     mediaTypes: OASAnalysisGeneral;
     operationTotal: OASAnalysisGeneral;
-    rawFileSize: OASAnalysisGeneral;
     securityTypes: OASAnalysisGeneral;
   };
   openapi: {

--- a/packages/oas/src/analyzer/types.ts
+++ b/packages/oas/src/analyzer/types.ts
@@ -1,3 +1,29 @@
+// oxlint-disable perfectionist/sort-interfaces
+export const AnalyzerQueries = [
+  // General
+  'mediaTypes',
+  'operationTotal',
+  'securityTypes',
+
+  // OpenAPI
+  'additionalProperties',
+  'callbacks',
+  'circularRefs',
+  'commonParameters',
+  'discriminators',
+  'links',
+  'style',
+  'polymorphism',
+  'references',
+  'serverVariables',
+  'xmlRequests',
+  'xmlResponses',
+  'xmlSchemas',
+  'webhooks',
+] as const;
+
+export type AnalyzerQuery = (typeof AnalyzerQueries)[number];
+
 export interface OASAnalysisFeature {
   locations: string[];
   present: boolean;
@@ -9,25 +35,24 @@ export interface OASAnalysisGeneral {
 }
 
 export interface OASAnalysis {
-  general: {
-    mediaTypes: OASAnalysisGeneral;
-    operationTotal: OASAnalysisGeneral;
-    securityTypes: OASAnalysisGeneral;
-  };
-  openapi: {
-    additionalProperties: OASAnalysisFeature;
-    callbacks: OASAnalysisFeature;
-    circularRefs: OASAnalysisFeature;
-    commonParameters: OASAnalysisFeature;
-    discriminators: OASAnalysisFeature;
-    links: OASAnalysisFeature;
-    polymorphism: OASAnalysisFeature;
-    references: OASAnalysisFeature;
-    serverVariables: OASAnalysisFeature;
-    style: OASAnalysisFeature;
-    xmlRequests: OASAnalysisFeature;
-    xmlResponses: OASAnalysisFeature;
-    xmlSchemas: OASAnalysisFeature;
-    webhooks: OASAnalysisFeature;
-  };
+  // General
+  mediaTypes?: OASAnalysisGeneral;
+  operationTotal?: OASAnalysisGeneral;
+  securityTypes?: OASAnalysisGeneral;
+
+  // OpenAPI
+  additionalProperties?: OASAnalysisFeature;
+  callbacks?: OASAnalysisFeature;
+  circularRefs?: OASAnalysisFeature;
+  commonParameters?: OASAnalysisFeature;
+  discriminators?: OASAnalysisFeature;
+  links?: OASAnalysisFeature;
+  polymorphism?: OASAnalysisFeature;
+  references?: OASAnalysisFeature;
+  serverVariables?: OASAnalysisFeature;
+  style?: OASAnalysisFeature;
+  xmlRequests?: OASAnalysisFeature;
+  xmlResponses?: OASAnalysisFeature;
+  xmlSchemas?: OASAnalysisFeature;
+  webhooks?: OASAnalysisFeature;
 }

--- a/packages/oas/src/analyzer/util.ts
+++ b/packages/oas/src/analyzer/util.ts
@@ -1,6 +1,6 @@
 import { JSONPath } from 'jsonpath-plus';
 
-interface JSONPathResult {
+export interface JSONPathResult {
   hasArrExpr?: boolean;
   parent: any;
   parentProperty: string;

--- a/packages/oas/src/lib/refs.ts
+++ b/packages/oas/src/lib/refs.ts
@@ -7,6 +7,16 @@ import { isRef } from '../types.js';
 import { isPrimitive } from './helpers.js';
 
 /**
+ * Normalize a `$ref` pointer (`#/components/schemas/Pet`) into a plain JSON pointer
+ * (`/components/schemas/Pet`) so it can be compared against `jsonpath-plus` result pointers, which
+ * never carry the leading `#`.
+ *
+ */
+export function toPointer($ref: string): string {
+  return $ref.startsWith('#') ? $ref.slice(1) : $ref;
+}
+
+/**
  * Decorate component schemas within the API definition with a `x-readme-ref-name` property so we
  * can retin their original schema names during dereferencing or `$ref` resolution operations.
  *

--- a/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
@@ -3,10 +3,6 @@
 exports[`#analyzer() > should should analyzer an OpenAPI definition 1`] = `
 {
   "general": {
-    "dereferencedFileSize": {
-      "found": 0.03,
-      "name": "Dereferenced File Size",
-    },
     "mediaTypes": {
       "found": [
         "application/json",
@@ -19,10 +15,6 @@ exports[`#analyzer() > should should analyzer an OpenAPI definition 1`] = `
     "operationTotal": {
       "found": 20,
       "name": "Operation",
-    },
-    "rawFileSize": {
-      "found": 0.01,
-      "name": "Raw File Size",
     },
     "securityTypes": {
       "found": [

--- a/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
@@ -1,130 +1,290 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`#analyzeOperation() > should query for everything by defualt 1`] = `
+{
+  "additionalProperties": {
+    "locations": [],
+    "present": false,
+  },
+  "callbacks": {
+    "locations": [],
+    "present": false,
+  },
+  "circularRefs": {
+    "locations": [],
+    "present": false,
+  },
+  "commonParameters": {
+    "locations": [],
+    "present": false,
+  },
+  "discriminators": {
+    "locations": [],
+    "present": false,
+  },
+  "links": {
+    "locations": [],
+    "present": false,
+  },
+  "mediaTypes": {
+    "found": [],
+    "name": "Media Type",
+  },
+  "operationTotal": {
+    "found": 1,
+    "name": "Operation",
+  },
+  "polymorphism": {
+    "locations": [],
+    "present": false,
+  },
+  "references": {
+    "locations": [
+      "#/components/requestBodies/Pet/content/application~1json/schema",
+      "#/components/requestBodies/Pet/content/application~1xml/schema",
+      "#/components/schemas/Pet/properties/category",
+      "#/components/schemas/Pet/properties/tags/items",
+      "#/paths/~1pet/post/requestBody",
+    ],
+    "present": true,
+  },
+  "securityTypes": {
+    "found": [
+      "oauth2",
+    ],
+    "name": "Security Type",
+  },
+  "serverVariables": {
+    "locations": [],
+    "present": false,
+  },
+  "style": {
+    "locations": [],
+    "present": false,
+  },
+  "webhooks": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlRequests": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlResponses": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlSchemas": {
+    "locations": [
+      "#/components/schemas/Category",
+      "#/components/schemas/Pet",
+      "#/components/schemas/Pet/properties/photoUrls",
+      "#/components/schemas/Pet/properties/tags",
+      "#/components/schemas/Tag",
+    ],
+    "present": true,
+  },
+}
+`;
+
+exports[`#analyzeWebhookOperation() > should query for everything by defualt 1`] = `
+{
+  "additionalProperties": {
+    "locations": [],
+    "present": false,
+  },
+  "callbacks": {
+    "locations": [],
+    "present": false,
+  },
+  "circularRefs": {
+    "locations": [],
+    "present": false,
+  },
+  "commonParameters": {
+    "locations": [],
+    "present": false,
+  },
+  "discriminators": {
+    "locations": [],
+    "present": false,
+  },
+  "links": {
+    "locations": [],
+    "present": false,
+  },
+  "mediaTypes": {
+    "found": [],
+    "name": "Media Type",
+  },
+  "operationTotal": {
+    "found": 1,
+    "name": "Operation",
+  },
+  "polymorphism": {
+    "locations": [],
+    "present": false,
+  },
+  "references": {
+    "locations": [
+      "#/webhooks/newPet/post/requestBody/content/application~1json/schema",
+    ],
+    "present": true,
+  },
+  "securityTypes": {
+    "found": [],
+    "name": "Security Type",
+  },
+  "serverVariables": {
+    "locations": [],
+    "present": false,
+  },
+  "style": {
+    "locations": [],
+    "present": false,
+  },
+  "webhooks": {
+    "locations": [
+      "#/webhooks/newPet",
+    ],
+    "present": true,
+  },
+  "xmlRequests": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlResponses": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlSchemas": {
+    "locations": [],
+    "present": false,
+  },
+}
+`;
+
 exports[`#analyzer() > should should analyzer an OpenAPI definition 1`] = `
 {
-  "general": {
-    "mediaTypes": {
-      "found": [
-        "application/json",
-        "application/x-www-form-urlencoded",
-        "application/xml",
-        "multipart/form-data",
-      ],
-      "name": "Media Type",
-    },
-    "operationTotal": {
-      "found": 20,
-      "name": "Operation",
-    },
-    "securityTypes": {
-      "found": [
-        "apiKey",
-        "oauth2",
-      ],
-      "name": "Security Type",
-    },
+  "additionalProperties": {
+    "locations": [
+      "#/paths/~1store~1inventory/get/responses/200/content/application~1json/schema/additionalProperties",
+    ],
+    "present": true,
   },
-  "openapi": {
-    "additionalProperties": {
-      "locations": [
-        "#/paths/~1store~1inventory/get/responses/200/content/application~1json/schema/additionalProperties",
-      ],
-      "present": true,
-    },
-    "callbacks": {
-      "locations": [],
-      "present": false,
-    },
-    "circularRefs": {
-      "locations": [],
-      "present": false,
-    },
-    "commonParameters": {
-      "locations": [],
-      "present": false,
-    },
-    "discriminators": {
-      "locations": [],
-      "present": false,
-    },
-    "links": {
-      "locations": [],
-      "present": false,
-    },
-    "polymorphism": {
-      "locations": [],
-      "present": false,
-    },
-    "references": {
-      "locations": [
-        "#/components/requestBodies/Pet/content/application~1json/schema",
-        "#/components/requestBodies/Pet/content/application~1xml/schema",
-        "#/components/requestBodies/UserArray/content/application~1json/schema/items",
-        "#/components/schemas/Pet/properties/category",
-        "#/components/schemas/Pet/properties/tags/items",
-        "#/paths/~1pet/post/requestBody",
-        "#/paths/~1pet/put/requestBody",
-        "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1json/schema/items",
-        "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1xml/schema/items",
-        "#/paths/~1pet~1findByTags/get/responses/200/content/application~1json/schema/items",
-        "#/paths/~1pet~1findByTags/get/responses/200/content/application~1xml/schema/items",
-        "#/paths/~1pet~1{petId}/get/responses/200/content/application~1json/schema",
-        "#/paths/~1pet~1{petId}/get/responses/200/content/application~1xml/schema",
-        "#/paths/~1pet~1{petId}~1uploadImage/post/responses/200/content/application~1json/schema",
-        "#/paths/~1store~1order/post/requestBody/content/application~1json/schema",
-        "#/paths/~1store~1order/post/responses/200/content/application~1json/schema",
-        "#/paths/~1store~1order/post/responses/200/content/application~1xml/schema",
-        "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1json/schema",
-        "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1xml/schema",
-        "#/paths/~1user/post/requestBody/content/application~1json/schema",
-        "#/paths/~1user~1createWithArray/post/requestBody",
-        "#/paths/~1user~1createWithList/post/requestBody",
-        "#/paths/~1user~1{username}/get/responses/200/content/application~1json/schema",
-        "#/paths/~1user~1{username}/get/responses/200/content/application~1xml/schema",
-        "#/paths/~1user~1{username}/put/requestBody/content/application~1json/schema",
-      ],
-      "present": true,
-    },
-    "serverVariables": {
-      "locations": [],
-      "present": false,
-    },
-    "style": {
-      "locations": [],
-      "present": false,
-    },
-    "webhooks": {
-      "locations": [],
-      "present": false,
-    },
-    "xmlRequests": {
-      "locations": [],
-      "present": false,
-    },
-    "xmlResponses": {
-      "locations": [
-        "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1xml",
-        "#/paths/~1pet~1findByTags/get/responses/200/content/application~1xml",
-        "#/paths/~1pet~1{petId}/get/responses/200/content/application~1xml",
-        "#/paths/~1store~1order/post/responses/200/content/application~1xml",
-        "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1xml",
-        "#/paths/~1user~1login/get/responses/200/content/application~1xml",
-        "#/paths/~1user~1{username}/get/responses/200/content/application~1xml",
-      ],
-      "present": true,
-    },
-    "xmlSchemas": {
-      "locations": [
-        "#/components/schemas/Category",
-        "#/components/schemas/Order",
-        "#/components/schemas/Pet",
-        "#/components/schemas/Pet/properties/photoUrls",
-        "#/components/schemas/Pet/properties/tags",
-        "#/components/schemas/Tag",
-        "#/components/schemas/User",
-      ],
-      "present": true,
-    },
+  "callbacks": {
+    "locations": [],
+    "present": false,
+  },
+  "circularRefs": {
+    "locations": [],
+    "present": false,
+  },
+  "commonParameters": {
+    "locations": [],
+    "present": false,
+  },
+  "discriminators": {
+    "locations": [],
+    "present": false,
+  },
+  "links": {
+    "locations": [],
+    "present": false,
+  },
+  "mediaTypes": {
+    "found": [
+      "application/json",
+      "application/x-www-form-urlencoded",
+      "application/xml",
+      "multipart/form-data",
+    ],
+    "name": "Media Type",
+  },
+  "operationTotal": {
+    "found": 20,
+    "name": "Operation",
+  },
+  "polymorphism": {
+    "locations": [],
+    "present": false,
+  },
+  "references": {
+    "locations": [
+      "#/components/requestBodies/Pet/content/application~1json/schema",
+      "#/components/requestBodies/Pet/content/application~1xml/schema",
+      "#/components/requestBodies/UserArray/content/application~1json/schema/items",
+      "#/components/schemas/Pet/properties/category",
+      "#/components/schemas/Pet/properties/tags/items",
+      "#/paths/~1pet/post/requestBody",
+      "#/paths/~1pet/put/requestBody",
+      "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1json/schema/items",
+      "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1xml/schema/items",
+      "#/paths/~1pet~1findByTags/get/responses/200/content/application~1json/schema/items",
+      "#/paths/~1pet~1findByTags/get/responses/200/content/application~1xml/schema/items",
+      "#/paths/~1pet~1{petId}/get/responses/200/content/application~1json/schema",
+      "#/paths/~1pet~1{petId}/get/responses/200/content/application~1xml/schema",
+      "#/paths/~1pet~1{petId}~1uploadImage/post/responses/200/content/application~1json/schema",
+      "#/paths/~1store~1order/post/requestBody/content/application~1json/schema",
+      "#/paths/~1store~1order/post/responses/200/content/application~1json/schema",
+      "#/paths/~1store~1order/post/responses/200/content/application~1xml/schema",
+      "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1json/schema",
+      "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1xml/schema",
+      "#/paths/~1user/post/requestBody/content/application~1json/schema",
+      "#/paths/~1user~1createWithArray/post/requestBody",
+      "#/paths/~1user~1createWithList/post/requestBody",
+      "#/paths/~1user~1{username}/get/responses/200/content/application~1json/schema",
+      "#/paths/~1user~1{username}/get/responses/200/content/application~1xml/schema",
+      "#/paths/~1user~1{username}/put/requestBody/content/application~1json/schema",
+    ],
+    "present": true,
+  },
+  "securityTypes": {
+    "found": [
+      "apiKey",
+      "oauth2",
+    ],
+    "name": "Security Type",
+  },
+  "serverVariables": {
+    "locations": [],
+    "present": false,
+  },
+  "style": {
+    "locations": [],
+    "present": false,
+  },
+  "webhooks": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlRequests": {
+    "locations": [],
+    "present": false,
+  },
+  "xmlResponses": {
+    "locations": [
+      "#/paths/~1pet~1findByStatus/get/responses/200/content/application~1xml",
+      "#/paths/~1pet~1findByTags/get/responses/200/content/application~1xml",
+      "#/paths/~1pet~1{petId}/get/responses/200/content/application~1xml",
+      "#/paths/~1store~1order/post/responses/200/content/application~1xml",
+      "#/paths/~1store~1order~1{orderId}/get/responses/200/content/application~1xml",
+      "#/paths/~1user~1login/get/responses/200/content/application~1xml",
+      "#/paths/~1user~1{username}/get/responses/200/content/application~1xml",
+    ],
+    "present": true,
+  },
+  "xmlSchemas": {
+    "locations": [
+      "#/components/schemas/Category",
+      "#/components/schemas/Order",
+      "#/components/schemas/Pet",
+      "#/components/schemas/Pet/properties/photoUrls",
+      "#/components/schemas/Pet/properties/tags",
+      "#/components/schemas/Tag",
+      "#/components/schemas/User",
+    ],
+    "present": true,
   },
 }
 `;

--- a/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
+++ b/packages/oas/test/analyzer/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`#analyzeOperation() > should query for everything by defualt 1`] = `
+exports[`#analyzeOperation() > should query for everything by default 1`] = `
 {
   "additionalProperties": {
     "locations": [],
@@ -27,7 +27,9 @@ exports[`#analyzeOperation() > should query for everything by defualt 1`] = `
     "present": false,
   },
   "mediaTypes": {
-    "found": [],
+    "found": [
+      "application/json",
+    ],
     "name": "Media Type",
   },
   "operationTotal": {
@@ -40,18 +42,13 @@ exports[`#analyzeOperation() > should query for everything by defualt 1`] = `
   },
   "references": {
     "locations": [
-      "#/components/requestBodies/Pet/content/application~1json/schema",
-      "#/components/requestBodies/Pet/content/application~1xml/schema",
-      "#/components/schemas/Pet/properties/category",
-      "#/components/schemas/Pet/properties/tags/items",
-      "#/paths/~1pet/post/requestBody",
+      "#/components/requestBodies/UserArray/content/application~1json/schema/items",
+      "#/paths/~1user~1createWithArray/post/requestBody",
     ],
     "present": true,
   },
   "securityTypes": {
-    "found": [
-      "oauth2",
-    ],
+    "found": [],
     "name": "Security Type",
   },
   "serverVariables": {
@@ -76,18 +73,14 @@ exports[`#analyzeOperation() > should query for everything by defualt 1`] = `
   },
   "xmlSchemas": {
     "locations": [
-      "#/components/schemas/Category",
-      "#/components/schemas/Pet",
-      "#/components/schemas/Pet/properties/photoUrls",
-      "#/components/schemas/Pet/properties/tags",
-      "#/components/schemas/Tag",
+      "#/components/schemas/User",
     ],
     "present": true,
   },
 }
 `;
 
-exports[`#analyzeWebhookOperation() > should query for everything by defualt 1`] = `
+exports[`#analyzeWebhookOperation() > should query for everything by default 1`] = `
 {
   "additionalProperties": {
     "locations": [],
@@ -114,7 +107,9 @@ exports[`#analyzeWebhookOperation() > should query for everything by defualt 1`]
     "present": false,
   },
   "mediaTypes": {
-    "found": [],
+    "found": [
+      "application/json",
+    ],
     "name": "Media Type",
   },
   "operationTotal": {

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -16,9 +16,6 @@ describe('#analyzeOperation()', () => {
   it('should scope `references` down to just what the operation (and anything it references) uses', async () => {
     const analysis = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
 
-    // `POST /pet`'s `requestBody` is a `$ref`, and everything it transitively pulls in
-    // (`requestBodies.Pet`, `schemas.Pet`, and Pet's own `category`/`tags` refs) should be
-    // reported — but nothing belonging to any other operation.
     expect(analysis.openapi.references).toStrictEqual({
       present: true,
       locations: [
@@ -32,8 +29,8 @@ describe('#analyzeOperation()', () => {
   });
 
   it('should scope `securityTypes` down to just the scheme that the operation uses', async () => {
-    const postPet = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
-    expect(postPet.general.securityTypes.found).toStrictEqual(['oauth2']);
+    const addPet = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
+    expect(addPet.general.securityTypes.found).toStrictEqual(['oauth2']);
 
     const getPetById = await analyzeOperation(petstore as OASDocument, '/pet/{petId}', 'get');
     expect(getPetById.general.securityTypes.found).toStrictEqual(['apiKey']);
@@ -45,8 +42,6 @@ describe('#analyzeOperation()', () => {
   });
 
   it('should not require the definition to be reduced down first', async () => {
-    // The whole point: pass the full, unreduced definition and get back an operation-scoped
-    // result without needing `OpenAPIReducer` in the middle.
     const analysis = await analyzeOperation(petstore as OASDocument, '/store/inventory', 'get');
 
     expect(analysis.openapi.references.present).toBe(false);

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -13,10 +13,31 @@ describe('#analyzer()', () => {
 });
 
 describe('#analyzeOperation()', () => {
-  it('should scope `references` down to just what the operation (and anything it references) uses', async () => {
-    const analysis = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
+  it('should query for everything by defualt', async () => {
+    const analysis = await analyzeOperation(petstore as OASDocument, {
+      method: 'post',
+      path: '/pet',
+    });
 
-    expect(analysis.openapi.references).toStrictEqual({
+    expect(analysis).toMatchSnapshot();
+  });
+
+  it('should support supplying a specific query', async () => {
+    const analysis = await analyzeOperation(petstore as OASDocument, {
+      method: 'post',
+      path: '/pet',
+      query: ['references'],
+    });
+
+    expect(analysis).toStrictEqual({
+      references: expect.any(Object),
+    });
+  });
+
+  it('should scope `references` down to just what the operation (and anything it references) uses', async () => {
+    const analysis = await analyzeOperation(petstore as OASDocument, { method: 'post', path: '/pet' });
+
+    expect(analysis.references).toStrictEqual({
       present: true,
       locations: [
         '#/components/requestBodies/Pet/content/application~1json/schema',
@@ -29,48 +50,74 @@ describe('#analyzeOperation()', () => {
   });
 
   it('should scope `securityTypes` down to just the scheme that the operation uses', async () => {
-    const addPet = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
-    expect(addPet.general.securityTypes.found).toStrictEqual(['oauth2']);
+    const addPet = await analyzeOperation(petstore as OASDocument, { method: 'post', path: '/pet' });
+    expect(addPet.securityTypes?.found).toStrictEqual(['oauth2']);
 
-    const getPetById = await analyzeOperation(petstore as OASDocument, '/pet/{petId}', 'get');
-    expect(getPetById.general.securityTypes.found).toStrictEqual(['apiKey']);
+    const getPetById = await analyzeOperation(petstore as OASDocument, { method: 'get', path: '/pet/{petId}' });
+    expect(getPetById.securityTypes?.found).toStrictEqual(['apiKey']);
   });
 
   it('should report an operation total of 1, since a scoped analysis is only ever one operation', async () => {
-    const analysis = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
-    expect(analysis.general.operationTotal.found).toBe(1);
+    const analysis = await analyzeOperation(petstore as OASDocument, { method: 'post', path: '/pet' });
+    expect(analysis.operationTotal?.found).toBe(1);
   });
 
   it('should not require the definition to be reduced down first', async () => {
-    const analysis = await analyzeOperation(petstore as OASDocument, '/store/inventory', 'get');
+    const analysis = await analyzeOperation(petstore as OASDocument, { method: 'get', path: '/store/inventory' });
 
-    expect(analysis.openapi.references.present).toBe(false);
-    expect(analysis.general.securityTypes.found).toStrictEqual(['apiKey']);
+    expect(analysis.references?.present).toBe(false);
+    expect(analysis.securityTypes?.found).toStrictEqual(['apiKey']);
   });
 
   it('should throw for an operation that does not exist', async () => {
-    await expect(analyzeOperation(petstore as OASDocument, '/nope', 'get')).rejects.toThrow('Path `/nope` not found.');
+    await expect(analyzeOperation(petstore as OASDocument, { method: 'get', path: '/nope' })).rejects.toThrow(
+      'Path `/nope` not found.',
+    );
   });
 });
 
 describe('#analyzeWebhookOperation()', () => {
-  it('should scope `references` down to just what the webhook operation uses', async () => {
-    const analysis = await analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, 'newPet', 'post');
+  it('should query for everything by defualt', async () => {
+    const analysis = await analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, {
+      webhookName: 'newPet',
+      method: 'post',
+    });
 
-    expect(analysis.openapi.references).toStrictEqual({
+    expect(analysis).toMatchSnapshot();
+  });
+
+  it('should support supplying a specific query', async () => {
+    const analysis = await analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, {
+      webhookName: 'newPet',
+      method: 'post',
+      query: ['references'],
+    });
+
+    expect(analysis).toStrictEqual({
+      references: expect.any(Object),
+    });
+  });
+
+  it('should scope `references` down to just what the webhook operation uses', async () => {
+    const analysis = await analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, {
+      webhookName: 'newPet',
+      method: 'post',
+    });
+
+    expect(analysis.references).toStrictEqual({
       present: true,
       locations: ['#/webhooks/newPet/post/requestBody/content/application~1json/schema'],
     });
 
-    expect(analysis.openapi.webhooks).toStrictEqual({
+    expect(analysis.webhooks).toStrictEqual({
       present: true,
       locations: ['#/webhooks/newPet'],
     });
   });
 
   it('should throw for a webhook that does not exist', async () => {
-    await expect(analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, 'nope', 'post')).rejects.toThrow(
-      'Webhook `nope` not found.',
-    );
+    await expect(
+      analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, { webhookName: 'nope', method: 'post' }),
+    ).rejects.toThrow('Webhook `nope` not found.');
   });
 });

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -13,10 +13,10 @@ describe('#analyzer()', () => {
 });
 
 describe('#analyzeOperation()', () => {
-  it('should query for everything by defualt', async () => {
+  it('should query for everything by default', async () => {
     const analysis = await analyzeOperation(petstore as OASDocument, {
       method: 'post',
-      path: '/pet',
+      path: '/user/createWithArray',
     });
 
     expect(analysis).toMatchSnapshot();
@@ -77,7 +77,7 @@ describe('#analyzeOperation()', () => {
 });
 
 describe('#analyzeWebhookOperation()', () => {
-  it('should query for everything by defualt', async () => {
+  it('should query for everything by default', async () => {
     const analysis = await analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, {
       webhookName: 'newPet',
       method: 'post',

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -1,12 +1,81 @@
 import type { OASDocument } from '../../src/types.js';
 
 import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import webhooksSpec from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
 import { describe, expect, it } from 'vitest';
 
-import { analyzer } from '../../src/analyzer/index.js';
+import { analyzeOperation, analyzeWebhookOperation, analyzer } from '../../src/analyzer/index.js';
 
 describe('#analyzer()', () => {
   it('should should analyzer an OpenAPI definition', async () => {
     await expect(analyzer(petstore as OASDocument)).resolves.toMatchSnapshot();
+  });
+});
+
+describe('#analyzeOperation()', () => {
+  it('should scope `references` down to just what the operation (and anything it references) uses', async () => {
+    const analysis = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
+
+    // `POST /pet`'s `requestBody` is a `$ref`, and everything it transitively pulls in
+    // (`requestBodies.Pet`, `schemas.Pet`, and Pet's own `category`/`tags` refs) should be
+    // reported — but nothing belonging to any other operation.
+    expect(analysis.openapi.references).toStrictEqual({
+      present: true,
+      locations: [
+        '#/components/requestBodies/Pet/content/application~1json/schema',
+        '#/components/requestBodies/Pet/content/application~1xml/schema',
+        '#/components/schemas/Pet/properties/category',
+        '#/components/schemas/Pet/properties/tags/items',
+        '#/paths/~1pet/post/requestBody',
+      ],
+    });
+  });
+
+  it('should scope `securityTypes` down to just the scheme that the operation uses', async () => {
+    const postPet = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
+    expect(postPet.general.securityTypes.found).toStrictEqual(['oauth2']);
+
+    const getPetById = await analyzeOperation(petstore as OASDocument, '/pet/{petId}', 'get');
+    expect(getPetById.general.securityTypes.found).toStrictEqual(['apiKey']);
+  });
+
+  it('should report an operation total of 1, since a scoped analysis is only ever one operation', async () => {
+    const analysis = await analyzeOperation(petstore as OASDocument, '/pet', 'post');
+    expect(analysis.general.operationTotal.found).toBe(1);
+  });
+
+  it('should not require the definition to be reduced down first', async () => {
+    // The whole point: pass the full, unreduced definition and get back an operation-scoped
+    // result without needing `OpenAPIReducer` in the middle.
+    const analysis = await analyzeOperation(petstore as OASDocument, '/store/inventory', 'get');
+
+    expect(analysis.openapi.references.present).toBe(false);
+    expect(analysis.general.securityTypes.found).toStrictEqual(['apiKey']);
+  });
+
+  it('should throw for an operation that does not exist', async () => {
+    await expect(analyzeOperation(petstore as OASDocument, '/nope', 'get')).rejects.toThrow('Path `/nope` not found.');
+  });
+});
+
+describe('#analyzeWebhookOperation()', () => {
+  it('should scope `references` down to just what the webhook operation uses', async () => {
+    const analysis = await analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, 'newPet', 'post');
+
+    expect(analysis.openapi.references).toStrictEqual({
+      present: true,
+      locations: ['#/webhooks/newPet/post/requestBody/content/application~1json/schema'],
+    });
+
+    expect(analysis.openapi.webhooks).toStrictEqual({
+      present: true,
+      locations: ['#/webhooks/newPet'],
+    });
+  });
+
+  it('should throw for a webhook that does not exist', async () => {
+    await expect(analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, 'nope', 'post')).rejects.toThrow(
+      'Webhook `nope` not found.',
+    );
   });
 });

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -17,14 +17,12 @@ import trainTravel from '@readme/oas-examples/3.1/json/train-travel.json' with {
 import webhooks from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
 import { describe, expect, it } from 'vitest';
 
-import { dereferenceOas } from '../../../src/analyzer/dereference.js';
 import {
   analyzeAdditionalProperties,
   analyzeCallbacks,
   analyzeCircularRefs,
   analyzeCommonParameters,
   analyzeDiscriminators,
-  analyzeFileSize,
   analyzeLinks,
   analyzeMediaTypes,
   analyzeParameterSerialization,
@@ -142,17 +140,6 @@ describe('analyzer queries (OpenAPI)', () => {
 
     it("should not find where it doesn't exist", () => {
       expect(analyzeDiscriminators(readme as unknown as OASDocument)).toHaveLength(0);
-    });
-  });
-
-  describe('#analyzeFileSize()', () => {
-    it('should calculate the size of the definition in its raw form', async () => {
-      const { api: dereferenced } = await dereferenceOas(structuredClone(trainTravel) as unknown as OASDocument);
-
-      expect(analyzeFileSize(structuredClone(trainTravel) as unknown as OASDocument, dereferenced)).toStrictEqual({
-        raw: 0.03,
-        dereferenced: 0.14,
-      });
     });
   });
 

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -18,24 +18,24 @@ import webhooks from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 
 import { describe, expect, it } from 'vitest';
 
 import {
-  analyzeAdditionalProperties,
-  analyzeCallbacks,
-  analyzeCircularRefs,
-  analyzeCommonParameters,
-  analyzeDiscriminators,
-  analyzeLinks,
-  analyzeMediaTypes,
-  analyzeParameterSerialization,
-  analyzePolymorphism,
-  analyzeReferences,
-  analyzeSecurityTypes,
-  analyzeServerVariables,
-  analyzeTotalOperations,
-  analyzeWebhooks,
-  analyzeXMLRequests,
-  analyzeXMLResponses,
-  analyzeXMLSchemas,
-} from '../../../src/analyzer/index.js';
+  additionalProperties as analyzeAdditionalProperties,
+  callbacks as analyzeCallbacks,
+  circularRefs as analyzeCircularRefs,
+  commonParameters as analyzeCommonParameters,
+  discriminators as analyzeDiscriminators,
+  links as analyzeLinks,
+  mediaTypes as analyzeMediaTypes,
+  parameterSerialization as analyzeParameterSerialization,
+  polymorphism as analyzePolymorphism,
+  references as analyzeReferences,
+  securityTypes as analyzeSecurityTypes,
+  serverVariables as analyzeServerVariables,
+  totalOperations as analyzeTotalOperations,
+  webhooks as analyzeWebhooks,
+  xmlRequests as analyzeXMLRequests,
+  xmlResponses as analyzeXMLResponses,
+  xmlSchemas as analyzeXMLSchemas,
+} from '../../../src/analyzer/queries/openapi.js';
 import Oas from '../../../src/index.js';
 import responses from '../../__datasets__/responses.json' with { type: 'json' };
 

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -36,6 +36,7 @@ import {
   xmlResponses as analyzeXMLResponses,
   xmlSchemas as analyzeXMLSchemas,
 } from '../../../src/analyzer/queries/openapi.js';
+import { computeOperationScope } from '../../../src/analyzer/scope.js';
 import Oas from '../../../src/index.js';
 import responses from '../../__datasets__/responses.json' with { type: 'json' };
 
@@ -174,6 +175,15 @@ describe('analyzer queries (OpenAPI)', () => {
         'application/x-www-form-urlencoded',
         'application/xml',
         'multipart/form-data',
+      ]);
+    });
+
+    it('should include media types from a `$ref` request body in components', () => {
+      const scope = computeOperationScope(petstore as OASDocument, '/pet', 'post');
+
+      expect(analyzeMediaTypes(petstore as OASDocument, scope)).toStrictEqual([
+        'application/json',
+        'application/xml',
       ]);
     });
   });

--- a/packages/oas/test/analyzer/queries/openapi.test.ts
+++ b/packages/oas/test/analyzer/queries/openapi.test.ts
@@ -181,10 +181,7 @@ describe('analyzer queries (OpenAPI)', () => {
     it('should include media types from a `$ref` request body in components', () => {
       const scope = computeOperationScope(petstore as OASDocument, '/pet', 'post');
 
-      expect(analyzeMediaTypes(petstore as OASDocument, scope)).toStrictEqual([
-        'application/json',
-        'application/xml',
-      ]);
+      expect(analyzeMediaTypes(petstore as OASDocument, scope)).toStrictEqual(['application/json', 'application/xml']);
     });
   });
 

--- a/packages/oas/test/analyzer/scope.test.ts
+++ b/packages/oas/test/analyzer/scope.test.ts
@@ -1,0 +1,144 @@
+import type { OASDocument } from '../../src/types.js';
+
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import webhooksSpec from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeOperationScope,
+  computeWebhookScope,
+  estimateScopedSize,
+  isAncestorOfScope,
+  isPointerInScope,
+  toPointer,
+} from '../../src/analyzer/scope.js';
+
+describe('#computeOperationScope()', () => {
+  it('should scope to the operation itself, and its security scheme, when it has no other `$ref` pointers', () => {
+    const scope = computeOperationScope(petstore as OASDocument, '/store/inventory', 'get');
+
+    expect(scope.rootPointer).toBe('/paths/~1store~1inventory/get');
+    expect(scope.reachableRefs).toStrictEqual(new Set(['#/components/securitySchemes/api_key']));
+  });
+
+  it('should transitively follow `$ref` pointers into referenced schemas', () => {
+    // `POST /pet`'s `requestBody` is a `$ref` to `#/components/requestBodies/Pet`, whose content
+    // schemas are themselves `$ref` pointers to `#/components/schemas/Pet`, which itself contains
+    // `$ref` pointers to `Category` and `Tag`. All of that should be reachable, even though none of
+    // it is directly on the operation.
+    const scope = computeOperationScope(petstore as OASDocument, '/pet', 'post');
+
+    expect(scope.reachableRefs).toStrictEqual(
+      new Set([
+        '#/components/requestBodies/Pet',
+        '#/components/schemas/Pet',
+        '#/components/schemas/Category',
+        '#/components/schemas/Tag',
+        '#/components/securitySchemes/petstore_auth',
+      ]),
+    );
+  });
+
+  it('should be case-insensitive for both the path and the method', () => {
+    const scope = computeOperationScope(petstore as OASDocument, '/PET', 'POST');
+
+    expect(scope.rootPointer).toBe('/paths/~1pet/post');
+  });
+
+  it('should scope operation-level security requirements to their security scheme', () => {
+    // `GET /pet/{petId}` uses `api_key`, not the `petstore_auth` that `POST /pet` uses.
+    const scope = computeOperationScope(petstore as OASDocument, '/pet/{petId}', 'get');
+
+    expect(scope.reachableRefs.has('#/components/securitySchemes/api_key')).toBe(true);
+    expect(scope.reachableRefs.has('#/components/securitySchemes/petstore_auth')).toBe(false);
+  });
+
+  it('should throw if the path does not exist', () => {
+    expect(() => computeOperationScope(petstore as OASDocument, '/nope', 'get')).toThrow('Path `/nope` not found.');
+  });
+
+  it('should throw if the operation does not exist on an otherwise valid path', () => {
+    expect(() => computeOperationScope(petstore as OASDocument, '/pet', 'trace')).toThrow(
+      'Operation `trace /pet` not found.',
+    );
+  });
+});
+
+describe('#computeWebhookScope()', () => {
+  it('should transitively follow `$ref` pointers into referenced schemas', () => {
+    const scope = computeWebhookScope(webhooksSpec as unknown as OASDocument, 'newPet', 'post');
+
+    expect(scope.rootPointer).toBe('/webhooks/newPet/post');
+    expect(scope.reachableRefs).toStrictEqual(new Set(['#/components/schemas/Pet']));
+  });
+
+  it('should throw if the webhook does not exist', () => {
+    expect(() => computeWebhookScope(webhooksSpec as unknown as OASDocument, 'nope', 'post')).toThrow(
+      'Webhook `nope` not found.',
+    );
+  });
+
+  it('should throw if the webhook operation does not exist on an otherwise valid webhook', () => {
+    expect(() => computeWebhookScope(webhooksSpec as unknown as OASDocument, 'newPet', 'patch')).toThrow(
+      'Webhook operation `patch newPet` not found.',
+    );
+  });
+});
+
+describe('#isPointerInScope()', () => {
+  const scope = computeOperationScope(petstore as OASDocument, '/pet', 'post');
+
+  it('should consider the operation itself in scope', () => {
+    expect(isPointerInScope('/paths/~1pet/post/requestBody', scope)).toBe(true);
+  });
+
+  it('should consider a reachable component in scope', () => {
+    expect(isPointerInScope('/components/schemas/Pet/properties/category', scope)).toBe(true);
+  });
+
+  it('should not consider an unrelated operation in scope', () => {
+    expect(isPointerInScope('/paths/~1pet/put/requestBody', scope)).toBe(false);
+  });
+
+  it('should not treat a sibling with a shared prefix as in scope', () => {
+    // `/paths/~1pet` is a prefix of `/paths/~1pet~1findByStatus` as a raw string, but they're
+    // unrelated paths and shouldn't be conflated.
+    expect(isPointerInScope('/paths/~1pet~1findByStatus/get', scope)).toBe(false);
+  });
+});
+
+describe('#isAncestorOfScope()', () => {
+  it('should identify when a scope is nested within a coarser pointer', () => {
+    const scope = computeWebhookScope(webhooksSpec as unknown as OASDocument, 'newPet', 'post');
+
+    expect(isAncestorOfScope('/webhooks/newPet', scope)).toBe(true);
+    expect(isAncestorOfScope('/webhooks/somethingElse', scope)).toBe(false);
+  });
+});
+
+describe('#toPointer()', () => {
+  it('should strip a leading `#` off of a `$ref` pointer', () => {
+    expect(toPointer('#/components/schemas/Pet')).toBe('/components/schemas/Pet');
+  });
+
+  it('should leave an already-plain pointer alone', () => {
+    expect(toPointer('/components/schemas/Pet')).toBe('/components/schemas/Pet');
+  });
+});
+
+describe('#estimateScopedSize()', () => {
+  it('should estimate a nonzero size for an operation that references components', () => {
+    const scope = computeOperationScope(petstore as OASDocument, '/pet', 'post');
+
+    expect(estimateScopedSize(petstore, scope)).toBeGreaterThan(0);
+  });
+
+  it('should not double-count a pointer that appears in both `extraPointers` and `reachableRefs`', () => {
+    const scope = computeOperationScope(petstore as OASDocument, '/store/inventory', 'get');
+    const sizeOnce = estimateScopedSize(petstore, scope);
+
+    // Estimating twice against the same root and scope should be idempotent (this is also what
+    // exercises the memoized size cache).
+    expect(estimateScopedSize(petstore, scope)).toBe(sizeOnce);
+  });
+});

--- a/packages/oas/test/analyzer/scope.test.ts
+++ b/packages/oas/test/analyzer/scope.test.ts
@@ -1,4 +1,4 @@
-import type { OASDocument } from '../../src/types.js';
+import type { OAS31Document, OASDocument } from '../../src/types.js';
 
 import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
 import webhooksSpec from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
@@ -7,10 +7,8 @@ import { describe, expect, it } from 'vitest';
 import {
   computeOperationScope,
   computeWebhookScope,
-  estimateScopedSize,
   isAncestorOfScope,
   isPointerInScope,
-  toPointer,
 } from '../../src/analyzer/scope.js';
 
 describe('#computeOperationScope()', () => {
@@ -66,20 +64,20 @@ describe('#computeOperationScope()', () => {
 
 describe('#computeWebhookScope()', () => {
   it('should transitively follow `$ref` pointers into referenced schemas', () => {
-    const scope = computeWebhookScope(webhooksSpec as unknown as OASDocument, 'newPet', 'post');
+    const scope = computeWebhookScope(webhooksSpec as OAS31Document, 'newPet', 'post');
 
     expect(scope.rootPointer).toBe('/webhooks/newPet/post');
     expect(scope.reachableRefs).toStrictEqual(new Set(['#/components/schemas/Pet']));
   });
 
   it('should throw if the webhook does not exist', () => {
-    expect(() => computeWebhookScope(webhooksSpec as unknown as OASDocument, 'nope', 'post')).toThrow(
+    expect(() => computeWebhookScope(webhooksSpec as OAS31Document, 'nope', 'post')).toThrow(
       'Webhook `nope` not found.',
     );
   });
 
   it('should throw if the webhook operation does not exist on an otherwise valid webhook', () => {
-    expect(() => computeWebhookScope(webhooksSpec as unknown as OASDocument, 'newPet', 'patch')).toThrow(
+    expect(() => computeWebhookScope(webhooksSpec as OAS31Document, 'newPet', 'patch')).toThrow(
       'Webhook operation `patch newPet` not found.',
     );
   });
@@ -109,36 +107,9 @@ describe('#isPointerInScope()', () => {
 
 describe('#isAncestorOfScope()', () => {
   it('should identify when a scope is nested within a coarser pointer', () => {
-    const scope = computeWebhookScope(webhooksSpec as unknown as OASDocument, 'newPet', 'post');
+    const scope = computeWebhookScope(webhooksSpec as OAS31Document, 'newPet', 'post');
 
     expect(isAncestorOfScope('/webhooks/newPet', scope)).toBe(true);
     expect(isAncestorOfScope('/webhooks/somethingElse', scope)).toBe(false);
-  });
-});
-
-describe('#toPointer()', () => {
-  it('should strip a leading `#` off of a `$ref` pointer', () => {
-    expect(toPointer('#/components/schemas/Pet')).toBe('/components/schemas/Pet');
-  });
-
-  it('should leave an already-plain pointer alone', () => {
-    expect(toPointer('/components/schemas/Pet')).toBe('/components/schemas/Pet');
-  });
-});
-
-describe('#estimateScopedSize()', () => {
-  it('should estimate a nonzero size for an operation that references components', () => {
-    const scope = computeOperationScope(petstore as OASDocument, '/pet', 'post');
-
-    expect(estimateScopedSize(petstore, scope)).toBeGreaterThan(0);
-  });
-
-  it('should not double-count a pointer that appears in both `extraPointers` and `reachableRefs`', () => {
-    const scope = computeOperationScope(petstore as OASDocument, '/store/inventory', 'get');
-    const sizeOnce = estimateScopedSize(petstore, scope);
-
-    // Estimating twice against the same root and scope should be idempotent (this is also what
-    // exercises the memoized size cache).
-    expect(estimateScopedSize(petstore, scope)).toBe(sizeOnce);
   });
 });

--- a/packages/oas/test/benchmarks/analyzer.bench.ts
+++ b/packages/oas/test/benchmarks/analyzer.bench.ts
@@ -56,7 +56,7 @@ describe('per-operation analysis (docusign, 50 operations)', () => {
     async () => {
       for (const [path, method] of operations) {
         // oxlint-disable-next-line no-await-in-loop
-        await analyzeOperation(docusignDefinition, path, method);
+        await analyzeOperation(docusignDefinition, { path, method });
       }
     },
     { iterations: 3 },

--- a/packages/oas/test/benchmarks/analyzer.bench.ts
+++ b/packages/oas/test/benchmarks/analyzer.bench.ts
@@ -1,0 +1,64 @@
+import type { OASDocument } from '../../src/types.js';
+
+import { bench, describe } from 'vitest';
+
+import { analyzeOperation, analyzer } from '../../src/analyzer/index.js';
+import { OpenAPIReducer } from '../../src/reducer/index.js';
+import docusign from '../__datasets__/docusign.json' with { type: 'json' };
+
+const httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
+/**
+ * Grab the first `count` operations out of a definition, in whatever order `Object.keys()` hands
+ * paths and methods back in.
+ *
+ */
+function sampleOperations(definition: OASDocument, count: number): [string, string][] {
+  const operations: [string, string][] = [];
+
+  Object.keys(definition.paths || {}).forEach(path => {
+    if (operations.length >= count) {
+      return;
+    }
+
+    Object.keys((definition.paths as Record<string, Record<string, unknown>>)[path] || {}).forEach(method => {
+      if (httpMethods.includes(method.toLowerCase())) {
+        operations.push([path, method]);
+      }
+    });
+  });
+
+  return operations.slice(0, count);
+}
+
+const docusignDefinition = docusign as unknown as OASDocument;
+const operations = sampleOperations(docusignDefinition, 50);
+
+describe('per-operation analysis (docusign, 50 operations)', () => {
+  bench(
+    'OpenAPIReducer.reduce() + analyzer() per operation',
+    async () => {
+      for (const [path, method] of operations) {
+        const reduced = OpenAPIReducer.init(structuredClone(docusignDefinition)).byOperation(path, method).reduce();
+
+        // We're intentionally analyzing operations one at a time here, not in parallel: this is
+        // simulating the real batch-processing workload (analyzing hundreds of operations out of
+        // the same definition, serially) that this benchmark exists to measure.
+        // oxlint-disable-next-line no-await-in-loop
+        await analyzer(reduced);
+      }
+    },
+    { iterations: 3 },
+  );
+
+  bench(
+    'analyzeOperation() against the full, unreduced definition',
+    async () => {
+      for (const [path, method] of operations) {
+        // oxlint-disable-next-line no-await-in-loop
+        await analyzeOperation(docusignDefinition, path, method);
+      }
+    },
+    { iterations: 3 },
+  );
+});

--- a/packages/oas/test/lib/refs.test.ts
+++ b/packages/oas/test/lib/refs.test.ts
@@ -4,12 +4,23 @@ import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 
 import { describe, expect, it } from 'vitest';
 
 import {
+  toPointer,
   decodePointer,
   dereferenceRef,
   dereferenceRefDeep,
   encodePointer,
   mergeReferencedSchemasIntoRoot,
 } from '../../src/lib/refs.js';
+
+describe('#toPointer()', () => {
+  it('should strip a leading `#` off of a `$ref` pointer', () => {
+    expect(toPointer('#/components/schemas/Pet')).toBe('/components/schemas/Pet');
+  });
+
+  it('should leave an already-plain pointer alone', () => {
+    expect(toPointer('/components/schemas/Pet')).toBe('/components/schemas/Pet');
+  });
+});
 
 describe('#encodePointer()', () => {
   it('should encode a string to a JSON pointer', () => {

--- a/packages/oas/test/reducer/docusign-cases.test.ts
+++ b/packages/oas/test/reducer/docusign-cases.test.ts
@@ -13,9 +13,9 @@ expect.extend({ toBeAValidOpenAPIDefinition });
 describe('reducer (docusign circular refs)', () => {
   // Sanity check to ensure that this API definition does in fact contain circular references.
   it('should contain circular references', async () => {
-    const analyzerResult = await analyzer(structuredClone(docusign) as OASDocument);
+    const analyzerResult = await analyzer(structuredClone(docusign) as OASDocument, ['circularRefs']);
 
-    expect(analyzerResult.openapi.circularRefs).toStrictEqual({
+    expect(analyzerResult.circularRefs).toStrictEqual({
       present: true,
       locations: [
         '#/components/schemas/bulkSendingCopyDocGenFormFieldRowValue/properties/docGenFormFieldList/items',
@@ -34,8 +34,8 @@ describe('reducer (docusign circular refs)', () => {
 
       await expect(reduced).toBeAValidOpenAPIDefinition();
 
-      const analyzerResult = await analyzer(structuredClone(reduced));
-      expect(analyzerResult.openapi.circularRefs).toStrictEqual({
+      const analyzerResult = await analyzer(structuredClone(reduced), ['circularRefs']);
+      expect(analyzerResult.circularRefs).toStrictEqual({
         present: false,
         locations: [
           // This endpoint didn't have any circular references before we reduced it and shouldn't
@@ -81,8 +81,8 @@ describe('reducer (docusign circular refs)', () => {
 
       await expect(reduced).toBeAValidOpenAPIDefinition();
 
-      const analyzerResult = await analyzer(structuredClone(reduced));
-      expect(analyzerResult.openapi.circularRefs).toStrictEqual({
+      const analyzerResult = await analyzer(structuredClone(reduced), ['circularRefs']);
+      expect(analyzerResult.circularRefs).toStrictEqual({
         present: true,
         locations: [
           '#/components/schemas/docGenFormFieldRowValue/properties/docGenFormFieldList/items',


### PR DESCRIPTION
> [!IMPORTANT]
> This is contains breaking changes for `oas` and will be published to a new major release.

## 🧰 Changes

Analyzing a large OpenAPI definition operation-by-operation used to require cloning and reducing the full document with `oas/reducer` for each operation, then running `analyzer()` on that reduced copy — re-dereferencing and re-scanning from scratch every time. On large specs with hundreds of operations, that added up to minutes in production.

This refactor adds scoped analysis against the full, unreduced definition, with caching so the expensive work is paid once per definition reference.

### New entry points:
* `analyzeOperation(definition, { path, method, query? })` — analyze a single path operation and anything it references
* `analyzeWebhookOperation(definition, { webhookName, method, query? })` — same for OpenAPI 3.1 webhooks
Each call computes an OperationScope: the operation (or webhook operation), path-level common parameters, and every $ref transitively reachable from those — mirroring the ref-walk OpenAPIReducer already does, but read-only and without cloning the document.

Each call computes an `OperationScope`: the operation (or webhook operation), path-level common parameters, and every `$ref` transitively reachable from those — mirroring the ref-walk `OpenAPIReducer` already does, but read-only and without cloning the document.

### Performance
Two caches keyed by the original `definition` object reference:

* `dereferenceOasShared()` — clones and dereferences once; reuse across calls
* `queryCached()` — runs each JSONPath scan once per definition; filter results per operation
 
**Important:** pass the same `definition` reference across calls. Fresh clones defeat the cache.

Benchmark (`test/benchmarks/analyzer.bench.ts`), 50 operations from a ~2.8MB DocuSign spec:

| Approach | Time (3 iterations) |
| :--- | :--- |
| OpenAPIReducer.reduce() + analyzer() per operation | ~2564ms |
| analyzeOperation() against the full definition | ~210ms |

**~12× faster**, with the gap widening as operation count grows.

### Selective queries
`analyzer()` and the new scoped helpers accept an optional query array to run only the metrics you need:

```ts
await analyzer(petstore, ['polymorphism', 'references']);
await analyzeOperation(petstore, { path: '/pet', method: 'post', query: ['references'] });
```

### Query improvements
* `mediaTypes` now scans `components.requestBodies`, `components.responses`, and `webhooks` in addition to `paths` (fixes missed media types behind `$ref`)
* `additionalProperties` correctly finds usage inside $ref pointers

## 💥 Breaking changes
| Before | After |
| :--- | :--- |
| `analysis.general.*` / `analysis.openapi.*` | Flat top-level keys (analysis.mediaTypes, analysis.references, etc.) |
| `rawFileSize`, `dereferencedFileSize` | Removed |
| Individual query functions exported from `oas/analyzer` |No longer exported; use `analyzer(def, ['queryName'])` instead |