### PR TITLE
fix(oas-to-har): header parameters not being matched case-insensitively against supplied values

### DIFF
--- a/.changeset/tame-turtles-relax.md
+++ b/.changeset/tame-turtles-relax.md
@@ -1,0 +1,5 @@
+---
+"@readme/oas-to-har": patch
+---
+
+Fix header parameters not being matched against supplied values when the parameter name and the value's key differ only in casing (e.g. `X-Customer-Code` vs `x-customer-code`)

--- a/packages/oas-to-har/src/index.ts
+++ b/packages/oas-to-har/src/index.ts
@@ -32,6 +32,31 @@ import {
   parseJSONStringsInBodyWithSchema,
 } from './lib/utils.js';
 
+/**
+ * Retrieves the value for a given parameter out of the bucket of values for its `in` type (e.g.
+ * `values.header`).
+ *
+ * HTTP header names are case-insensitive, but incoming header values (e.g. as normalized by
+ * `api/core`) are often lowercased while the OAS document defining the header parameter may use
+ * any casing (e.g. `X-Customer-Code`). So for headers we fall back to a case-insensitive lookup
+ * if there wasn't an exact match on the parameter name.
+ */
+function getParamValue(
+  values: DataForHAR,
+  param: ParameterObject,
+  type: 'body' | 'cookie' | 'header' | 'path' | 'query',
+) {
+  const bucket = values[type];
+  if (bucket && typeof bucket === 'object' && !(param.name in bucket) && type === 'header') {
+    const matchedKey = Object.keys(bucket).find(key => key.toLowerCase() === param.name.toLowerCase());
+    if (matchedKey !== undefined) {
+      return bucket[matchedKey];
+    }
+  }
+
+  return bucket?.[param.name];
+}
+
 function formatter(
   values: DataForHAR,
   param: ParameterObject,
@@ -39,7 +64,7 @@ function formatter(
   onlyIfExists = false,
 ) {
   if (param.style) {
-    const value = values[type][param.name];
+    const value = getParamValue(values, param, type);
     // Note: Technically we could send everything through the format style and choose the proper
     // default for each `in` type (e.g. query defaults to form).
     return formatStyle(value, param);
@@ -48,8 +73,8 @@ function formatter(
   let value: string | number | boolean | undefined;
 
   // Handle missing values
-  if (typeof values[type][param.name] !== 'undefined') {
-    value = values[type][param.name];
+  if (typeof getParamValue(values, param, type) !== 'undefined') {
+    value = getParamValue(values, param, type);
   } else if (onlyIfExists && !param.required) {
     value = undefined;
   } else if (param.required && param.schema && !isRef(param.schema) && param.schema.default) {

--- a/packages/oas-to-har/test/parameters.test.ts
+++ b/packages/oas-to-har/test/parameters.test.ts
@@ -704,6 +704,19 @@ describe('parameter handling', () => {
     );
 
     it(
+      'should match a header parameter case-insensitively against the supplied form data',
+      assertHeaders(
+        {
+          parameters: [{ name: 'X-Customer-Code', in: 'header', schema: { type: 'string' } }],
+        },
+        // `api/core` normalizes incoming header keys to lowercase before oas-to-har ever sees
+        // them, so the form data key won't necessarily match the parameter's defined casing.
+        { header: { 'x-customer-code': 'abc123' } },
+        [{ name: 'X-Customer-Code', value: 'abc123' }],
+      ),
+    );
+
+    it(
       'should pass an `accept` header if endpoint expects a content back from response',
       assertHeaders(
         {


### PR DESCRIPTION
## Description

HTTP header names are case-insensitive, but the values passed in for building a request HAR (e.g. as normalized by `api/core`, which lowercases incoming header keys) don't necessarily match the casing used for the header parameter's name in the OAS document.

For example, a parameter defined as:

```json
{
  "name": "X-Customer-Code",
  "in": "header",
  "schema": { "type": "string" }
}
```

wasn't matched against a supplied value keyed as `x-customer-code`, so the formatter would treat the value as missing even though it was actually provided.

This adds a case-insensitive fallback lookup specifically for header parameters (other `in` types, like query and path, are left untouched since they aren't inherently case-insensitive).

Fixes #849

## Testing

Added a regression test in `packages/oas-to-har/test/parameters.test.ts` reproducing the exact scenario from the issue, and confirmed it fails without the fix and passes with it. Ran the full `oas-to-har` test suite (393 passing) and `tsc --noEmit`, both clean.