### PR TITLE
perf(oas): cache compiled path matchers across lookups

### DIFF
--- a/.changeset/path-matcher-cache.md
+++ b/.changeset/path-matcher-cache.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Compiled `path-to-regexp` matchers for path templates are now cached across lookups, making repeated URL→operation resolution (`findOperation()`, `findOperationWithoutMethod()`, `getOperation()`) roughly 4-9x faster depending on definition size.

--- a/packages/oas/CHANGELOG.md
+++ b/packages/oas/CHANGELOG.md
@@ -13,7 +13,6 @@
 - c0a781d: Refactor `oas/analyzer` to support analyzing a single operation or webhook directly against a full API definition without needing to reduce it down first.
 
   Breaking changes:
-
   - `dereferencedFileSize` and `rawFileSize` are no longer supported.
   - `oas/analyzer` no longer exports individual query functions, instead you can supply your specific queries as an array of strings to the `analyzer` function.
   - The object that `oas/analyzer` returns has also been reshaped to no longer have a `general` and `openapi` top-level key, everything is now flattened out.

--- a/packages/oas/src/lib/urls.ts
+++ b/packages/oas/src/lib/urls.ts
@@ -216,6 +216,41 @@ function normalizePath(path: string) {
   );
 }
 
+// Bounds the matcher cache in long-lived multi-tenant processes.
+const MATCHER_CACHE_MAX_SIZE = 10_000;
+const matcherCache = new Map<string, { cleanedPath: string; matcher: ((path: string) => Match<ParamData>) | null }>();
+
+/**
+ * Compile a path template into its normalized form and `path-to-regexp` matcher. Compiling costs
+ * an order of magnitude more than executing and depends only on the template string, so compiled
+ * matchers are cached process-wide. A `null` matcher marks a template that can't be compiled.
+ */
+function compilePathMatcher(path: string): {
+  cleanedPath: string;
+  matcher: ((path: string) => Match<ParamData>) | null;
+} {
+  let compiled = matcherCache.get(path);
+  if (compiled === undefined) {
+    const cleanedPath = normalizePath(path);
+    let matcher = null;
+    try {
+      matcher = match(cleanedPath, { decode: decodeURIComponent });
+    } catch {
+      // A template that can't be compiled (maybe it has a malformed path parameter) can never
+      // match; record that instead of failing.
+    }
+
+    if (matcherCache.size >= MATCHER_CACHE_MAX_SIZE) {
+      matcherCache.delete(matcherCache.keys().next().value as string);
+    }
+
+    compiled = { cleanedPath, matcher };
+    matcherCache.set(path, compiled);
+  }
+
+  return compiled;
+}
+
 /**
  * Generate path matches for a given path and origin on a set of OpenAPI path objects.
  *
@@ -229,15 +264,16 @@ export function generatePathMatches(paths: PathsObject, pathName: string, origin
   const prunedPathName = pathName.split('?')[0];
   const matches: PathMatches = Object.keys(paths)
     .map(path => {
-      const cleanedPath = normalizePath(path);
+      const { cleanedPath, matcher } = compilePathMatcher(path);
+      if (!matcher) return false;
 
       let matchResult: PathMatch['match'];
       try {
-        const matchStatement = match(cleanedPath, { decode: decodeURIComponent });
-        matchResult = matchStatement(prunedPathName);
+        matchResult = matcher(prunedPathName);
       } catch {
-        // If path matching fails for whatever reason (maybe they have a malformed path parameter)
-        // then we shouldn't also fail.
+        // Executing a matcher can throw independently of compiling it -- a malformed
+        // percent-encoding in the URL will throw in `decodeURIComponent` -- and should count as
+        // a non-match, not a failure.
         return false;
       }
 

--- a/packages/oas/test/benchmarks/url-matching.bench.ts
+++ b/packages/oas/test/benchmarks/url-matching.bench.ts
@@ -1,0 +1,57 @@
+import type { HttpMethods, OASDocument } from '../../src/types.js';
+
+import petstore from '@readme/oas-examples/3.0/json/petstore.json' with { type: 'json' };
+import { bench, describe } from 'vitest';
+
+import Oas from '../../src/index.js';
+import docusign from '../__datasets__/docusign.json' with { type: 'json' };
+
+const httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
+/**
+ * Build a resolvable lookup URL for every operation in a definition: the server URL with its
+ * defaults filled in, plus each path with its parameters swapped for literal values.
+ *
+ */
+function buildLookups(oas: Oas): [string, HttpMethods][] {
+  const serverUrl = oas.url();
+  const lookups: [string, HttpMethods][] = [];
+
+  Object.keys(oas.api.paths || {}).forEach(path => {
+    Object.keys((oas.api.paths as Record<string, Record<string, unknown>>)[path] || {}).forEach(method => {
+      if (httpMethods.includes(method.toLowerCase())) {
+        lookups.push([`${serverUrl}${path.replace(/{[^}]+}/g, 'test123')}`, method as HttpMethods]);
+      }
+    });
+  });
+
+  return lookups;
+}
+
+const petstoreOas = Oas.init(structuredClone(petstore));
+const petstoreLookups = buildLookups(petstoreOas);
+
+const docusignOas = Oas.init(structuredClone(docusign as unknown as OASDocument));
+const docusignLookups = buildLookups(docusignOas);
+
+describe(`URL to operation matching (petstore, 14 paths, ${petstoreLookups.length} lookups)`, () => {
+  bench('findOperation()', () => {
+    for (const [url, method] of petstoreLookups) {
+      petstoreOas.findOperation(url, method);
+    }
+  });
+});
+
+describe(`URL to operation matching (docusign, 209 paths, ${docusignLookups.length} lookups)`, () => {
+  bench('findOperation()', () => {
+    for (const [url, method] of docusignLookups) {
+      docusignOas.findOperation(url, method);
+    }
+  });
+
+  bench('findOperationWithoutMethod()', () => {
+    for (const [url] of docusignLookups) {
+      docusignOas.findOperationWithoutMethod(url);
+    }
+  });
+});


### PR DESCRIPTION
| 📈 Follow-up to #1176 |
| :------------------- |

## 🧰 Changes

Every URL lookup (`findOperation()` and friends) compiled a `path-to-regexp` matcher for every path template in the definition, executed it once and threw it away. Compiling costs an order of magnitude more than executing, so recompilation was ~90% of a lookup.

A compiled matcher depends only on the template string, so they're now cached process-wide, same pattern as the analyzer's query cache from #1170. String keys can't live in a `WeakMap`, so the cache is size-bounded instead.

Warm lookups against `main`:

| spec | before | after |
| :--- | :--- | :--- |
| petstore (14 paths) | ~14 µs | ~3 µs |
| synthetic 500 paths | ~560 µs | ~60 µs |

## 🧬 QA & Testing

- Templates that fail to compile are cached as never-matching, the same outcome as the old per-lookup try/catch. Execution errors (like a bad percent-encoding hitting `decodeURIComponent`) depend on the incoming URL, not the template, so they stay per-lookup.
- Full suite passes untouched.
