### PR TITLE
feat(oas): match URLs served by path-item and operation-level servers

### DIFF
--- a/.changeset/operation-server-matching.md
+++ b/.changeset/operation-server-matching.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+`findOperation()`, `findOperationWithoutMethod()`, `getOperation()` and `findOperationMatches()` now resolve URLs served by path-item and operation-level `servers`, following OpenAPI server precedence (operation, then path-item, then root). Paths without server overrides are matched against root servers exactly as before, and a cheap guard keeps lookups on root-only definitions fast.

--- a/packages/oas/CHANGELOG.md
+++ b/packages/oas/CHANGELOG.md
@@ -13,7 +13,6 @@
 - c0a781d: Refactor `oas/analyzer` to support analyzing a single operation or webhook directly against a full API definition without needing to reduce it down first.
 
   Breaking changes:
-
   - `dereferencedFileSize` and `rawFileSize` are no longer supported.
   - `oas/analyzer` no longer exports individual query functions, instead you can supply your specific queries as an array of strings to the `analyzer` function.
   - The object that `oas/analyzer` returns has also been reshaped to no longer have a `general` and `openapi` top-level key, everything is now flattened out.

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -5,6 +5,7 @@ import type {
   HttpMethods,
   OASDocument,
   OperationObject,
+  PathsObject,
   SecuritySchemeObject,
   ServerObject,
   Servers,
@@ -43,6 +44,14 @@ import {
 import { Operation, Webhook } from './operation/index.js';
 import { isOpenAPI31, isRef } from './types.js';
 import { SERVER_VARIABLE_REGEX, supportedMethods } from './utils.js';
+
+/**
+ * A URL decomposed into the server URL that serves it and the path that's left over.
+ */
+interface ServerURLSplit {
+  origin: string;
+  pathName: string;
+}
 
 export default class Oas {
   /**
@@ -256,12 +265,26 @@ export default class Oas {
   }
 
   findOperationMatches(url: string): PathMatches | undefined {
+    // Root server matches are collected first so that when `findTargetPath()` breaks a tie
+    // between equally-specific matches, the last one -- the server defined closest to the
+    // operation -- wins.
+    const annotatedPaths = [
+      ...(this.findRootServerOperationMatches(url) || []),
+      ...this.findOverriddenServerOperationMatches(url),
+    ];
+    if (!annotatedPaths.length) return undefined;
+
+    return annotatedPaths;
+  }
+
+  /**
+   * Find matches for a URL against paths as they are served by the root-level `servers`.
+   */
+  private findRootServerOperationMatches(url: string): PathMatches | undefined {
     const { origin, hostname } = new URL(url);
     const originRegExp = new RegExp(origin, 'i');
     const { servers, paths } = this.api;
 
-    let pathName: string | undefined;
-    let targetServer: ServerObject | undefined;
     let matchedServer: ServerObject | undefined;
 
     if (!servers || !servers.length) {
@@ -280,64 +303,151 @@ export default class Oas {
       }
     }
 
-    if (matchedServer) {
-      // Instead of setting `url` directly against `matchedServer` we need to set it to an
-      // intermediary object as directly modifying `matchedServer.url` will in turn update
-      // `this.servers[idx].url` which we absolutely do not want to happen.
-      targetServer = {
-        ...matchedServer,
-        url: this.replaceUrl(matchedServer.url, matchedServer.variables || {}),
-      };
+    const substituted = matchedServer ? this.splitURLOnSubstitutedServer(url, matchedServer) : undefined;
+    let target = substituted?.pathName ? substituted : undefined;
 
-      [, pathName] = url.split(new RegExp(targetServer.url, 'i'));
-    }
-
-    // If we **still** haven't found a matching server, then the OAS server URL might have server
-    // variables and we should loosen it up with regex to try to discover a matching path.
-    //
-    // For example if an OAS has `https://{region}.node.example.com/v14` set as its server URL, and
-    // the `this.user` object has a `region` value of `us`, if we're trying to locate an operation
-    // for https://eu.node.example.com/v14/api/esm we won't be able to because normally the users
-    // `region` of `us` will be transposed in and we'll be trying to locate `eu.node.example.com`
-    // in `us.node.example.com` -- which won't work.
-    //
-    // So what this does is transform `https://{region}.node.example.com/v14` into
-    // `https://([-_a-zA-Z0-9[\\]]+).node.example.com/v14`, and from there we'll be able to match
-    // https://eu.node.example.com/v14/api/esm and ultimately find the operation matches for
-    // `/api/esm`.
-    if (!matchedServer || !pathName) {
-      const matchedServerAndPath = (servers || [])
-        .map(server => {
-          const rgx = transformURLIntoRegex(server.url);
-          const found = new RegExp(rgx).exec(url);
-          if (!found) {
-            return;
-          }
-
-          return {
-            matchedServer: server,
-            pathName: url.split(new RegExp(rgx)).slice(-1).pop(),
-          };
-        })
-        .filter((item): item is { matchedServer: ServerObject; pathName: string | undefined } => item !== undefined);
-
-      if (!matchedServerAndPath.length) {
-        return undefined;
+    // If we **still** haven't found a matching server, then the OAS server URLs might have server
+    // variables in them and we should loosen those up into regex to try to discover a matching
+    // path. For example if an OAS has `https://{region}.node.example.com/v14` set as its server
+    // URL and the user's `region` is `us`, we'd be trying to locate `us.node.example.com` inside
+    // a https://eu.node.example.com/v14/api/esm URL -- which won't work. Loosened into the
+    // `https://([-_a-zA-Z0-9:.[\\]]+).node.example.com/v14` regex, it will.
+    if (!target) {
+      for (const server of servers || []) {
+        target = this.splitURLOnServerRegex(url, server);
+        if (target) break;
       }
-
-      pathName = matchedServerAndPath[0].pathName;
-      targetServer = {
-        ...matchedServerAndPath[0].matchedServer,
-      };
     }
 
-    if (pathName === undefined) return undefined;
-    if (pathName === '') pathName = '/';
-    if (!paths || !targetServer) return undefined;
-    const annotatedPaths = generatePathMatches(paths, pathName, targetServer.url);
+    if (!target || !paths) return undefined;
+
+    const annotatedPaths = generatePathMatches(paths, target.pathName || '/', target.origin);
     if (!annotatedPaths.length) return undefined;
 
     return annotatedPaths;
+  }
+
+  /**
+   * Find matches for a URL against paths whose operations override the root-level `servers` with
+   * path-item or operation-level `servers`.
+   *
+   * @see {@link https://spec.openapis.org/oas/v3.1.0#path-item-object}
+   */
+  private findOverriddenServerOperationMatches(url: string): PathMatches {
+    const { paths } = this.api;
+    const matches: PathMatches = [];
+    if (!paths) return matches;
+
+    Object.keys(paths).forEach(path => {
+      const rawPathItem = paths[path];
+      if (!rawPathItem) return;
+
+      // Most paths don't override the root servers, so before doing any allocation or
+      // dereferencing work make sure this one might: it declares path-item or operation servers,
+      // or hides them behind a `$ref` that we'd have to resolve to know.
+      let mayHaveOverrides = isRef(rawPathItem) || !!rawPathItem.servers?.length;
+      if (!mayHaveOverrides) {
+        for (const method of supportedMethods) {
+          const rawOperation = rawPathItem[method];
+          if (rawOperation && (isRef(rawOperation) || (rawOperation as OperationObject).servers?.length)) {
+            mayHaveOverrides = true;
+            break;
+          }
+        }
+      }
+
+      if (!mayHaveOverrides) return;
+
+      const pathItem = dereferenceRef(rawPathItem, this.api);
+      if (!pathItem || isRef(pathItem)) return;
+
+      // Group this path's operations by the server list that governs them, following OpenAPI
+      // server precedence: operation-level servers, then path-item servers. Operations with
+      // neither are served by the root-level servers and are already covered by
+      // `findRootServerOperationMatches()`.
+      const groups = new Map<string, { operations: Record<string, OperationObject>; servers: ServerObject[] }>();
+      supportedMethods.forEach(method => {
+        const operation = dereferenceRef(pathItem[method], this.api);
+        if (!operation || isRef(operation)) return;
+
+        const servers = operation.servers?.length
+          ? operation.servers
+          : pathItem.servers?.length
+            ? pathItem.servers
+            : undefined;
+        if (!servers) return;
+
+        const key = JSON.stringify(servers);
+        let group = groups.get(key);
+        if (!group) {
+          group = { operations: {}, servers };
+          groups.set(key, group);
+        }
+        group.operations[method] = operation;
+      });
+
+      groups.forEach(({ operations, servers }) => {
+        for (const server of servers) {
+          const target = this.splitURLIntoOriginAndPathName(url, server);
+          if (!target) continue;
+
+          const annotatedPaths = generatePathMatches(
+            { [path]: operations } as PathsObject,
+            target.pathName || '/',
+            target.origin,
+          );
+
+          if (annotatedPaths.length) {
+            matches.push(...annotatedPaths);
+            return;
+          }
+        }
+      });
+    });
+
+    return matches;
+  }
+
+  /**
+   * Split a URL on a server URL, trying the server URL with its variables filled in with their
+   * defaults first and then with its variables loosened into regex.
+   */
+  private splitURLIntoOriginAndPathName(url: string, server: ServerObject): ServerURLSplit | undefined {
+    return this.splitURLOnSubstitutedServer(url, server) || this.splitURLOnServerRegex(url, server);
+  }
+
+  /**
+   * Try to split a URL on a server URL with its variables filled in with their defaults.
+   */
+  private splitURLOnSubstitutedServer(url: string, server: ServerObject): ServerURLSplit | undefined {
+    try {
+      const substitutedUrl = this.replaceUrl(server.url, server.variables || {});
+      const [, pathName] = url.split(new RegExp(substitutedUrl, 'i'));
+      if (pathName !== undefined) {
+        return { origin: substitutedUrl, pathName };
+      }
+    } catch {
+      // A server URL that can't be expressed as regex shouldn't fail the whole lookup.
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Try to split a URL on a server URL with its variables loosened into regex, so URLs that use
+   * non-default variable values still resolve.
+   */
+  private splitURLOnServerRegex(url: string, server: ServerObject): ServerURLSplit | undefined {
+    try {
+      const regex = transformURLIntoRegex(server.url);
+      if (new RegExp(regex).exec(url)) {
+        return { origin: server.url, pathName: url.split(new RegExp(regex)).slice(-1).pop() || '' };
+      }
+    } catch {
+      // Same as above.
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/oas/src/lib/urls.ts
+++ b/packages/oas/src/lib/urls.ts
@@ -292,6 +292,11 @@ export function filterPathMethods(pathMatches: PathMatches, targetMethod: HttpMe
 }
 
 /**
+ * Of the given matches, pick the one with the fewest path parameters, as a literal segment match
+ * is more specific than a parameter capture. Ties intentionally go to the **later** match (the
+ * `<=`): `Oas.findOperationMatches()` relies on this by appending operation and path-item server
+ * matches after root server ones, so that the server defined closest to the operation wins.
+ *
  * @param pathMatches URL and PathsObject matches to narrow down to find a target path.
  * @returns An object containing matches that were discovered in the API definition.
  */

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1282,43 +1282,58 @@ describe('Oas', () => {
       });
 
       it('should support relative path-item and operation-level servers', () => {
-        expect(pathLevelServers.findOperation('https://example.com/v2/relative-path-server', 'get')?.url).toMatchObject(
+        expect(pathLevelServers.findOperation('https://example.com/v2/relative-path-server', 'get')?.url).toStrictEqual(
           {
             origin: '/v2',
             path: '/relative-path-server',
+            nonNormalizedPath: '/relative-path-server',
+            slugs: {},
+            method: 'GET',
           },
         );
 
         expect(
           pathLevelServers.findOperation('https://example.com/v3/relative-operation-server', 'get')?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: '/v3',
           path: '/relative-operation-server',
+          nonNormalizedPath: '/relative-operation-server',
+          slugs: {},
+          method: 'GET',
         });
       });
 
       it('should support operation-level server variables', () => {
         expect(
           pathLevelServers.findOperation('https://operation.example.com/v3/operation-server-variables', 'get')?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: 'https://operation.example.com/v3',
           path: '/operation-server-variables',
+          nonNormalizedPath: '/operation-server-variables',
+          slugs: {},
+          method: 'GET',
         });
 
         expect(
           pathLevelServers.findOperation('https://operation.example.com/v9/operation-server-variables', 'get')?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: 'https://operation.example.com/{version}',
           path: '/operation-server-variables',
+          nonNormalizedPath: '/operation-server-variables',
+          slugs: {},
+          method: 'GET',
         });
       });
 
       it('should resolve path-item `$ref` servers', () => {
         expect(
           pathLevelServers.findOperation('https://path-item-ref.example.com/path-item-ref-server', 'get')?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: 'https://path-item-ref.example.com',
           path: '/path-item-ref-server',
+          nonNormalizedPath: '/path-item-ref-server',
+          slugs: {},
+          method: 'GET',
         });
       });
 
@@ -1326,25 +1341,34 @@ describe('Oas', () => {
         expect(
           pathLevelServers.findOperation('https://empty-operation-path.example.com/empty-operation-servers', 'get')
             ?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: 'https://empty-operation-path.example.com',
           path: '/empty-operation-servers',
+          nonNormalizedPath: '/empty-operation-servers',
+          slugs: {},
+          method: 'GET',
         });
 
         expect(
           pathLevelServers.findOperation('https://demo.example.com:443/v2/empty-path-item-servers', 'get')?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: 'https://demo.example.com:443/v2',
           path: '/empty-path-item-servers',
+          nonNormalizedPath: '/empty-path-item-servers',
+          slugs: {},
+          method: 'GET',
         });
       });
 
       it('should be discoverable through `findOperationWithoutMethod()` and `getOperation()`', () => {
+        // `url.method` is only stamped by method filtering, so it shouldn't appear here.
         expect(
           operationServers.findOperationWithoutMethod('https://httpbin.com/anything/demo/operation')?.url,
-        ).toMatchObject({
+        ).toStrictEqual({
           origin: 'https://httpbin.com/anything/demo',
           path: '/operation',
+          nonNormalizedPath: '/operation',
+          slugs: {},
         });
 
         const operation = pathLevelServers.getOperation(

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -1,6 +1,8 @@
 import type { HttpMethods, OASDocument } from '../src/types.js';
 
 import petstoreSpec from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import serverPathLevelSpec from '@readme/oas-examples/3.0/json/server-path-level.json' with { type: 'json' };
+import operationServersSpec from '@readme/oas-examples/3.0/json/server-variables.json' with { type: 'json' };
 import webhooksSpec from '@readme/oas-examples/3.1/json/webhooks.json' with { type: 'json' };
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -1203,6 +1205,156 @@ describe('Oas', () => {
           slugs: {},
           method: 'GET',
         });
+      });
+    });
+
+    describe('operation and path-item servers', () => {
+      let operationServers: Oas;
+      let pathLevelServers: Oas;
+
+      beforeEach(() => {
+        operationServers = Oas.init(structuredClone(operationServersSpec));
+        pathLevelServers = Oas.init(structuredClone(serverPathLevelSpec));
+      });
+
+      it('should find an operation served by an operation-level server', () => {
+        const res = operationServers.findOperation('https://httpbin.com/anything/demo/operation', 'post');
+
+        expect(res?.url).toStrictEqual({
+          origin: 'https://httpbin.com/anything/demo',
+          path: '/operation',
+          nonNormalizedPath: '/operation',
+          slugs: {},
+          method: 'POST',
+        });
+      });
+
+      it('should find an operation served by an operation-level server with a non-default variable', () => {
+        const res = operationServers.findOperation('https://httpbin.com/anything/custom/operation', 'post');
+
+        expect(res?.url).toStrictEqual({
+          origin: 'https://httpbin.com/anything/{subpath}',
+          path: '/operation',
+          nonNormalizedPath: '/operation',
+          slugs: {},
+          method: 'POST',
+        });
+      });
+
+      it('should find an operation served by a path-item server', () => {
+        const res = operationServers.findOperation('https://httpbin.com/anything/common/demo/path', 'put');
+
+        expect(res?.url).toStrictEqual({
+          origin: 'https://httpbin.com/anything/common/demo',
+          path: '/path',
+          nonNormalizedPath: '/path',
+          slugs: {},
+          method: 'PUT',
+        });
+      });
+
+      it('should prefer operation-level servers over path-item servers', () => {
+        const res = operationServers.findOperation('https://httpbin.com/anything/demo/combo', 'put');
+
+        expect(res?.url).toStrictEqual({
+          origin: 'https://httpbin.com/anything/demo',
+          path: '/combo',
+          nonNormalizedPath: '/combo',
+          slugs: {},
+          method: 'PUT',
+        });
+
+        // Because `/combo` defines operation-level servers, its path-item servers shouldn't serve
+        // it.
+        expect(operationServers.findOperation('https://httpbin.com/anything/common/demo/combo', 'put')).toBeUndefined();
+      });
+
+      it('should still match against root servers when an operation has no server overrides', () => {
+        const res = operationServers.findOperation('https://demo.example.com:443/v2/global', 'post');
+
+        expect(res?.url).toStrictEqual({
+          origin: 'https://demo.example.com:443/v2',
+          path: '/global',
+          nonNormalizedPath: '/global',
+          slugs: {},
+          method: 'POST',
+        });
+      });
+
+      it('should support relative path-item and operation-level servers', () => {
+        expect(pathLevelServers.findOperation('https://example.com/v2/relative-path-server', 'get')?.url).toMatchObject(
+          {
+            origin: '/v2',
+            path: '/relative-path-server',
+          },
+        );
+
+        expect(
+          pathLevelServers.findOperation('https://example.com/v3/relative-operation-server', 'get')?.url,
+        ).toMatchObject({
+          origin: '/v3',
+          path: '/relative-operation-server',
+        });
+      });
+
+      it('should support operation-level server variables', () => {
+        expect(
+          pathLevelServers.findOperation('https://operation.example.com/v3/operation-server-variables', 'get')?.url,
+        ).toMatchObject({
+          origin: 'https://operation.example.com/v3',
+          path: '/operation-server-variables',
+        });
+
+        expect(
+          pathLevelServers.findOperation('https://operation.example.com/v9/operation-server-variables', 'get')?.url,
+        ).toMatchObject({
+          origin: 'https://operation.example.com/{version}',
+          path: '/operation-server-variables',
+        });
+      });
+
+      it('should resolve path-item `$ref` servers', () => {
+        expect(
+          pathLevelServers.findOperation('https://path-item-ref.example.com/path-item-ref-server', 'get')?.url,
+        ).toMatchObject({
+          origin: 'https://path-item-ref.example.com',
+          path: '/path-item-ref-server',
+        });
+      });
+
+      it('should treat empty server arrays as absent when applying precedence', () => {
+        expect(
+          pathLevelServers.findOperation('https://empty-operation-path.example.com/empty-operation-servers', 'get')
+            ?.url,
+        ).toMatchObject({
+          origin: 'https://empty-operation-path.example.com',
+          path: '/empty-operation-servers',
+        });
+
+        expect(
+          pathLevelServers.findOperation('https://demo.example.com:443/v2/empty-path-item-servers', 'get')?.url,
+        ).toMatchObject({
+          origin: 'https://demo.example.com:443/v2',
+          path: '/empty-path-item-servers',
+        });
+      });
+
+      it('should be discoverable through `findOperationWithoutMethod()` and `getOperation()`', () => {
+        expect(
+          operationServers.findOperationWithoutMethod('https://httpbin.com/anything/demo/operation')?.url,
+        ).toMatchObject({
+          origin: 'https://httpbin.com/anything/demo',
+          path: '/operation',
+        });
+
+        const operation = pathLevelServers.getOperation(
+          'https://operation.example.com/v3/operation-server-variables',
+          'get',
+        );
+
+        expect(operation).toBeInstanceOf(Operation);
+        expect(operation?.getSummary()).toBe('Operation-level server variables');
+        expect(operation?.url()).toBe('https://operation.example.com/v3');
       });
     });
   });


### PR DESCRIPTION
| 🚥 Resolves RM-1745 |
| :------------------- |

## 🧰 Changes

`findOperation()` and friends only matched URLs against root-level `servers`, so operations that override them at the path-item or operation level could never resolve. #1159 taught the display side about those servers, this teaches lookups.

- Operations are grouped by the server list that governs them (operation > path-item > root, empty arrays fall through), then matched against those servers in declared order using the same two strategies as root matching.
- When a URL resolves to both a root match and an override match at equal specificity, the override wins.
- Root matching behavior is unchanged. The split strategies it shares with the new code are now common helpers.
- Paths without overrides are skipped via a cheap guard, so root-only definitions barely pay for this.

## 🧬 QA & Testing

New tests cover server precedence (including two operations on one path governed by different servers), relative server URLs, variables with non-default values, path-item `$ref`s, empty server arrays, and the `findOperationWithoutMethod()`/`getOperation()` wrappers. The rest of the suite passes untouched, which pins root-only behavior.
