### PR TITLE
feat: full OpenAPI 3.2 support (parsing, validation, runtime)

### DIFF
--- a/.changeset/chatty-camels-attend.md
+++ b/.changeset/chatty-camels-attend.md
@@ -1,0 +1,5 @@
+---
+"@readme/oas-examples": minor
+---
+
+Added OpenAPI 3.2 example definitions: a 3.2 petstore and an `openapi32-features` definition exercising `$self`, server `name`, tag `parent`/`kind`, the QUERY method, `additionalOperations`, `querystring` parameters, `itemSchema`, `dataValue`/`serializedValue` examples, discriminator `defaultMapping`, and the `deviceAuthorization` OAuth 2.0 flow.

--- a/.changeset/clear-baths-jog.md
+++ b/.changeset/clear-baths-jog.md
@@ -1,8 +1,0 @@
----
-"oas-normalize": minor
-"@readme/oas-to-har": minor
-"@readme/openapi-parser": minor
-"oas": minor
----
-
-Add typing support for OpenAPI 3.2. Does not support parsing or validating OpenAPI 3.2 definitions.

--- a/.changeset/heavy-pandas-search.md
+++ b/.changeset/heavy-pandas-search.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+OpenAPI 3.2 support: typings (via `@scalar/openapi-types`), webhooks, and a new `Oas.getAdditionalOperations()` accessor for the 3.2 `additionalOperations` path item map. `getPaths()` intentionally excludes `additionalOperations` so its `HttpMethods`-keyed return type stays intact — use `getAdditionalOperations()` for those, or `Oas.operation()`, which now falls back to `additionalOperations` for custom methods. Media type example extraction now also understands the 3.2 `dataValue` and `serializedValue` example properties with a `value` → `dataValue` → `serializedValue` precedence chain. Runtime modeling of sequential media type `itemSchema`s (e.g. sample generation) is deferred for now; they are validated but a single-item sample would misrepresent a stream and nothing renders sequential media types yet.

--- a/.changeset/olive-parrots-report.md
+++ b/.changeset/olive-parrots-report.md
@@ -1,0 +1,5 @@
+---
+"@readme/openapi-parser": minor
+---
+
+Full OpenAPI 3.2 support: definitions can now be parsed and validated against the published 3.2 JSON Schema, with spec-level validation coverage for `additionalOperations` (including a friendly error when an entry uses a method that already has a fixed field), `deviceAuthorization` OAuth 2.0 flows, `querystring` parameters, and sequential media type `itemSchema`s.

--- a/.changeset/spicy-berries-repeat.md
+++ b/.changeset/spicy-berries-repeat.md
@@ -1,0 +1,5 @@
+---
+"@readme/oas-to-har": minor
+---
+
+OpenAPI 3.2 support: HAR generation for `query` operations and for custom-method operations sourced from `additionalOperations`.

--- a/.changeset/violet-poems-invent.md
+++ b/.changeset/violet-poems-invent.md
@@ -1,0 +1,5 @@
+---
+"oas-normalize": minor
+---
+
+OpenAPI 3.2 definitions can now be loaded, validated, converted, bundled, and dereferenced.

--- a/packages/oas-examples/3.2/json/openapi32-features.json
+++ b/packages/oas-examples/3.2/json/openapi32-features.json
@@ -1,0 +1,341 @@
+{
+  "openapi": "3.2.0",
+  "$self": "https://api.example.com/v1/openapi.json",
+  "info": {
+    "title": "OpenAPI 3.2 Feature Showcase",
+    "summary": "Demonstrates new OpenAPI 3.2 capabilities",
+    "version": "1.0.0",
+    "description": "An example API highlighting OpenAPI 3.2 features including hierarchical tags, the QUERY method, additionalOperations, querystring parameters, sequential media types, enhanced examples, and OAuth2 device authorization."
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1",
+      "name": "production",
+      "description": "Production server"
+    },
+    {
+      "url": "https://staging-api.example.com/v1",
+      "name": "staging",
+      "description": "Staging server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "platform",
+      "summary": "Platform",
+      "kind": "nav"
+    },
+    {
+      "name": "events",
+      "summary": "Events",
+      "parent": "platform",
+      "kind": "nav"
+    },
+    {
+      "name": "partner",
+      "summary": "Partner APIs",
+      "kind": "audience"
+    },
+    {
+      "name": "search",
+      "summary": "Search",
+      "parent": "platform",
+      "kind": "nav"
+    }
+  ],
+  "paths": {
+    "/search": {
+      "query": {
+        "tags": ["search"],
+        "summary": "Search resources with a query payload",
+        "description": "Uses the new QUERY HTTP method for complex, idempotent search operations with a request body.",
+        "operationId": "searchResources",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchQuery"
+              },
+              "examples": {
+                "basic": {
+                  "summary": "Basic search",
+                  "dataValue": {
+                    "query": "status:active",
+                    "limit": 25
+                  },
+                  "serializedValue": "{\"query\":\"status:active\",\"limit\":25}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Resource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalOperations": {
+        "PURGE": {
+          "tags": ["search"],
+          "summary": "Purge search cache",
+          "description": "Custom HTTP method via additionalOperations.",
+          "operationId": "purgeSearchCache",
+          "responses": {
+            "204": {
+              "description": "Cache purged"
+            }
+          }
+        }
+      }
+    },
+    "/events/stream": {
+      "get": {
+        "tags": ["events"],
+        "summary": "Stream live events",
+        "description": "Server-Sent Events stream using itemSchema for sequential media types.",
+        "operationId": "streamEvents",
+        "responses": {
+          "200": {
+            "description": "Event stream",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "type": "object",
+                  "required": ["id", "type", "data"],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/log": {
+      "get": {
+        "tags": ["events"],
+        "summary": "Stream event log as JSON Lines",
+        "operationId": "streamEventLog",
+        "parameters": [
+          {
+            "name": "filters",
+            "in": "querystring",
+            "description": "Querystring parameter location with schema content (OpenAPI 3.2).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "since": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "types": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON Lines event log",
+            "content": {
+              "application/jsonl": {
+                "itemSchema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resources/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "tags": ["platform"],
+        "summary": "Get a resource",
+        "operationId": "getResource",
+        "responses": {
+          "200": {
+            "description": "Resource found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Resource"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SearchQuery": {
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 25
+          }
+        }
+      },
+      "Resource": {
+        "type": "object",
+        "required": ["id", "type"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "user": "#/components/schemas/UserResource",
+            "device": "#/components/schemas/DeviceResource"
+          },
+          "defaultMapping": "#/components/schemas/Resource"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UserResource"
+          },
+          {
+            "$ref": "#/components/schemas/DeviceResource"
+          }
+        ]
+      },
+      "UserResource": {
+        "type": "object",
+        "required": ["id", "type", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "user"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "DeviceResource": {
+        "type": "object",
+        "required": ["id", "type", "model"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "device"
+          },
+          "model": {
+            "type": "string"
+          }
+        }
+      },
+      "Event": {
+        "type": "object",
+        "required": ["id", "type", "timestamp"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "deviceAuth": {
+        "type": "oauth2",
+        "description": "OAuth 2.0 Device Authorization Flow for limited-input devices.",
+        "flows": {
+          "deviceAuthorization": {
+            "deviceAuthorizationUrl": "https://auth.example.com/device",
+            "tokenUrl": "https://auth.example.com/token",
+            "scopes": {
+              "events:read": "Read event streams",
+              "search:query": "Execute search queries"
+            }
+          }
+        }
+      },
+      "sessionCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session",
+        "description": "Cookie-style parameter support expanded in OpenAPI 3.2."
+      }
+    }
+  },
+  "security": [
+    {
+      "deviceAuth": ["events:read"]
+    }
+  ]
+}

--- a/packages/oas-examples/3.2/json/petstore.json
+++ b/packages/oas-examples/3.2/json/petstore.json
@@ -1,0 +1,1064 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "parameters": [],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ],
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "default": {
+            "description": "successful response"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Updated name of the pet",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "Updated status of the pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          },
+          "description": "order placed for purchasing the pet",
+          "required": true
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "description": "Created user object",
+          "required": true
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserArray"
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserArray"
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "description": "Updated user object",
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "xml": {
+          "name": "Order"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Category"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "userStatus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "User Status"
+          }
+        },
+        "xml": {
+          "name": "User"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Tag"
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "name": "photoUrl",
+              "wrapped": true
+            },
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "name": "tag",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "Pet"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        },
+        "description": "Pet object that needs to be added to the store",
+        "required": true
+      },
+      "UserArray": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "description": "List of user object",
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/packages/oas-examples/3.2/json/petstore.json
+++ b/packages/oas-examples/3.2/json/petstore.json
@@ -47,9 +47,7 @@
   "paths": {
     "/pet": {
       "post": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Add a new pet to the store",
         "description": "",
         "operationId": "addPet",
@@ -61,10 +59,7 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ],
         "requestBody": {
@@ -72,9 +67,7 @@
         }
       },
       "put": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Update an existing pet",
         "description": "",
         "operationId": "updatePet",
@@ -92,10 +85,7 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ],
         "requestBody": {
@@ -105,9 +95,7 @@
     },
     "/pet/findByStatus": {
       "get": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Finds Pets by status",
         "description": "Multiple status values can be provided with comma separated strings",
         "operationId": "findPetsByStatus",
@@ -122,11 +110,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": [
-                  "available",
-                  "pending",
-                  "sold"
-                ],
+                "enum": ["available", "pending", "sold"],
                 "default": "available"
               }
             }
@@ -160,19 +144,14 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ]
       }
     },
     "/pet/findByTags": {
       "get": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Finds Pets by tags",
         "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
         "operationId": "findPetsByTags",
@@ -219,10 +198,7 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ],
         "deprecated": true
@@ -230,9 +206,7 @@
     },
     "/pet/{petId}": {
       "get": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Find pet by ID",
         "description": "Returns a single pet",
         "operationId": "getPetById",
@@ -281,9 +255,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Updates a pet in the store with form data",
         "description": "",
         "operationId": "updatePetWithForm",
@@ -306,10 +278,7 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ],
         "requestBody": {
@@ -333,9 +302,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "Deletes a pet",
         "description": "",
         "operationId": "deletePet",
@@ -369,19 +336,14 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ]
       }
     },
     "/pet/{petId}/uploadImage": {
       "post": {
-        "tags": [
-          "pet"
-        ],
+        "tags": ["pet"],
         "summary": "uploads an image",
         "description": "",
         "operationId": "uploadFile",
@@ -411,10 +373,7 @@
         },
         "security": [
           {
-            "petstore_auth": [
-              "write:pets",
-              "read:pets"
-            ]
+            "petstore_auth": ["write:pets", "read:pets"]
           }
         ],
         "requestBody": {
@@ -431,9 +390,7 @@
     },
     "/store/inventory": {
       "get": {
-        "tags": [
-          "store"
-        ],
+        "tags": ["store"],
         "summary": "Returns pet inventories by status",
         "description": "Returns a map of status codes to quantities",
         "operationId": "getInventory",
@@ -463,9 +420,7 @@
     },
     "/store/order": {
       "post": {
-        "tags": [
-          "store"
-        ],
+        "tags": ["store"],
         "summary": "Place an order for a pet",
         "description": "",
         "operationId": "placeOrder",
@@ -505,9 +460,7 @@
     },
     "/store/order/{orderId}": {
       "get": {
-        "tags": [
-          "store"
-        ],
+        "tags": ["store"],
         "summary": "Find purchase order by ID",
         "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
         "operationId": "getOrderById",
@@ -550,9 +503,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "store"
-        ],
+        "tags": ["store"],
         "summary": "Delete purchase order by ID",
         "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
         "operationId": "deleteOrder",
@@ -581,9 +532,7 @@
     },
     "/user": {
       "post": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Create user",
         "description": "This can only be done by the logged in user.",
         "operationId": "createUser",
@@ -608,9 +557,7 @@
     },
     "/user/createWithArray": {
       "post": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithArrayInput",
@@ -627,9 +574,7 @@
     },
     "/user/createWithList": {
       "post": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Creates list of users with given input array",
         "description": "",
         "operationId": "createUsersWithListInput",
@@ -646,9 +591,7 @@
     },
     "/user/login": {
       "get": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Logs user into the system",
         "description": "",
         "operationId": "loginUser",
@@ -712,9 +655,7 @@
     },
     "/user/logout": {
       "get": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Logs out current logged in user session",
         "description": "",
         "operationId": "logoutUser",
@@ -728,9 +669,7 @@
     },
     "/user/{username}": {
       "get": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Get user by user name",
         "description": "",
         "operationId": "getUserByName",
@@ -770,9 +709,7 @@
         }
       },
       "put": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Updated user",
         "description": "This can only be done by the logged in user.",
         "operationId": "updateUser",
@@ -808,9 +745,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "user"
-        ],
+        "tags": ["user"],
         "summary": "Delete user",
         "description": "This can only be done by the logged in user.",
         "operationId": "deleteUser",
@@ -860,11 +795,7 @@
           "status": {
             "type": "string",
             "description": "Order Status",
-            "enum": [
-              "placed",
-              "approved",
-              "delivered"
-            ]
+            "enum": ["placed", "approved", "delivered"]
           },
           "complete": {
             "type": "boolean",
@@ -942,10 +873,7 @@
       },
       "Pet": {
         "type": "object",
-        "required": [
-          "name",
-          "photoUrls"
-        ],
+        "required": ["name", "photoUrls"],
         "properties": {
           "id": {
             "type": "integer",
@@ -982,11 +910,7 @@
           "status": {
             "type": "string",
             "description": "pet status in the store",
-            "enum": [
-              "available",
-              "pending",
-              "sold"
-            ]
+            "enum": ["available", "pending", "sold"]
           }
         },
         "xml": {

--- a/packages/oas-examples/3.2/yaml/openapi32-features.yaml
+++ b/packages/oas-examples/3.2/yaml/openapi32-features.yaml
@@ -1,0 +1,243 @@
+openapi: 3.2.0
+$self: https://api.example.com/v1/openapi.json
+info:
+  title: OpenAPI 3.2 Feature Showcase
+  summary: Demonstrates new OpenAPI 3.2 capabilities
+  version: 1.0.0
+  description: An example API highlighting OpenAPI 3.2 features including hierarchical tags, the QUERY method, additionalOperations, querystring parameters, sequential media types, enhanced examples, and OAuth2 device authorization.
+servers:
+  - url: https://api.example.com/v1
+    name: production
+    description: Production server
+  - url: https://staging-api.example.com/v1
+    name: staging
+    description: Staging server
+tags:
+  - name: platform
+    summary: Platform
+    kind: nav
+  - name: events
+    summary: Events
+    parent: platform
+    kind: nav
+  - name: partner
+    summary: Partner APIs
+    kind: audience
+  - name: search
+    summary: Search
+    parent: platform
+    kind: nav
+paths:
+  /search:
+    query:
+      tags:
+        - search
+      summary: Search resources with a query payload
+      description: Uses the new QUERY HTTP method for complex, idempotent search operations with a request body.
+      operationId: searchResources
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchQuery'
+            examples:
+              basic:
+                summary: Basic search
+                dataValue:
+                  query: status:active
+                  limit: 25
+                serializedValue: '{"query":"status:active","limit":25}'
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resource'
+    additionalOperations:
+      PURGE:
+        tags:
+          - search
+        summary: Purge search cache
+        description: Custom HTTP method via additionalOperations.
+        operationId: purgeSearchCache
+        responses:
+          '204':
+            description: Cache purged
+  /events/stream:
+    get:
+      tags:
+        - events
+      summary: Stream live events
+      description: Server-Sent Events stream using itemSchema for sequential media types.
+      operationId: streamEvents
+      responses:
+        '200':
+          description: Event stream
+          content:
+            text/event-stream:
+              itemSchema:
+                type: object
+                required:
+                  - id
+                  - type
+                  - data
+                properties:
+                  id:
+                    type: string
+                  type:
+                    type: string
+                  data:
+                    type: object
+                    additionalProperties: true
+  /events/log:
+    get:
+      tags:
+        - events
+      summary: Stream event log as JSON Lines
+      operationId: streamEventLog
+      parameters:
+        - name: filters
+          in: querystring
+          description: Querystring parameter location with schema content (OpenAPI 3.2).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  since:
+                    type: string
+                    format: date-time
+                  types:
+                    type: array
+                    items:
+                      type: string
+      responses:
+        '200':
+          description: JSON Lines event log
+          content:
+            application/jsonl:
+              itemSchema:
+                $ref: '#/components/schemas/Event'
+  /resources/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - platform
+      summary: Get a resource
+      operationId: getResource
+      responses:
+        '200':
+          description: Resource found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+components:
+  schemas:
+    SearchQuery:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 25
+    Resource:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          additionalProperties: true
+      discriminator:
+        propertyName: type
+        mapping:
+          user: '#/components/schemas/UserResource'
+          device: '#/components/schemas/DeviceResource'
+        defaultMapping: '#/components/schemas/Resource'
+      oneOf:
+        - $ref: '#/components/schemas/UserResource'
+        - $ref: '#/components/schemas/DeviceResource'
+    UserResource:
+      type: object
+      required:
+        - id
+        - type
+        - name
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          const: user
+        name:
+          type: string
+    DeviceResource:
+      type: object
+      required:
+        - id
+        - type
+        - model
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          const: device
+        model:
+          type: string
+    Event:
+      type: object
+      required:
+        - id
+        - type
+        - timestamp
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        payload:
+          type: object
+          additionalProperties: true
+  securitySchemes:
+    deviceAuth:
+      type: oauth2
+      description: OAuth 2.0 Device Authorization Flow for limited-input devices.
+      flows:
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://auth.example.com/device
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            events:read: Read event streams
+            search:query: Execute search queries
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: session
+      description: Cookie-style parameter support expanded in OpenAPI 3.2.
+security:
+  - deviceAuth:
+      - events:read

--- a/packages/oas-examples/3.2/yaml/petstore.yaml
+++ b/packages/oas-examples/3.2/yaml/petstore.yaml
@@ -1,0 +1,694 @@
+openapi: 3.2.0
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/v2
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      parameters: []
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      parameters: []
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      deprecated: true
+  /pet/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        default:
+          description: successful response
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ''
+      operationId: placeOrder
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+        description: order placed for purchasing the pet
+        required: true
+  /store/order/{orderId}:
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 10
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithArrayInput
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithListInput
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  /user/{username}:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: 'The name that needs to be fetched. Use user1 for testing. '
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid user supplied
+        '404':
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/packages/oas-examples/README.md
+++ b/packages/oas-examples/README.md
@@ -1,6 +1,6 @@
 # @readme/oas-examples
 
-A collection of example [OpenAPI 3.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md) and [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md) documents.
+A collection of example [OpenAPI 3.x](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md) and [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md) documents.
 
 [![npm](https://img.shields.io/npm/v/@readme/oas-examples)](https://npm.im/@readme/oas-examples) [![Build](https://github.com/readmeio/oas/workflows/CI/badge.svg)](https://github.com/readmeio/oas/tree/main/packages/oas-examples)
 
@@ -24,4 +24,4 @@ npm install --save @readme/oas-examples
 import petstore from '@readme/oas-examples/3.0/json/petstore.json';
 ```
 
-Check out the `2.0/`, `3.0/`, and `3.1/` directories for the full list of available examples.
+Check out the `2.0/`, `3.0/`, `3.1/`, and `3.2/` directories for the full list of available examples.

--- a/packages/oas-examples/test/index.test.ts
+++ b/packages/oas-examples/test/index.test.ts
@@ -12,6 +12,7 @@ describe.each([
   ['Swagger 2.0', 'swagger', '2.0'],
   ['OpenAPI 3.0', 'openapi', '3.0'],
   ['OpenAPI 3.1', 'openapi', '3.1'],
+  ['OpenAPI 3.2', 'openapi', '3.2'],
 ])('%s', (_, specification, version) => {
   it('should have parity between JSON and YAML petstores', async () => {
     const json = await parse(path.join(import.meta.dirname, `../${version}/json/petstore.json`));

--- a/packages/oas-normalize/README.md
+++ b/packages/oas-normalize/README.md
@@ -94,7 +94,7 @@ console.log(definition);
 
 ### `.validate()`
 
-Validate a given API definition. This supports Swagger 2.0 and OpenAPI 3.x API definitions, as well as Postman 2.x collections.
+Validate a given API definition. This supports Swagger 2.0 and OpenAPI 3.0, 3.1, and 3.2 API definitions, as well as Postman 2.x collections.
 
 ```ts
 try {

--- a/packages/oas-normalize/test/index.test.ts
+++ b/packages/oas-normalize/test/index.test.ts
@@ -319,6 +319,18 @@ describe('OASNormalize', () => {
       });
     });
 
+    describe('OpenAPI 3.2 support', () => {
+      it('should pass an OpenAPI 3.2 definition through untouched', async () => {
+        const petstore32 = JSON.parse(
+          fs.readFileSync(require.resolve('@readme/oas-examples/3.2/json/petstore.json'), 'utf8'),
+        );
+
+        const o = new OASNormalize(structuredClone(petstore32));
+
+        await expect(o.convert()).resolves.toStrictEqual(petstore32);
+      });
+    });
+
     describe('Postman support', () => {
       it('should support converting a Postman collection to OpenAPI (validating it in the process)', async () => {
         const o = new OASNormalize(require.resolve('./__fixtures__/postman/petstore.collection.json'), {
@@ -449,6 +461,18 @@ describe('OASNormalize', () => {
 
     it('should not attempt to upconvert an OpenAPI definition if we dont need to', async () => {
       const o = new OASNormalize(structuredClone(webhooks));
+
+      await expect(o.validate()).resolves.toStrictEqual({
+        specification: 'OpenAPI',
+        valid: true,
+        warnings: [],
+      });
+    });
+
+    it('should validate an OpenAPI 3.2 definition', async () => {
+      const o = new OASNormalize(require.resolve('@readme/oas-examples/3.2/json/petstore.json'), {
+        enablePaths: true,
+      });
 
       await expect(o.validate()).resolves.toStrictEqual({
         specification: 'OpenAPI',
@@ -692,6 +716,15 @@ describe('OASNormalize', () => {
       ).resolves.toStrictEqual({
         specification: 'openapi',
         version: '3.1.0',
+      });
+
+      await expect(
+        new OASNormalize(require.resolve('@readme/oas-examples/3.2/json/petstore.json'), {
+          enablePaths: true,
+        }).version(),
+      ).resolves.toStrictEqual({
+        specification: 'openapi',
+        version: '3.2.0',
       });
     });
 

--- a/packages/oas-to-har/test/index.test.ts
+++ b/packages/oas-to-har/test/index.test.ts
@@ -157,6 +157,70 @@ describe('oas-to-har', () => {
     expect(har.log.entries[0].request.postData?.text).toBe('{"items":[],"metadata":{},"wrappers":[{"metadata":{}}]}');
   });
 
+  describe('OpenAPI 3.2 support', () => {
+    let spec32: Oas;
+
+    beforeEach(() => {
+      spec32 = Oas.init({
+        openapi: '3.2.0',
+        info: { title: 'OpenAPI 3.2 support', version: '1.0.0' },
+        servers: [{ url: 'https://httpbin.org' }],
+        paths: {
+          '/search': {
+            query: {
+              operationId: 'search',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        query: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                '200': { description: 'OK' },
+              },
+            },
+            additionalOperations: {
+              PURGE: {
+                operationId: 'purgeSearch',
+                responses: {
+                  '204': { description: 'Purged' },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should support a `query` operation with a request body', async () => {
+      const har = oasToHar(spec32, spec32.operation('/search', 'query'), {
+        body: { query: 'status:active' },
+      });
+
+      await expect(har).toBeAValidHAR();
+      expect(har.log.entries[0].request.method).toBe('QUERY');
+      expect(har.log.entries[0].request.url).toBe('https://httpbin.org/search');
+      expect(har.log.entries[0].request.postData).toStrictEqual({
+        mimeType: 'application/json',
+        text: '{"query":"status:active"}',
+      });
+    });
+
+    it('should support an operation sourced from `additionalOperations`', async () => {
+      const har = oasToHar(spec32, spec32.operation('/search', 'PURGE'));
+
+      await expect(har).toBeAValidHAR();
+      expect(har.log.entries[0].request.method).toBe('PURGE');
+      expect(har.log.entries[0].request.url).toBe('https://httpbin.org/search');
+    });
+  });
+
   describe('url', () => {
     it('should be constructed from oas.url()', () => {
       const spec = Oas.init(structuredClone(petstore));

--- a/packages/oas/CHANGELOG.md
+++ b/packages/oas/CHANGELOG.md
@@ -13,7 +13,6 @@
 - c0a781d: Refactor `oas/analyzer` to support analyzing a single operation or webhook directly against a full API definition without needing to reduce it down first.
 
   Breaking changes:
-
   - `dereferencedFileSize` and `rawFileSize` are no longer supported.
   - `oas/analyzer` no longer exports individual query functions, instead you can supply your specific queries as an array of strings to the `analyzer` function.
   - The object that `oas/analyzer` returns has also been reshaped to no longer have a `general` and `openapi` top-level key, everything is now flattened out.

--- a/packages/oas/src/analyzer/index.ts
+++ b/packages/oas/src/analyzer/index.ts
@@ -1,9 +1,9 @@
-import type { OAS31Document, OASDocument } from '../types.js';
+import type { OAS31Document, OAS32Document, OASDocument } from '../types.js';
 import type { OperationScope } from './scope.js';
 import type { AnalyzerQuery, OASAnalysis } from './types.js';
 
 import { toPointer } from '../lib/refs.js';
-import { isOpenAPI31 } from '../types.js';
+import { isOpenAPI31, isOpenAPI32 } from '../types.js';
 
 import { dereferenceOasShared } from './dereference.js';
 import {
@@ -239,10 +239,10 @@ export async function analyzeWebhookOperation(
     query?: AnalyzerQuery[];
   },
 ): Promise<OASAnalysis> {
-  if (!isOpenAPI31(definition)) {
-    throw new TypeError('The supplied definition is not a OpenAPI 3.1 definition.');
+  if (!isOpenAPI31(definition) && !isOpenAPI32(definition)) {
+    throw new TypeError('The supplied definition is not a OpenAPI 3.1 or 3.2 definition.');
   }
 
-  const scope = computeWebhookScope(definition satisfies OAS31Document, webhookName, method);
+  const scope = computeWebhookScope(definition satisfies OAS31Document | OAS32Document, webhookName, method);
   return buildAnalysis(definition, query, scope);
 }

--- a/packages/oas/src/analyzer/scope.ts
+++ b/packages/oas/src/analyzer/scope.ts
@@ -1,4 +1,4 @@
-import type { OAS31Document, OASDocument } from '../types.js';
+import type { OAS31Document, OAS32Document, OASDocument } from '../types.js';
 
 import jsonPointer from 'jsonpointer';
 
@@ -174,7 +174,11 @@ export function computeOperationScope(definition: OASDocument, path: string, met
  * Compute the `OperationScope` for a single webhook operation within an OpenAPI 3.1 definition.
  *
  */
-export function computeWebhookScope(definition: OAS31Document, webhookName: string, method: string): OperationScope {
+export function computeWebhookScope(
+  definition: OAS31Document | OAS32Document,
+  webhookName: string,
+  method: string,
+): OperationScope {
   const webhooks = ('webhooks' in definition ? definition.webhooks : {}) as NonNullable<OAS31Document['webhooks']>;
   const webhookKey = resolveKey(Object.keys(webhooks || {}), webhookName);
   if (!webhookKey) {

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -13,7 +13,7 @@ import type {
   TagObject,
   User,
 } from './types.js';
-import type { OpenAPIV3_1 } from '@scalar/openapi-types';
+import type { OpenAPIV3_1, OpenAPIV3_2 } from '@scalar/openapi-types';
 
 import {
   CODE_SAMPLES,
@@ -42,7 +42,7 @@ import {
   variablesFromServers,
 } from './lib/urls.js';
 import { Operation, Webhook } from './operation/index.js';
-import { isOpenAPI31, isRef } from './types.js';
+import { isOpenAPI31, isOpenAPI32, isRef } from './types.js';
 import { SERVER_VARIABLE_REGEX, supportedMethods } from './utils.js';
 
 export default class Oas {
@@ -218,11 +218,12 @@ export default class Oas {
    * Retrieve an Operation of Webhook class instance for a given path and method.
    *
    * @param path Path to lookup and retrieve.
-   * @param method HTTP Method to retrieve on the path.
+   * @param method HTTP Method to retrieve on the path. On OpenAPI 3.2 definitions this may also
+   *    be a custom method that's documented within a path items `additionalOperations` map.
    */
   operation(
     path: string,
-    method: HttpMethods,
+    method: HttpMethods | (string & {}),
     opts: {
       /**
        * If you prefer to first look for a webhook with this path and method.
@@ -239,11 +240,11 @@ export default class Oas {
     };
 
     if (opts.isWebhook) {
-      if (isOpenAPI31(this.api)) {
+      if (isOpenAPI31(this.api) || isOpenAPI32(this.api)) {
         const webhookPath = dereferenceRef(this.api?.webhooks?.[path], this.api);
         if (webhookPath && !isRef(webhookPath)) {
-          if (webhookPath?.[method]) {
-            operation = webhookPath[method];
+          if (webhookPath?.[method as HttpMethods]) {
+            operation = webhookPath[method as HttpMethods];
             return new Webhook(this, path, method, operation);
           }
         }
@@ -252,8 +253,17 @@ export default class Oas {
 
     if (this?.api?.paths?.[path]) {
       const pathItem = dereferenceRef(this.api.paths[path], this.api);
-      if (pathItem?.[method]) {
-        operation = dereferenceRef(pathItem[method], this.api);
+      if (supportedMethods.includes(method as (typeof supportedMethods)[number])) {
+        if (pathItem?.[method as HttpMethods]) {
+          operation = dereferenceRef(pathItem[method as HttpMethods], this.api);
+        }
+      } else if (isOpenAPI32(this.api)) {
+        // If this isn't a method that has a fixed field on the path item then it may instead be
+        // documented within the OpenAPI 3.2 `additionalOperations` map.
+        const additionalOperations = (pathItem as OpenAPIV3_2.PathItemObject)?.additionalOperations;
+        if (additionalOperations?.[method]) {
+          operation = dereferenceRef(additionalOperations[method], this.api);
+        }
       }
     }
 
@@ -540,6 +550,55 @@ export default class Oas {
   }
 
   /**
+   * Returns every operation that's documented within the OpenAPI 3.2 `additionalOperations` maps
+   * in this API definition, keyed by path and then by HTTP method, with every operation mapped to
+   * an instance of the `Operation` class.
+   *
+   * Because `additionalOperations` documents operations for HTTP methods that don't have a fixed
+   * field on a path item these are intentionally **not** returned by `getPaths()`.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#path-item-object}
+   */
+  getAdditionalOperations(): Record<string, Record<string, Operation>> {
+    const operations: Record<string, Record<string, Operation>> = {};
+    if (!isOpenAPI32(this.api) || !this.api.paths) {
+      return operations;
+    }
+
+    Object.keys(this.api.paths).forEach(path => {
+      // If this is a specification extension then we should ignore it.
+      if (path.startsWith('x-')) {
+        return;
+      }
+
+      let pathItem = this.api.paths![path];
+      if (!pathItem) {
+        return;
+      } else if (isRef(pathItem)) {
+        // Though this library is generally unaware of `$ref` pointers we're making a singular
+        // exception with this accessor out of convenience.
+        this.api.paths![path] = dereferenceRef(pathItem, this.api);
+        pathItem = this.api.paths![path];
+        if (!pathItem || isRef(pathItem)) {
+          return;
+        }
+      }
+
+      const additionalOperations = (pathItem as OpenAPIV3_2.PathItemObject).additionalOperations;
+      if (!additionalOperations) {
+        return;
+      }
+
+      operations[path] = {};
+      Object.keys(additionalOperations).forEach(method => {
+        operations[path][method] = this.operation(path, method);
+      });
+    });
+
+    return operations;
+  }
+
+  /**
    * Returns the `webhooks` object that exists in this API definition but with every `method`
    * mapped to an instance of the `Webhook` class.
    *
@@ -548,14 +607,17 @@ export default class Oas {
    */
   getWebhooks(): Record<string, Record<HttpMethods, Webhook>> {
     const webhooks: Record<string, Record<HttpMethods, Webhook>> = {};
-    if (!isOpenAPI31(this.api) || !this.api.webhooks) {
+    if ((!isOpenAPI31(this.api) && !isOpenAPI32(this.api)) || !this.api.webhooks) {
       return webhooks;
     }
 
     Object.keys(this.api.webhooks).forEach(id => {
       webhooks[id] = {} as Record<HttpMethods, Webhook>;
 
-      const webhookPath = dereferenceRef((this.api as OpenAPIV3_1.Document).webhooks?.[id], this.api);
+      const webhookPath = dereferenceRef(
+        (this.api as OpenAPIV3_1.Document | OpenAPIV3_2.Document).webhooks?.[id],
+        this.api,
+      );
       if (webhookPath) {
         Object.keys(webhookPath).forEach(method => {
           if (!supportedMethods.includes(method as HttpMethods)) {

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -6,6 +6,7 @@ import type {
   KeyedSecuritySchemeObject,
   MediaTypeObject,
   OAS31Document,
+  OAS32Document,
   OASDocument,
   OperationObject,
   ParameterObject,
@@ -72,9 +73,10 @@ export class Operation {
   path: string;
 
   /**
-   * HTTP Method that this operation is targeted towards.
+   * HTTP Method that this operation is targeted towards. On OpenAPI 3.2 definitions this may
+   * also be a custom method that's documented within a path items `additionalOperations` map.
    */
-  method: HttpMethods;
+  method: HttpMethods | (string & {});
 
   /**
    * The primary Content Type that this operation accepts.
@@ -109,7 +111,7 @@ export class Operation {
     response: string[];
   };
 
-  constructor(oas: Oas, path: string, method: HttpMethods, operation: OperationObject) {
+  constructor(oas: Oas, path: string, method: HttpMethods | (string & {}), operation: OperationObject) {
     this.oas = oas;
     this.schema = operation;
     this.api = oas.api;
@@ -1260,7 +1262,7 @@ export class Webhook extends Operation {
   /**
    * OpenAPI API Definition that this webhook originated from.
    */
-  declare api: OAS31Document;
+  declare api: OAS31Document | OAS32Document;
 
   /**
    * Retrieve the `summary` for this callback.

--- a/packages/oas/src/operation/lib/get-mediatype-examples.ts
+++ b/packages/oas/src/operation/lib/get-mediatype-examples.ts
@@ -90,6 +90,20 @@ export function getMediaTypeExamples(
             }
 
             example = exampleObject.value;
+          } else if ('dataValue' in exampleObject) {
+            // OpenAPI 3.2 deprecated `value` in favor of `dataValue`, however if both are present
+            // then `value` takes precedence as it likely predates any 3.2 upgrade to the
+            // definition.
+            exampleObject.dataValue = dereferenceRefDeep(exampleObject.dataValue, definition);
+            if (exampleObject.dataValue === undefined || collectRefsInSchema(exampleObject.dataValue).size > 0) {
+              return false;
+            }
+
+            example = exampleObject.dataValue;
+          } else if ('serializedValue' in exampleObject && exampleObject.serializedValue !== undefined) {
+            // `serializedValue` examples are already serialized into their target media type so
+            // we return them as-is, without ever attempting to parse or dereference them.
+            example = exampleObject.serializedValue;
           }
         }
 

--- a/packages/oas/src/types.ts
+++ b/packages/oas/src/types.ts
@@ -146,6 +146,8 @@ export type ServerObject = OpenAPIV3_2.ServerObject | OpenAPIV3_1.ServerObject |
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-variable-object}
  */
+// The `OpenAPIV3_2` namespace does not have its own `ServerVariableObject` as OpenAPI 3.2 uses
+// the same shape as 3.1.
 export type ServerVariableObject = OpenAPIV3_1.ServerVariableObject | OpenAPIV3.ServerVariableObject;
 export type ServerVariablesObject = Record<string, ServerVariableObject>;
 export type ServerVariable = Record<
@@ -339,6 +341,8 @@ export type KeyedSecuritySchemeObject = SecuritySchemeObject & {
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-requirement-object}
  */
+// The `OpenAPIV3_2` namespace does not have its own `SecurityRequirementObject` as OpenAPI 3.2
+// uses the same shape as 3.1.
 export type SecurityRequirementObject = OpenAPIV3_1.SecurityRequirementObject | OpenAPIV3.SecurityRequirementObject;
 
 /**

--- a/packages/oas/test/analyzer/index.test.ts
+++ b/packages/oas/test/analyzer/index.test.ts
@@ -120,4 +120,29 @@ describe('#analyzeWebhookOperation()', () => {
       analyzeWebhookOperation(webhooksSpec as unknown as OASDocument, { webhookName: 'nope', method: 'post' }),
     ).rejects.toThrow('Webhook `nope` not found.');
   });
+
+  it('should analyze a webhook operation on an OpenAPI 3.2 definition', async () => {
+    const definition = {
+      openapi: '3.2.0',
+      info: { title: 'Test', version: '1.0.0' },
+      webhooks: {
+        newPet: {
+          post: {
+            operationId: 'newPet',
+            requestBody: {
+              content: { 'application/json': { schema: { type: 'object', properties: { id: { type: 'string' } } } } },
+            },
+            responses: { 200: { description: 'ok' } },
+          },
+        },
+      },
+    } as unknown as OASDocument;
+
+    const analysis = await analyzeWebhookOperation(definition, { webhookName: 'newPet', method: 'post' });
+
+    expect(analysis.webhooks).toStrictEqual({
+      present: true,
+      locations: ['#/webhooks/newPet'],
+    });
+  });
 });

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -2,6 +2,7 @@ import type { HttpMethods, OASDocument } from '../src/types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
 import webhooksSpec from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
+import openapi32FeaturesSpec from '@readme/oas-examples/3.2/json/openapi32-features.json' with { type: 'json' };
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import Oas from '../src/index.js';
@@ -681,6 +682,45 @@ describe('Oas', () => {
         requestBodyExamples: undefined,
         responseExamples: undefined,
         callbackExamples: undefined,
+      });
+    });
+
+    describe('OpenAPI 3.2 `additionalOperations`', () => {
+      it('should fall back to `additionalOperations` for a method without a fixed field', () => {
+        const oas = Oas.init(structuredClone(openapi32FeaturesSpec));
+        const operation = oas.operation('/search', 'PURGE');
+
+        expect(operation).toBeInstanceOf(Operation);
+        expect(operation.path).toBe('/search');
+        expect(operation.method).toBe('PURGE');
+        expect(operation.schema).toStrictEqual({
+          tags: ['search'],
+          summary: 'Purge search cache',
+          description: 'Custom HTTP method via additionalOperations.',
+          operationId: 'purgeSearchCache',
+          responses: expect.any(Object),
+        });
+      });
+
+      it('should still return an operation object for a custom method that is not documented', () => {
+        const oas = Oas.init(structuredClone(openapi32FeaturesSpec));
+        const operation = oas.operation('/search', 'LOCK');
+
+        expect(operation).toMatchObject({
+          schema: { parameters: [] },
+          path: '/search',
+          method: 'LOCK',
+        });
+      });
+
+      it('should not look at `additionalOperations` on non-3.2 definitions', () => {
+        const operation = petstore.operation('/pet', 'PURGE');
+
+        expect(operation).toMatchObject({
+          schema: { parameters: [] },
+          path: '/pet',
+          method: 'PURGE',
+        });
       });
     });
   });
@@ -1754,9 +1794,67 @@ describe('Oas', () => {
     });
   });
 
+  describe('.getAdditionalOperations()', () => {
+    it('should return every operation within an `additionalOperations` map', () => {
+      const oas = Oas.init(structuredClone(openapi32FeaturesSpec));
+      const operations = oas.getAdditionalOperations();
+
+      expect(operations).toStrictEqual({
+        '/search': {
+          PURGE: expect.any(Operation),
+        },
+      });
+
+      expect(operations['/search'].PURGE.method).toBe('PURGE');
+      expect(operations['/search'].PURGE.getOperationId()).toBe('purgeSearchCache');
+    });
+
+    it('should not return paths that have no `additionalOperations`', () => {
+      const oas = Oas.init(structuredClone(openapi32FeaturesSpec));
+
+      expect(oas.getAdditionalOperations()['/events/stream']).toBeUndefined();
+    });
+
+    it('should return an empty object on definitions that are not OpenAPI 3.2', () => {
+      expect(petstore.getAdditionalOperations()).toStrictEqual({});
+      expect(webhooks.getAdditionalOperations()).toStrictEqual({});
+    });
+
+    it('should return an empty object on a 3.2 definition without any `additionalOperations`', () => {
+      const oas = Oas.init({
+        openapi: '3.2.0',
+        info: { title: 'testing', version: '1.0.0' },
+        paths: {
+          '/anything': {
+            get: { responses: { '200': { description: 'OK' } } },
+          },
+        },
+      });
+
+      expect(oas.getAdditionalOperations()).toStrictEqual({});
+    });
+  });
+
   describe('.getWebhooks()', () => {
     it('should return all webhooks if webhooks are present', () => {
       const hooks = webhooks.getWebhooks();
+
+      expect(Object.keys(hooks)).toHaveLength(1);
+      expect(hooks).toStrictEqual({
+        newPet: {
+          post: expect.any(Webhook),
+          delete: expect.any(Webhook),
+        },
+      });
+    });
+
+    it('should return webhooks on OpenAPI 3.2 definitions', () => {
+      const oas = Oas.init({
+        ...structuredClone(webhooksSpec),
+        openapi: '3.2.0',
+      });
+
+      const hooks = oas.getWebhooks();
 
       expect(Object.keys(hooks)).toHaveLength(1);
       expect(hooks).toStrictEqual({

--- a/packages/oas/test/operation/lib/get-mediatype-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-mediatype-examples.test.ts
@@ -283,9 +283,9 @@ describe('getMediaTypeExamples()', () => {
         },
       };
 
-      expect(getMediaTypeExamples('application/json', media, { components: {} } as unknown as OASDocument)).toStrictEqual(
-        [],
-      );
+      expect(
+        getMediaTypeExamples('application/json', media, { components: {} } as unknown as OASDocument),
+      ).toStrictEqual([]);
     });
 
     it('should fall back to `serializedValue`, returned as-is without parsing', () => {

--- a/packages/oas/test/operation/lib/get-mediatype-examples.test.ts
+++ b/packages/oas/test/operation/lib/get-mediatype-examples.test.ts
@@ -204,4 +204,126 @@ describe('getMediaTypeExamples()', () => {
       ]);
     });
   });
+
+  describe('OpenAPI 3.2 `dataValue` and `serializedValue`', () => {
+    const definition = {} as unknown as OASDocument;
+
+    it('should support an example that only declares `dataValue`', () => {
+      const media: MediaTypeObject = {
+        examples: {
+          basic: {
+            summary: 'Basic search',
+            dataValue: { query: 'status:active', limit: 25 },
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'Basic search',
+          title: 'basic',
+          value: { query: 'status:active', limit: 25 },
+        },
+      ]);
+    });
+
+    it('should prefer `value` over `dataValue` when both are present', () => {
+      const media: MediaTypeObject = {
+        examples: {
+          both: {
+            value: { source: 'value' },
+            dataValue: { source: 'dataValue' },
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'both',
+          title: 'both',
+          value: { source: 'value' },
+        },
+      ]);
+    });
+
+    it('should deeply resolve `$ref` inside `dataValue`', () => {
+      const refDefinition = {
+        components: {
+          examples: {
+            Embedded: {
+              value: { id: 'emb-1' },
+            },
+          },
+        },
+      } as unknown as OASDocument;
+
+      const media: MediaTypeObject = {
+        examples: {
+          nested: {
+            dataValue: [{ $ref: '#/components/examples/Embedded/value' }],
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, refDefinition)).toStrictEqual([
+        {
+          summary: 'nested',
+          title: 'nested',
+          value: [{ id: 'emb-1' }],
+        },
+      ]);
+    });
+
+    it('should drop an example when `dataValue` still contains a `$ref` after deep dereference', () => {
+      const media: MediaTypeObject = {
+        examples: {
+          bad: {
+            dataValue: { $ref: '#/components/examples/Nope' },
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, { components: {} } as unknown as OASDocument)).toStrictEqual(
+        [],
+      );
+    });
+
+    it('should fall back to `serializedValue`, returned as-is without parsing', () => {
+      const media: MediaTypeObject = {
+        examples: {
+          serialized: {
+            summary: 'Pre-serialized payload',
+            serializedValue: '{"query":"status:active","limit":25}',
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'Pre-serialized payload',
+          title: 'serialized',
+          value: '{"query":"status:active","limit":25}',
+        },
+      ]);
+    });
+
+    it('should prefer `dataValue` over `serializedValue` when both are present', () => {
+      const media: MediaTypeObject = {
+        examples: {
+          both: {
+            dataValue: { source: 'dataValue' },
+            serializedValue: '{"source":"serializedValue"}',
+          },
+        },
+      };
+
+      expect(getMediaTypeExamples('application/json', media, definition)).toStrictEqual([
+        {
+          summary: 'both',
+          title: 'both',
+          value: { source: 'dataValue' },
+        },
+      ]);
+    });
+  });
 });

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -41,7 +41,7 @@ npm install @readme/openapi-parser
 ## Features
 
 - Parses API definitions in either JSON or YAML formats.
-- Validates against the [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v2.0), [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.0), or [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.1) specifications.
+- Validates against the [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v2.0), [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.0), [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.1), or [OpenAPI 3.2](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.2) specifications.
 - Resolves all `$ref` pointers, including external files and URLs.
 - Can bundle all of your referenced API definitions into a single file that only has _internal_ `$ref` pointers.
 - Can dereference all `$ref` pointers, giving you a normal JSON object that's easy to work with.
@@ -62,7 +62,7 @@ try {
 
 ### `validate()`
 
-Validates the API definition against the [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v2.0), [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.0), or [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.1) specifications.
+Validates the API definition against the [Swagger 2.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v2.0), [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.0), [OpenAPI 3.1](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.1), or [OpenAPI 3.2](https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.2) specifications.
 
 In addition to validating the API definition against their respective specification schemas, it will also be validated against specific areas that aren't covered by the Swagger or OpenAPI schemas, such as duplicate parameters, invalid component schema names, or duplicate `operationId` values.
 

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -83,7 +83,8 @@ export async function dereference<S extends APIDocument = APIDocument>(
 }
 
 /**
- * Validates the API definition against the Swagger 2.0, OpenAPI 3.0, or OpenAPI 3.1 specifications.
+ * Validates the API definition against the Swagger 2.0, OpenAPI 3.0, OpenAPI 3.1, or OpenAPI 3.2
+ * specifications.
  *
  * In addition to validating the API definition against their respective specification schemas it
  * will also be validated against specific areas that aren't covered by the Swagger or OpenAPI
@@ -99,6 +100,7 @@ export async function dereference<S extends APIDocument = APIDocument>(
  * @see {@link https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v2.0}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.0}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.1}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/tree/main/schemas/v3.2}
  * @param api - A file path or URL to a JSON Schema object, or the JSON Schema object itself.
  * @param options
  */

--- a/packages/parser/src/validators/schema.ts
+++ b/packages/parser/src/validators/schema.ts
@@ -47,7 +47,25 @@ function initializeAjv(draft04: boolean = true) {
 }
 
 /**
- * Validates the given Swagger API against the Swagger 2.0 or OpenAPI 3.0 and 3.1 schemas.
+ * There's a bug with Ajv in how it handles `$dynamicRef` in the way that it's used within the
+ * 3.1 and 3.2 schemas so we need to do some adhoc workarounds, replacing `$dynamicRef: '#meta'`
+ * sites with the dereferenced `schema` definition itself. This retrieves that definition, with
+ * its `$dynamicAnchor` removed, for the version-specific branches below to patch in.
+ *
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/issues/2689}
+ * @see {@link https://github.com/ajv-validator/ajv/issues/1573}
+ */
+function getDynamicRefWorkaroundSchema(schema: typeof openapi.v31legacy | typeof openapi.v32legacy) {
+  const schemaDynamicRef = schema.$defs.schema;
+  if (typeof schemaDynamicRef === 'object' && '$dynamicAnchor' in schemaDynamicRef) {
+    delete schemaDynamicRef.$dynamicAnchor;
+  }
+
+  return schemaDynamicRef;
+}
+
+/**
+ * Validates the given Swagger API against the Swagger 2.0 or OpenAPI 3.0, 3.1, and 3.2 schemas.
  *
  */
 export function validateSchema(
@@ -76,28 +94,31 @@ export function validateSchema(
   let ajv: AjvDraft4 | Ajv;
 
   // Choose the appropriate schema (Swagger or OpenAPI)
-  let schema: typeof openapi.v2 | typeof openapi.v3 | typeof openapi.v31legacy;
+  let schema: typeof openapi.v2 | typeof openapi.v3 | typeof openapi.v31legacy | typeof openapi.v32legacy;
   const specificationName = getSpecificationName(api);
 
   if (isSwagger(api)) {
     schema = openapi.v2;
     ajv = initializeAjv();
   } else if (isOpenAPI32(api)) {
-    throw new TypeError('OpenAPI 3.2 is currently unsupported.');
+    schema = openapi.v32legacy;
+
+    const schemaDynamicRef = getDynamicRefWorkaroundSchema(schema);
+
+    // @ts-expect-error Intentionally setting up this funky schema for an AJV bug.
+    schema.$defs.components.properties.schemas.additionalProperties = schemaDynamicRef;
+    // @ts-expect-error -- see above
+    schema.$defs['media-type'].properties.itemSchema = schemaDynamicRef;
+    // @ts-expect-error -- see above
+    schema.$defs['media-type'].properties.schema = schemaDynamicRef;
+    // @ts-expect-error -- see above
+    schema.$defs.parameter.properties.schema = schemaDynamicRef;
+
+    ajv = initializeAjv(false);
   } else if (isOpenAPI31(api)) {
     schema = openapi.v31legacy;
 
-    /**
-     * There's a bug with Ajv in how it handles `$dynamicRef` in the way that it's used within the
-     * 3.1 schema so we need to do some adhoc workarounds.
-     *
-     * @see {@link https://github.com/OAI/OpenAPI-Specification/issues/2689}
-     * @see {@link https://github.com/ajv-validator/ajv/issues/1573}
-     */
-    const schemaDynamicRef = schema.$defs.schema;
-    if (typeof schemaDynamicRef === 'object' && '$dynamicAnchor' in schemaDynamicRef) {
-      delete schemaDynamicRef.$dynamicAnchor;
-    }
+    const schemaDynamicRef = getDynamicRefWorkaroundSchema(schema);
 
     // @ts-expect-error Intentionally setting up this funky schema for an AJV bug.
     schema.$defs.components.properties.schemas.additionalProperties = schemaDynamicRef;

--- a/packages/parser/src/validators/spec/openapi.ts
+++ b/packages/parser/src/validators/spec/openapi.ts
@@ -8,14 +8,19 @@ import { SpecificationValidator } from './index.js';
 
 type ParameterObject =
   | (OpenAPIV3_1.ParameterObject | OpenAPIV3_1.ReferenceObject)
+  | (OpenAPIV3_2.ParameterObject | OpenAPIV3_2.ReferenceObject)
   | (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject);
 
+type PathItemObject = OpenAPIV3_1.PathItemObject | OpenAPIV3_2.PathItemObject | OpenAPIV3.PathItemObject;
+type OperationObject = OpenAPIV3_1.OperationObject | OpenAPIV3_2.OperationObject | OpenAPIV3.OperationObject;
+
 /**
- * Validates parts of the OpenAPI 3.0 and 3.1 specification that aren't covered by their JSON
- * Schema definitions.
+ * Validates parts of the OpenAPI 3.0, 3.1, and 3.2 specification that aren't covered by their
+ * JSON Schema definitions.
  *
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md}
  * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md}
+ * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md}
  */
 export class OpenAPISpecificationValidator extends SpecificationValidator {
   api: OpenAPIV3_2.Document | OpenAPIV3_1.Document | OpenAPIV3.Document;
@@ -31,6 +36,7 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
 
   runPreSchemaChecks(): void {
     this.checkSecuritySchemes();
+    this.checkAdditionalOperations();
   }
 
   run(): void {
@@ -81,7 +87,7 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
         !Object.keys(this.api.components || {}).length
       ) {
         this.reportError(
-          'OpenAPI 3.1 definitions must contain at least one entry in either `paths`, `webhooks`, or `components`.',
+          'OpenAPI 3.1 and 3.2 definitions must contain at least one entry in either `paths`, `webhooks`, or `components`.',
         );
       }
     }
@@ -91,36 +97,59 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
    * Validates the given path.
    *
    */
-  private validatePath(
-    path: OpenAPIV3_1.PathItemObject | OpenAPIV3.PathItemObject,
-    pathId: string,
-    operationIds: string[],
-  ) {
+  private validatePath(path: PathItemObject, pathId: string, operationIds: string[]) {
     supportedHTTPMethods.forEach(operationName => {
       const operation = path[operationName];
-      const operationId = `${pathId}/${operationName}`;
-
       if (operation) {
-        const declaredOperationId = operation.operationId;
-        if (declaredOperationId) {
-          if (!operationIds.includes(declaredOperationId)) {
-            operationIds.push(declaredOperationId);
-          } else if (this.rules['duplicate-operation-id'] === 'warning') {
-            this.reportWarning(`The operationId \`${declaredOperationId}\` is duplicated and should be made unique.`);
-          } else {
-            this.reportError(`The operationId \`${declaredOperationId}\` is duplicated and must be made unique.`);
-          }
+        this.validateOperation(path, pathId, operation, `${pathId}/${operationName}`, operationIds);
+      }
+    });
+
+    /**
+     * OpenAPI 3.2 allows path items to document operations for HTTP methods that don't have a
+     * fixed field of their own within the `additionalOperations` map.
+     *
+     * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#path-item-object}
+     */
+    if (isOpenAPI32(this.api) && 'additionalOperations' in path && path.additionalOperations) {
+      Object.keys(path.additionalOperations).forEach(method => {
+        const operation = path.additionalOperations[method];
+        if (operation) {
+          this.validateOperation(path, pathId, operation, `${pathId}/additionalOperations/${method}`, operationIds);
         }
+      });
+    }
+  }
 
-        this.validateParameters(path, pathId, operation, operationId);
+  /**
+   * Validates the given operation.
+   *
+   */
+  private validateOperation(
+    path: PathItemObject,
+    pathId: string,
+    operation: OperationObject,
+    operationId: string,
+    operationIds: string[],
+  ) {
+    const declaredOperationId = operation.operationId;
+    if (declaredOperationId) {
+      if (!operationIds.includes(declaredOperationId)) {
+        operationIds.push(declaredOperationId);
+      } else if (this.rules['duplicate-operation-id'] === 'warning') {
+        this.reportWarning(`The operationId \`${declaredOperationId}\` is duplicated and should be made unique.`);
+      } else {
+        this.reportError(`The operationId \`${declaredOperationId}\` is duplicated and must be made unique.`);
+      }
+    }
 
-        Object.keys(operation.responses || {}).forEach(responseCode => {
-          const response = operation.responses[responseCode];
-          const responseId = `${operationId}/responses/${responseCode}`;
-          if (response && !('$ref' in response)) {
-            this.validateResponse(response, responseId);
-          }
-        });
+    this.validateParameters(path, pathId, operation, operationId);
+
+    Object.keys(operation.responses || {}).forEach(responseCode => {
+      const response = operation.responses[responseCode];
+      const responseId = `${operationId}/responses/${responseCode}`;
+      if (response && !('$ref' in response)) {
+        this.validateResponse(response, responseId);
       }
     });
   }
@@ -129,12 +158,7 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
    * Validates the parameters for the given operation.
    *
    */
-  private validateParameters(
-    path: OpenAPIV3_1.PathItemObject | OpenAPIV3.PathItemObject,
-    pathId: string,
-    operation: OpenAPIV3_1.OperationObject | OpenAPIV3.OperationObject,
-    operationId: string,
-  ) {
+  private validateParameters(path: PathItemObject, pathId: string, operation: OperationObject, operationId: string) {
     const pathParams = path.parameters || [];
     const operationParams = operation.parameters || [];
 
@@ -252,7 +276,7 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
    * Note: The requirement for exactly one media type is already enforced by the OpenAPI JSON schema.
    */
   private validateParameterContent(
-    content: OpenAPIV3_1.ParameterObject['content'] | OpenAPIV3.ParameterObject['content'],
+    content: OpenAPIV3_1.ParameterObject['content'] | OpenAPIV3_2.ParameterObject['content'] | OpenAPIV3.ParameterObject['content'],
     parameterId: string,
   ) {
     const mediaTypes = Object.keys(content);
@@ -277,7 +301,10 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
    * Validates the given response object.
    *
    */
-  private validateResponse(response: OpenAPIV3_1.ResponseObject | OpenAPIV3.ResponseObject, responseId: string) {
+  private validateResponse(
+    response: OpenAPIV3_1.ResponseObject | OpenAPIV3_2.ResponseObject | OpenAPIV3.ResponseObject,
+    responseId: string,
+  ) {
     Object.keys(response.headers || {}).forEach(headerName => {
       const header = response.headers[headerName];
       const headerId = `${responseId}/headers/${headerName}`;
@@ -315,7 +342,10 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
    * Validates the given Swagger schema object.
    *
    */
-  private validateSchema(schema: OpenAPIV3_1.SchemaObject | OpenAPIV3.SchemaObject, schemaId: string) {
+  private validateSchema(
+    schema: OpenAPIV3_1.SchemaObject | OpenAPIV3_2.SchemaObject | OpenAPIV3.SchemaObject,
+    schemaId: string,
+  ) {
     if (schema.type === 'array' && !schema.items) {
       if (this.rules['array-without-items'] === 'warning') {
         this.reportWarning(`\`${schemaId}\` is an array, so it should include an \`items\` schema.`);
@@ -447,11 +477,49 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
       // check passes, but the spec demands at least one grant type inside.
       if (type === 'oauth2' && scheme.flows && typeof scheme.flows === 'object') {
         if (Object.keys(scheme.flows as object).length === 0) {
-          reportIssue(
-            `\`${schemeId}\` has empty \`flows\`. At least one grant type is required: \`implicit\`, \`password\`, \`clientCredentials\`, or \`authorizationCode\`.`,
-          );
+          const grantTypes = isOpenAPI32(this.api)
+            ? '`implicit`, `password`, `clientCredentials`, `authorizationCode`, or `deviceAuthorization`'
+            : '`implicit`, `password`, `clientCredentials`, or `authorizationCode`';
+
+          reportIssue(`\`${schemeId}\` has empty \`flows\`. At least one grant type is required: ${grantTypes}.`);
         }
       }
+    });
+  }
+
+  /**
+   * Checks OpenAPI 3.2 `additionalOperations` maps for keys that duplicate the HTTP methods that
+   * already have fixed fields on the path item (`get`, `put`, etc.).
+   *
+   * The JSON Schema catches this through a `propertyNames.not.enum` constraint but AJV renders
+   * that failure as an inscrutable "NOT must NOT be valid" error, so this pre-AJV pass surfaces
+   * a targeted error instead.
+   *
+   * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#path-item-object}
+   */
+  private checkAdditionalOperations() {
+    if (!isOpenAPI32(this.api)) {
+      return;
+    }
+
+    const fixedFieldMethods = supportedHTTPMethods.map(method => method.toUpperCase());
+
+    Object.keys(this.api.paths || {}).forEach(pathName => {
+      const path = this.api.paths[pathName];
+      if (!path || typeof path !== 'object' || !('additionalOperations' in path) || !path.additionalOperations) {
+        return;
+      }
+
+      Object.keys(path.additionalOperations).forEach(method => {
+        if (fixedFieldMethods.includes(method)) {
+          // AJV instance paths are JSON Pointers, so the slashes within the path name itself
+          // need to be escaped for the flagged path to match.
+          this.flagInstancePath(`/paths/${pathName.replace(/~/g, '~0').replace(/\//g, '~1')}/additionalOperations`);
+          this.reportError(
+            `\`/paths${pathName}/additionalOperations\` must not contain \`${method}\` because it already has a fixed field on the path item. Define this operation within \`${method.toLowerCase()}\` instead.`,
+          );
+        }
+      });
     });
   }
 

--- a/packages/parser/src/validators/spec/openapi.ts
+++ b/packages/parser/src/validators/spec/openapi.ts
@@ -276,7 +276,10 @@ export class OpenAPISpecificationValidator extends SpecificationValidator {
    * Note: The requirement for exactly one media type is already enforced by the OpenAPI JSON schema.
    */
   private validateParameterContent(
-    content: OpenAPIV3_1.ParameterObject['content'] | OpenAPIV3_2.ParameterObject['content'] | OpenAPIV3.ParameterObject['content'],
+    content:
+      | OpenAPIV3_1.ParameterObject['content']
+      | OpenAPIV3_2.ParameterObject['content']
+      | OpenAPIV3.ParameterObject['content'],
     parameterId: string,
   ) {
     const mediaTypes = Object.keys(content);

--- a/packages/parser/test/specs/better-errors/3.2/invalid-component-name.yaml
+++ b/packages/parser/test/specs/better-errors/3.2/invalid-component-name.yaml
@@ -1,0 +1,25 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+paths:
+  /anything:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  '$ref': '#/components/schemas/User«Information»'
+components:
+  schemas:
+    User«Information»: # <---- component names should match ^[a-zA-Z0-9\.\-_]+$
+      type: object
+      properties:
+        first:
+          type: boolean
+        last:
+          type: boolean

--- a/packages/parser/test/specs/better-errors/3.2/invalid-x-extension-path.yaml
+++ b/packages/parser/test/specs/better-errors/3.2/invalid-x-extension-path.yaml
@@ -1,0 +1,13 @@
+openapi: 3.2.0
+info:
+  version: 1.0.0
+  title: Invalid API
+servers:
+  - url: https://httpbin.org
+paths:
+  /anything:
+    get:
+      responses:
+        400:
+          description: OK
+          invalid-x-extension: true # <---- this shouldn't be here

--- a/packages/parser/test/specs/better-errors/3.2/invalid-x-extension-root.yaml
+++ b/packages/parser/test/specs/better-errors/3.2/invalid-x-extension-root.yaml
@@ -1,0 +1,13 @@
+openapi: 3.2.0
+info:
+  version: 1.0.0
+  title: Invalid API
+servers:
+  - url: https://httpbin.org
+paths:
+  /anything:
+    get:
+      responses:
+        400:
+          description: OK
+invalid-x-extension: true # <---- this shouldn't be here

--- a/packages/parser/test/specs/better-errors/better-errors.test.ts
+++ b/packages/parser/test/specs/better-errors/better-errors.test.ts
@@ -19,6 +19,12 @@ describe('Better errors', () => {
         errors: [{ message: expect.stringContaining('invalid-x-extension is not expected to be here!') }],
       });
     });
+
+    it('OpenAPI 3.2', async () => {
+      await expect(relativePath('specs/better-errors/3.2/invalid-x-extension-root.yaml')).not.toValidate({
+        errors: [{ message: expect.stringContaining('invalid-x-extension is not expected to be here!') }],
+      });
+    });
   });
 
   describe('invalid `x-` extension at a path level', () => {
@@ -30,6 +36,12 @@ describe('Better errors', () => {
 
     it('OpenAPI 3.1', async () => {
       await expect(relativePath('specs/better-errors/3.1/invalid-x-extension-path.yaml')).not.toValidate({
+        errors: [{ message: expect.stringContaining('invalid-x-extension is not expected to be here!') }],
+      });
+    });
+
+    it('OpenAPI 3.2', async () => {
+      await expect(relativePath('specs/better-errors/3.2/invalid-x-extension-path.yaml')).not.toValidate({
         errors: [{ message: expect.stringContaining('invalid-x-extension is not expected to be here!') }],
       });
     });
@@ -51,12 +63,18 @@ describe('Better errors', () => {
     });
   });
 
-  // The JSON Schema for OpenAPI 3.1 is the only schema available that can properly detect these
-  // within AJV so we're only testing that here. OpenAPI 3.0 and Swagger 2.0 have tests cases for
-  // this under within the `validate-spec` suite.
+  // The JSON Schemas for OpenAPI 3.1 and 3.2 are the only schemas available that can properly
+  // detect these within AJV so we're only testing those here. OpenAPI 3.0 and Swagger 2.0 have
+  // tests cases for this under within the `validate-spec` suite.
   describe('invalid component name', () => {
     it('OpenAPI 3.1', async () => {
       await expect(relativePath('specs/better-errors/3.1/invalid-component-name.yaml')).not.toValidate({
+        errors: [{ message: expect.stringContaining('must match pattern ^[a-zA-Z0-9._-]+$') }],
+      });
+    });
+
+    it('OpenAPI 3.2', async () => {
+      await expect(relativePath('specs/better-errors/3.2/invalid-component-name.yaml')).not.toValidate({
         errors: [{ message: expect.stringContaining('must match pattern ^[a-zA-Z0-9._-]+$') }],
       });
     });

--- a/packages/parser/test/specs/invalid/__snapshots__/invalid.test.ts.snap
+++ b/packages/parser/test/specs/invalid/__snapshots__/invalid.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Invalid APIs (can't be parsed) > and the file is an OpenAPI 3.1 definit
   "additionalErrors": 0,
   "errors": [
     {
-      "message": "OpenAPI 3.1 definitions must contain at least one entry in either \`paths\`, \`webhooks\`, or \`components\`.",
+      "message": "OpenAPI 3.1 and 3.2 definitions must contain at least one entry in either \`paths\`, \`webhooks\`, or \`components\`.",
     },
   ],
   "specification": "OpenAPI",
@@ -19,7 +19,7 @@ exports[`Invalid APIs (can't be parsed) > and the file is an OpenAPI 3.1 definit
   "additionalErrors": 0,
   "errors": [
     {
-      "message": "OpenAPI 3.1 definitions must contain at least one entry in either \`paths\`, \`webhooks\`, or \`components\`.",
+      "message": "OpenAPI 3.1 and 3.2 definitions must contain at least one entry in either \`paths\`, \`webhooks\`, or \`components\`.",
     },
   ],
   "specification": "OpenAPI",

--- a/packages/parser/test/specs/validate-schema/__snapshots__/validate-schema.test.ts.snap
+++ b/packages/parser/test/specs/validate-schema/__snapshots__/validate-schema.test.ts.snap
@@ -401,6 +401,28 @@ exports[`Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation) > 'optiona
 }
 `;
 
+exports[`Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation) > OpenAPI 3.2 > should catch an \`itemSchema\` that is not a schema 1`] = `
+{
+  "additionalErrors": 0,
+  "errors": [
+    {
+      "message": "TYPE must be object,boolean
+
+  13 |             "content": {
+  14 |               "application/jsonl": {
+> 15 |                 "itemSchema": "not-a-schema"
+     |                               ^ type must be object,boolean
+  16 |               }
+  17 |             }
+  18 |           }",
+    },
+  ],
+  "specification": "OpenAPI",
+  "valid": false,
+  "warnings": [],
+}
+`;
+
 exports[`Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation) > should return all errors 1`] = `
 {
   "additionalErrors": 0,

--- a/packages/parser/test/specs/validate-schema/invalid/item-schema-not-an-object.yaml
+++ b/packages/parser/test/specs/validate-schema/invalid/item-schema-not-an-object.yaml
@@ -1,0 +1,13 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+paths:
+  /events:
+    get:
+      responses:
+        '200':
+          description: A stream of events
+          content:
+            application/jsonl:
+              itemSchema: not-a-schema

--- a/packages/parser/test/specs/validate-schema/validate-schema.test.ts
+++ b/packages/parser/test/specs/validate-schema/validate-schema.test.ts
@@ -107,4 +107,14 @@ describe('Invalid APIs (Swagger 2.0 and OpenAPI 3.x schema validation)', () => {
   ])('$name', async ({ file }) => {
     await expect(validate(relativePath(`specs/validate-schema/invalid/${file}`))).resolves.toMatchSnapshot();
   });
+
+  describe('OpenAPI 3.2', () => {
+    // This exercises the AJV `$dynamicRef` workaround on the `itemSchema` media type property,
+    // which only exists in the OpenAPI 3.2 schema.
+    it('should catch an `itemSchema` that is not a schema', async () => {
+      await expect(
+        validate(relativePath('specs/validate-schema/invalid/item-schema-not-an-object.yaml')),
+      ).resolves.toMatchSnapshot();
+    });
+  });
 });

--- a/packages/parser/test/specs/validate-spec/__snapshots__/validate-spec.test.ts.snap
+++ b/packages/parser/test/specs/validate-spec/__snapshots__/validate-spec.test.ts.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Invalid APIs (specification validation) > OpenAPI 3.2-specific cases > should catch a definition without paths, webhooks, or components 1`] = `
+{
+  "additionalErrors": 0,
+  "errors": [
+    {
+      "message": "REQUIRED must have required property 'paths'
+
+> 1 | {
+    | ^ paths is missing here!
+  2 |   "openapi": "3.2.0",
+  3 |   "info": {
+  4 |     "version": "1.0",",
+    },
+  ],
+  "specification": "OpenAPI",
+  "valid": false,
+  "warnings": [],
+}
+`;
+
 exports[`Invalid APIs (specification validation) > components / definitions > should catch a component schema name that contains a space > OpenAPI 3.1 1`] = `
 {
   "additionalErrors": 0,

--- a/packages/parser/test/specs/validate-spec/invalid/3.2/additional-operations-fixed-method.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.2/additional-operations-fixed-method.yaml
@@ -1,0 +1,11 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+paths:
+  /files:
+    additionalOperations:
+      GET:
+        responses:
+          '200':
+            description: OK

--- a/packages/parser/test/specs/validate-spec/invalid/3.2/additional-operations-path-param-no-placeholder.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.2/additional-operations-path-param-no-placeholder.yaml
@@ -1,0 +1,17 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+paths:
+  /files:
+    additionalOperations:
+      COPY:
+        parameters:
+          - name: fileId
+            in: path
+            required: true
+            schema:
+              type: string
+        responses:
+          '200':
+            description: OK

--- a/packages/parser/test/specs/validate-spec/invalid/3.2/duplicate-operation-ids.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.2/duplicate-operation-ids.yaml
@@ -1,0 +1,17 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+paths:
+  /files:
+    get:
+      operationId: files
+      responses:
+        '200':
+          description: OK
+    additionalOperations:
+      COPY:
+        operationId: files
+        responses:
+          '200':
+            description: OK

--- a/packages/parser/test/specs/validate-spec/invalid/3.2/empty-paths.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.2/empty-paths.yaml
@@ -1,0 +1,5 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+paths: {}

--- a/packages/parser/test/specs/validate-spec/invalid/3.2/no-paths-webhooks-or-components.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.2/no-paths-webhooks-or-components.yaml
@@ -1,0 +1,4 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API

--- a/packages/parser/test/specs/validate-spec/invalid/3.2/oauth2-empty-flows.yaml
+++ b/packages/parser/test/specs/validate-spec/invalid/3.2/oauth2-empty-flows.yaml
@@ -1,0 +1,9 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Invalid API
+components:
+  securitySchemes:
+    OAuthEmpty:
+      type: oauth2
+      flows: {}

--- a/packages/parser/test/specs/validate-spec/valid/3.2/additional-operations.yaml
+++ b/packages/parser/test/specs/validate-spec/valid/3.2/additional-operations.yaml
@@ -1,0 +1,28 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Valid API
+paths:
+  /files/{fileId}:
+    parameters:
+      - name: fileId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getFile
+      responses:
+        '200':
+          description: The file
+    additionalOperations:
+      COPY:
+        operationId: copyFile
+        responses:
+          '200':
+            description: File copied
+      LOCK:
+        operationId: lockFile
+        responses:
+          '200':
+            description: File locked

--- a/packages/parser/test/specs/validate-spec/valid/3.2/device-authorization.yaml
+++ b/packages/parser/test/specs/validate-spec/valid/3.2/device-authorization.yaml
@@ -1,0 +1,23 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Valid API
+paths:
+  /users:
+    get:
+      security:
+        - OAuth2Device:
+            - read
+      responses:
+        '200':
+          description: hello world
+components:
+  securitySchemes:
+    OAuth2Device:
+      type: oauth2
+      flows:
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://example.com/device
+          tokenUrl: https://example.com/token
+          scopes:
+            read: Read access

--- a/packages/parser/test/specs/validate-spec/valid/3.2/item-schema.yaml
+++ b/packages/parser/test/specs/validate-spec/valid/3.2/item-schema.yaml
@@ -1,0 +1,17 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Valid API
+paths:
+  /events:
+    get:
+      responses:
+        '200':
+          description: A stream of events
+          content:
+            application/jsonl:
+              itemSchema:
+                type: object
+                properties:
+                  event:
+                    type: string

--- a/packages/parser/test/specs/validate-spec/valid/3.2/minimal.yaml
+++ b/packages/parser/test/specs/validate-spec/valid/3.2/minimal.yaml
@@ -1,0 +1,10 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Valid API
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: hello world

--- a/packages/parser/test/specs/validate-spec/valid/3.2/querystring-parameter.yaml
+++ b/packages/parser/test/specs/validate-spec/valid/3.2/querystring-parameter.yaml
@@ -1,0 +1,21 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Valid API
+paths:
+  /search:
+    query:
+      operationId: search
+      parameters:
+        - name: query
+          in: querystring
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                type: object
+                properties:
+                  term:
+                    type: string
+      responses:
+        '200':
+          description: Search results

--- a/packages/parser/test/specs/validate-spec/valid/3.2/webhooks-only.yaml
+++ b/packages/parser/test/specs/validate-spec/valid/3.2/webhooks-only.yaml
@@ -1,0 +1,18 @@
+openapi: 3.2.0
+info:
+  version: '1.0'
+  title: Valid API
+webhooks:
+  newPet:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: OK

--- a/packages/parser/test/specs/validate-spec/validate-spec.test.ts
+++ b/packages/parser/test/specs/validate-spec/validate-spec.test.ts
@@ -102,6 +102,92 @@ describe('Invalid APIs (specification validation)', () => {
     });
   });
 
+  describe('OpenAPI 3.2-specific cases', () => {
+    it('should allow a minimal definition', async () => {
+      await expect(relativePath('specs/validate-spec/valid/3.2/minimal.yaml')).toValidate();
+    });
+
+    it('should allow a definition comprised entirely of webhooks', async () => {
+      await expect(relativePath('specs/validate-spec/valid/3.2/webhooks-only.yaml')).toValidate();
+    });
+
+    it('should allow custom HTTP methods within `additionalOperations`', async () => {
+      await expect(relativePath('specs/validate-spec/valid/3.2/additional-operations.yaml')).toValidate();
+    });
+
+    it('should allow a `deviceAuthorization` OAuth 2.0 flow', async () => {
+      await expect(relativePath('specs/validate-spec/valid/3.2/device-authorization.yaml')).toValidate();
+    });
+
+    it('should allow a sequential media type documented with `itemSchema`', async () => {
+      await expect(relativePath('specs/validate-spec/valid/3.2/item-schema.yaml')).toValidate();
+    });
+
+    it('should allow a `querystring` parameter', async () => {
+      await expect(relativePath('specs/validate-spec/valid/3.2/querystring-parameter.yaml')).toValidate();
+    });
+
+    it('should catch an empty `paths` object', async () => {
+      await expect(relativePath('specs/validate-spec/invalid/3.2/empty-paths.yaml')).not.toValidate({
+        errors: [
+          {
+            message:
+              'OpenAPI 3.1 and 3.2 definitions must contain at least one entry in either `paths`, `webhooks`, or `components`.',
+          },
+        ],
+      });
+    });
+
+    it('should catch a definition without paths, webhooks, or components', async () => {
+      await expect(
+        validate(relativePath('specs/validate-spec/invalid/3.2/no-paths-webhooks-or-components.yaml')),
+      ).resolves.toMatchSnapshot();
+    });
+
+    it('should catch a duplicate operationId within `additionalOperations`', async () => {
+      await expect(relativePath('specs/validate-spec/invalid/3.2/duplicate-operation-ids.yaml')).not.toValidate({
+        errors: [{ message: 'The operationId `files` is duplicated and must be made unique.' }],
+      });
+    });
+
+    it('should catch an `additionalOperations` operation with a path parameter that has no matching template', async () => {
+      await expect(
+        relativePath('specs/validate-spec/invalid/3.2/additional-operations-path-param-no-placeholder.yaml'),
+      ).not.toValidate({
+        errors: [
+          {
+            message:
+              '`/paths/files/additionalOperations/COPY` has a path parameter named `fileId`, but there is no corresponding `{fileId}` in the path string.',
+          },
+        ],
+      });
+    });
+
+    it('should catch an `additionalOperations` entry for a method that has a fixed field', async () => {
+      await expect(
+        relativePath('specs/validate-spec/invalid/3.2/additional-operations-fixed-method.yaml'),
+      ).not.toValidate({
+        errors: [
+          {
+            message:
+              '`/paths/files/additionalOperations` must not contain `GET` because it already has a fixed field on the path item. Define this operation within `get` instead.',
+          },
+        ],
+      });
+    });
+
+    it('should catch `type: oauth2` with empty `flows` and mention `deviceAuthorization`', async () => {
+      await expect(relativePath('specs/validate-spec/invalid/3.2/oauth2-empty-flows.yaml')).not.toValidate({
+        errors: [
+          {
+            message:
+              '`/components/securitySchemes/OAuthEmpty` has empty `flows`. At least one grant type is required: `implicit`, `password`, `clientCredentials`, `authorizationCode`, or `deviceAuthorization`.',
+          },
+        ],
+      });
+    });
+  });
+
   describe('rule: `duplicate-non-request-body-parameters`', () => {
     describe('given duplicate header parameters', () => {
       describe('Swagger 2.0', () => {


### PR DESCRIPTION
## 🧰 Changes

Finishes the OpenAPI 3.2 work started on `cursor/ff1dc713` (which added typing-only support): 3.2 definitions can now be **parsed, validated, and consumed at runtime** across the monorepo.

### `@readme/openapi-parser`

- Removed the `OpenAPI 3.2 is currently unsupported` throw; 3.2 definitions now validate against the published v3.2 JSON Schema (Ajv 2020), patching the same `$dynamicRef` sites as 3.1 plus the new `media-type.itemSchema` site.
- Spec-level rules (duplicate `operationId`s, parameter checks, response checks) now also run over 3.2 `additionalOperations` entries.
- New pre-schema check that reports a targeted error when an `additionalOperations` key uses a method that already has a fixed field (e.g. `GET`), instead of AJV's cryptic `NOT must NOT be valid` output.
- The empty oauth2 `flows` error now lists `deviceAuthorization` as a grant type on 3.2 definitions.

### `oas`

- Webhooks are now recognized on 3.2 definitions (`getWebhooks()`, `operation(..., { isWebhook: true })`).
- New `Oas.getAdditionalOperations()` accessor (path → method → `Operation`). `getPaths()` intentionally excludes `additionalOperations` so its `HttpMethods`-keyed return type stays intact.
- `Oas.operation()` / `Operation.method` accept custom methods (`HttpMethods | (string & {})`), falling back to `additionalOperations` on 3.2 definitions.
- Media type example extraction understands the 3.2 `dataValue` and `serializedValue` example properties with a `value` → `dataValue` → `serializedValue` precedence chain (`serializedValue` is returned as-is, never parsed).
- `itemSchema` runtime modeling (e.g. sample generation) is deliberately deferred: a single-item sample would misrepresent a stream and nothing renders sequential media types yet. Validation of `itemSchema` works.

### `@readme/oas-examples`

- Restored the 3.2 petstore and `openapi32-features` fixtures that were removed when they couldn't be tested, and wired 3.2 into the test matrix — they validate cleanly against the real 3.2 validator.

### Tests & docs

- Parser: valid/invalid 3.2 fixtures (minimal, webhooks-only, `additionalOperations`, `deviceAuthorization`, `itemSchema`, `querystring`, empty `paths`, empty oauth2 `flows`), an `itemSchema` `$dynamicRef` regression test, and 3.2 better-errors cases.
- `oas-to-har`: QUERY operation with a request body + `additionalOperations`-sourced operation.
- `oas-normalize`: 3.2 validate/version/convert passthrough.
- READMEs updated to enumerate 3.2; the typing-only changeset was superseded by per-package minor changesets (no changeset for `@readme/openapi-schemas`, which already shipped the 3.2 schemas).

## 🧬 QA & Testing

- `npm test` at the root: 2163 tests passing (the `@readme/openapi-schemas` suite requires `npm run build:schemas` locally since turbo only caches `dist/**`).
- Smoke: `validate()` on `@readme/oas-examples/3.2/json/openapi32-features.json` → `{ valid: true, specification: 'OpenAPI' }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)