### PR TITLE
fix(oas): preserve allOf enum descriptions

### DIFF
--- a/.changeset/calm-wolves-describe.md
+++ b/.changeset/calm-wolves-describe.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Preserve response schema descriptions on `allOf` enum references.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -176,6 +176,40 @@ function isPolymorphicSchema(schema: SchemaObject): boolean {
   return 'allOf' in schema || 'anyOf' in schema || 'oneOf' in schema;
 }
 
+function formatEnumDescription(values: unknown[]): string {
+  return values
+    .filter(value => value !== undefined && (typeof value !== 'string' || value.trim() !== ''))
+    .map(value => `\`${value}\``)
+    .join(' ');
+}
+
+function withoutGeneratedEnumDescription(schema: SchemaObject): SchemaObject {
+  if (!Array.isArray(schema.enum) || typeof schema.description !== 'string') {
+    return schema;
+  }
+
+  const enumDescription = formatEnumDescription(schema.enum);
+  if (!enumDescription) {
+    return schema;
+  }
+
+  const paragraphs = schema.description.split(/\n\n+/).map(paragraph => paragraph.trim());
+  if (!paragraphs.includes(enumDescription)) {
+    return schema;
+  }
+
+  const description = paragraphs.filter(paragraph => paragraph !== enumDescription).join('\n\n');
+  const updatedSchema = { ...schema };
+
+  if (description) {
+    updatedSchema.description = description;
+  } else {
+    delete updatedSchema.description;
+  }
+
+  return updatedSchema;
+}
+
 /**
  * Decides if a single `oneOf` / `anyOf` entry should be merged with the parent schemas' sibling
  * `items` by wrapping both in `allOf` and running them through `toJSONSchema` (which merges
@@ -947,6 +981,15 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
           return toJSONSchema(item as SchemaObject, allOfOptions);
         });
 
+        if (addEnumsToDescriptions) {
+          // Enum values are added to descriptions during response schema conversion. They are
+          // generated display metadata, so they should not participate in `allOf` description
+          // precedence and overwrite an authored description alongside the `allOf`. Remove the
+          // generated paragraph from each converted branch before merging; the final enum handling
+          // below will append it once to the merged schema.
+          allOfSchemas = allOfSchemas.map(withoutGeneratedEnumDescription);
+        }
+
         // Find paths reached by 2+ branches, then inline each branch with deep recursion at
         // those conflict paths.
         const conflictPaths = collectConflictPaths(allOfSchemas, usedSchemas);
@@ -1514,10 +1557,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
     // filtering away empty and falsy strings here because adding empty `` blocks to the description
     // will serve nobody any good.
     if (addEnumsToDescriptions) {
-      const enums = schema.enum
-        .filter(v => v !== undefined && (typeof v !== 'string' || v.trim() !== ''))
-        .map(str => `\`${str}\``)
-        .join(' ');
+      const enums = formatEnumDescription(schema.enum);
 
       if (enums.length) {
         const currentDescription =

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -193,7 +193,7 @@ function withoutGeneratedEnumDescription(schema: SchemaObject): SchemaObject {
     return schema;
   }
 
-  const paragraphs = schema.description.split(/\n\n+/).map(paragraph => paragraph.trim());
+  const paragraphs = schema.description.split(/\n\n+/);
   if (!paragraphs.includes(enumDescription)) {
     return schema;
   }

--- a/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
@@ -453,6 +453,49 @@ describe('.getResponseAsJSONSchema()', () => {
         'x-readme-ref-name': 'Status',
       });
     });
+
+    it('should preserve authored Markdown whitespace in an allOf enum description', () => {
+      const description = 'Status example:\n\n    const status = "PENDING";';
+      const spec = createOasForOperation(
+        {
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      status: {
+                        allOf: [{ $ref: '#/components/schemas/Status' }],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          schemas: {
+            Status: {
+              type: 'string',
+              enum: ['PENDING', 'RESOLVED'],
+              description,
+            },
+          },
+        },
+      );
+
+      const schemas = spec.operation('/', 'get').getResponseAsJSONSchema('200');
+
+      expect(schemas?.[0].schema?.properties?.status).toStrictEqual({
+        type: 'string',
+        enum: ['PENDING', 'RESOLVED'],
+        description: `${description}\n\n\`PENDING\` \`RESOLVED\``,
+        'x-readme-ref-name': 'Status',
+      });
+    });
   });
 
   describe('`headers` support', () => {

--- a/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-response-as-json-schema.test.ts
@@ -411,6 +411,48 @@ describe('.getResponseAsJSONSchema()', () => {
         description: '`cachorro` `gato` `lagarto`',
       });
     });
+
+    it('should preserve a property description alongside an allOf enum ref', () => {
+      const spec = createOasForOperation(
+        {
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      status: {
+                        description: 'Status of the dispute',
+                        allOf: [{ $ref: '#/components/schemas/Status' }],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          schemas: {
+            Status: {
+              type: 'string',
+              enum: ['PENDING', 'RESOLVED'],
+            },
+          },
+        },
+      );
+
+      const schemas = spec.operation('/', 'get').getResponseAsJSONSchema('200');
+
+      expect(schemas?.[0].schema?.properties?.status).toStrictEqual({
+        type: 'string',
+        enum: ['PENDING', 'RESOLVED'],
+        description: 'Status of the dispute\n\n`PENDING` `RESOLVED`',
+        'x-readme-ref-name': 'Status',
+      });
+    });
   });
 
   describe('`headers` support', () => {


### PR DESCRIPTION
| 🚥 Resolves [CX-3712](https://linear.app/readme-io/issue/CX-3712) |
| :--------------------------------------------------------------- |

## 🧰 Changes

Preserves authored response property descriptions when an `allOf` branch defines an enum.

Generated enum values are excluded from description precedence during the merge, then appended once to the final description.

## 🧬 QA & Testing

- [x] Added coverage for a property description alongside an `allOf` enum reference
