### PR TITLE
fix(oas): validate x-readme.status-url as a string

### DIFF
--- a/.changeset/validate-status-url-string.md
+++ b/.changeset/validate-status-url-string.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Fix `validateExtension` rejecting `x-readme.status-url` as a boolean. The `status-url` extension was registered without a matching validator branch, so `validateExtensions()` fell through to the boolean check and threw `"x-readme.status-url" must be of type "Boolean"` for valid URL strings. It's now validated as a string.

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -23,6 +23,7 @@ import {
   OAUTH_OPTIONS,
   PARAMETER_ORDERING,
   SAMPLES_LANGUAGES,
+  STATUS_URL,
   validateParameterOrdering,
 } from './extensions.js';
 import { getAuth } from './lib/get-auth.js';
@@ -689,6 +690,10 @@ export default class Oas {
           if (typeof data[extension] !== 'object') {
             throw new TypeError(`"x-readme.${extension}" must be of type "Object"`);
           }
+        } else if (extension === STATUS_URL) {
+          if (typeof data[extension] !== 'string') {
+            throw new TypeError(`"x-readme.${extension}" must be of type "String"`);
+          }
         } else if (typeof data[extension] !== 'boolean') {
           throw new TypeError(`"x-readme.${extension}" must be of type "Boolean"`);
         }
@@ -709,6 +714,10 @@ export default class Oas {
       } else if (extension === OAUTH_OPTIONS) {
         if (typeof data !== 'object') {
           throw new TypeError(`"x-${extension}" must be of type "Object"`);
+        }
+      } else if (extension === STATUS_URL) {
+        if (typeof data !== 'string') {
+          throw new TypeError(`"x-${extension}" must be of type "String"`);
         }
       } else if (typeof data !== 'boolean') {
         throw new TypeError(`"x-${extension}" must be of type "Boolean"`);

--- a/packages/oas/test/extensions.test.ts
+++ b/packages/oas/test/extensions.test.ts
@@ -276,6 +276,7 @@ describe('#validateExtension', () => {
     ['METRICS_ENABLED', false, 'no', 'Boolean'],
     ['SAMPLES_LANGUAGES', ['swift'], {}, 'Array'],
     ['SIMPLE_MODE', true, 'absolutely not', 'Boolean'],
+    ['STATUS_URL', 'https://status.example.com', true, 'String'],
   ])('%s', (extension, validValue, invalidValue, expectedType) => {
     describe('should allow valid extensions', () => {
       it('should allow at the root level', () => {


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

`x-readme.status-url` was getting rejected on spec upload with `"x-readme.status-url" must be of type "Boolean"`, even though its a URL string.

`status-url` is the customer-declared health url we surface as the RFC 9727 `status` link relation in a project's `/.well-known/api-catalog`. it got added to `extensionDefaults` but `validateExtension` never got a branch for it, so `validateExtensions()` looped over it and fell through to the catch-all boolean check. this adds a `STATUS_URL` branch (both nested under `x-readme` and at the root `x-status-url`) that validates its a string, so valid urls pass and anything non-string gets a `must be of type "String"` error instead.

## 🧬 QA & Testing

covered by a new row in the `#validateExtension` test table in `packages/oas/test/extensions.test.ts`, a valid url string passes and a boolean now fails with `must be of type "String"`.

verified end to end by symlinking this build into the readme monorepo and uploading a spec with `"x-readme": { "status-url": "https://status.example.com" }`, which used to throw the boolean error and now imports fine.
