### PR TITLE
fix(oas): normalize server URLs after variable substitution

### DIFF
--- a/.changeset/tidy-ravens-smile.md
+++ b/.changeset/tidy-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Normalize server URLs after substituting server variable values.

--- a/packages/oas/src/index.ts
+++ b/packages/oas/src/index.ts
@@ -35,7 +35,7 @@ import {
   filterPathMethods,
   findTargetPath,
   generatePathMatches,
-  normalizedURLFromServers,
+  normalizeURL,
   splitUrlFromServers,
   stripTrailingSlash,
   transformURLIntoRegex,
@@ -113,8 +113,9 @@ export default class Oas {
   }
 
   url(selected = 0, variables?: ServerVariable): string {
-    const url = normalizedURLFromServers(this.api.servers, selected);
-    return this.replaceUrl(url, variables || this.defaultVariables(selected)).trim();
+    const url = this.api.servers?.[selected]?.url;
+    const resolvedUrl = url ? this.replaceUrl(url, variables || this.defaultVariables(selected)) : undefined;
+    return normalizeURL(resolvedUrl).trim();
   }
 
   variables(selected = 0): ServerVariablesObject {

--- a/packages/oas/src/lib/urls.ts
+++ b/packages/oas/src/lib/urls.ts
@@ -7,6 +7,8 @@ import { SERVER_VARIABLE_REGEX } from '../utils';
 
 import getUserVariable from './get-user-variable';
 
+const PROTOCOL_REGEX = /^[a-z][a-z\d+.-]*:\/\//i;
+
 export interface PathMatch {
   match?: Match<ParamData>;
   operation: PathsObject;
@@ -76,6 +78,7 @@ export function normalizeURL(url: string | undefined, urlForProtocolCheck: strin
   if (!url) return exampleDotCom;
 
   url = stripTrailingSlash(url);
+  if (!url) return exampleDotCom;
 
   // Check if the URL is just a path and missing an origin, for example `/api/v3`. If so, then make
   // `example.com` the origin to avoid it becoming something invalid like `https:///api/v3`.
@@ -93,7 +96,7 @@ export function normalizeURL(url: string | undefined, urlForProtocolCheck: strin
     return `https:${url}`;
   }
 
-  if (!urlForProtocolCheck?.includes('//')) {
+  if (!PROTOCOL_REGEX.test(urlForProtocolCheck?.trim() ?? '')) {
     return `https://${url}`;
   }
 
@@ -109,7 +112,7 @@ export function normalizeURL(url: string | undefined, urlForProtocolCheck: strin
  */
 function normalizedURLFromServers(servers: ServerObject[] | undefined, selected: number): string {
   const server = servers?.[selected];
-  const resolvedUrl = server?.url.replace(SERVER_VARIABLE_REGEX, (original, key) => {
+  const resolvedUrl = server?.url?.replace(SERVER_VARIABLE_REGEX, (original, key) => {
     return key in (server.variables || {}) ? String(server.variables?.[key].default) : original;
   });
 

--- a/packages/oas/src/lib/urls.ts
+++ b/packages/oas/src/lib/urls.ts
@@ -62,16 +62,38 @@ export function stripTrailingSlash(url: string): string {
   return url;
 }
 
-function ensureProtocol(url: string) {
-  // Add protocol to urls starting with // e.g. //example.com
-  // This is because httpsnippet throws a HARError when it doesnt have a protocol
-  if (url.match(/^\/\//)) {
+/**
+ * Normalize an OpenAPI server URL by ensuring that it has a proper HTTP protocol and doesn't have
+ * a trailing slash. If the URL is unavailable, fall back to `https://example.com` so callers always
+ * receive an inert absolute URL.
+ *
+ * @param url URL to normalize.
+ * @param urlForProtocolCheck A version of `url` with its server variables resolved. This is used
+ * only to determine whether `url` already supplies a protocol.
+ */
+export function normalizeURL(url: string | undefined, urlForProtocolCheck: string | undefined = url): string {
+  const exampleDotCom = 'https://example.com';
+  if (!url) return exampleDotCom;
+
+  url = stripTrailingSlash(url);
+
+  // Check if the URL is just a path and missing an origin, for example `/api/v3`. If so, then make
+  // `example.com` the origin to avoid it becoming something invalid like `https:///api/v3`.
+  // RM-1044
+  if (url.startsWith('/') && !url.startsWith('//')) {
+    const urlWithOrigin = new URL(exampleDotCom);
+    urlWithOrigin.pathname = url;
+    return urlWithOrigin.href;
+  }
+
+  // Inspect the resolved URL because a server variable may supply its protocol, but add any
+  // required prefix to `url` so unresolved templates remain intact. httpsnippet requires an
+  // explicit protocol when constructing a HAR.
+  if (urlForProtocolCheck?.startsWith('//')) {
     return `https:${url}`;
   }
 
-  // Add protocol to urls with no // within them
-  // This is because httpsnippet throws a HARError when it doesnt have a protocol
-  if (!url.match(/\/\//)) {
+  if (!urlForProtocolCheck?.includes('//')) {
     return `https://${url}`;
   }
 
@@ -79,37 +101,19 @@ function ensureProtocol(url: string) {
 }
 
 /**
- * Normalize an OpenAPI server URL by ensuring that it has a proper HTTP protocol and doesn't have a
- * trailing slash. If the selected server is unavailable or doesn't define a URL, fall back to
- * `https://example.com` so callers always receive an inert absolute URL.
+ * Normalize an unresolved OpenAPI server URL. Server variable defaults are substituted into a
+ * temporary copy of the URL so that a protocol supplied by a variable isn't added a second time.
  *
  * @param servers Server objects to choose from.
  * @param selected The index of the server object that we want to normalize.
  */
 export function normalizedURLFromServers(servers: ServerObject[] | undefined, selected: number): string {
-  const exampleDotCom = 'https://example.com';
-  let url: string | undefined;
-  try {
-    url = servers?.[selected]?.url;
-    // This is to catch the case where servers = [{}]
-    if (!url) throw new Error('no url');
+  const server = servers?.[selected];
+  const resolvedUrl = server?.url.replace(SERVER_VARIABLE_REGEX, (original, key) => {
+    return key in (server.variables || {}) ? String(server.variables?.[key].default) : original;
+  });
 
-    // Stripping the '/' off the end
-    url = stripTrailingSlash(url);
-
-    // Check if the URL is just a path a missing an origin, for example `/api/v3`. If so, then make
-    // `example.com` the origin to avoid it becoming something invalid like `https:///api/v3`.
-    // RM-1044
-    if (url.startsWith('/') && !url.startsWith('//')) {
-      const urlWithOrigin = new URL(exampleDotCom);
-      urlWithOrigin.pathname = url;
-      url = urlWithOrigin.href;
-    }
-  } catch {
-    url = exampleDotCom;
-  }
-
-  return ensureProtocol(url);
+  return normalizeURL(server?.url, resolvedUrl);
 }
 
 export function variablesFromServers(servers: ServerObject[] | undefined, selected = 0): ServerVariablesObject {

--- a/packages/oas/src/lib/urls.ts
+++ b/packages/oas/src/lib/urls.ts
@@ -107,7 +107,7 @@ export function normalizeURL(url: string | undefined, urlForProtocolCheck: strin
  * @param servers Server objects to choose from.
  * @param selected The index of the server object that we want to normalize.
  */
-export function normalizedURLFromServers(servers: ServerObject[] | undefined, selected: number): string {
+function normalizedURLFromServers(servers: ServerObject[] | undefined, selected: number): string {
   const server = servers?.[selected];
   const resolvedUrl = server?.url.replace(SERVER_VARIABLE_REGEX, (original, key) => {
     return key in (server.variables || {}) ? String(server.variables?.[key].default) : original;

--- a/packages/oas/src/operation/index.ts
+++ b/packages/oas/src/operation/index.ts
@@ -32,12 +32,7 @@ import type { ResponseSchemaObject } from './transformers/get-response-as-json-s
 
 import matchesMimeType from '../lib/matches-mimetype.js';
 import { decorateComponentSchemasWithRefName, dereferenceRef } from '../lib/refs.js';
-import {
-  defaultVariablesFromServers,
-  normalizedURLFromServers,
-  splitUrlFromServers,
-  variablesFromServers,
-} from '../lib/urls.js';
+import { defaultVariablesFromServers, normalizeURL, splitUrlFromServers, variablesFromServers } from '../lib/urls.js';
 import { isRef } from '../types.js';
 import { supportedMethods } from '../utils.js';
 
@@ -185,8 +180,9 @@ export class Operation {
   }
 
   url(selected = 0, variables?: ServerVariable): string {
-    const url = normalizedURLFromServers(this.getServers(), selected);
-    return this.oas.replaceUrl(url, variables || this.defaultVariables(selected)).trim();
+    const url = this.getServers()[selected]?.url;
+    const resolvedUrl = url ? this.oas.replaceUrl(url, variables || this.defaultVariables(selected)) : undefined;
+    return normalizeURL(resolvedUrl).trim();
   }
 
   variables(selected = 0): ServerVariablesObject {

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -102,6 +102,12 @@ describe('Oas', () => {
       expect(Oas.init({ servers: [{ url: 'example.com' }] }).url()).toBe('https://example.com');
     });
 
+    it('should add https:// if a path contains double slashes', () => {
+      expect(Oas.init({ servers: [{ url: 'api.example.com/v1//users' }] }).url()).toBe(
+        'https://api.example.com/v1//users',
+      );
+    });
+
     it('should accept an index for servers selection', () => {
       expect(Oas.init({ servers: [{ url: 'example.com' }, { url: 'https://api.example.com' }] }).url(1)).toBe(
         'https://api.example.com',
@@ -114,6 +120,10 @@ describe('Oas', () => {
 
     it('should make example.com the origin if none is present', () => {
       expect(Oas.init({ servers: [{ url: '/api/v3' }] }).url()).toBe('https://example.com/api/v3');
+    });
+
+    it('should default a root-relative server URL to example.com', () => {
+      expect(Oas.init({ servers: [{ url: '/' }] }).url()).toBe('https://example.com');
     });
 
     describe('server variables', () => {
@@ -328,6 +338,12 @@ describe('Oas', () => {
   });
 
   describe('.splitUrl()', () => {
+    it('should default an empty server object to example.com', () => {
+      expect(Oas.init({ servers: [{}] }).splitUrl()).toStrictEqual([
+        { key: 'https://example.com-0', type: 'text', value: 'https://example.com' },
+      ]);
+    });
+
     it('should split url into chunks', () => {
       expect(
         Oas.init({

--- a/packages/oas/test/index.test.ts
+++ b/packages/oas/test/index.test.ts
@@ -261,6 +261,16 @@ describe('Oas', () => {
       it('should pass through if no default set', () => {
         expect(Oas.init({ servers: [{ url: 'https://example.com/{path}' }] }).url()).toBe('https://example.com/{path}');
       });
+
+      it('should normalize a URL supplied by a server variable', () => {
+        const oasWithServerOrigin = Oas.init({
+          servers: [{ url: '{server}/v1', variables: { server: { default: 'https://api.example.com' } } }],
+        });
+
+        expect(oasWithServerOrigin.url()).toBe('https://api.example.com/v1');
+        expect(oasWithServerOrigin.url(0, { server: 'http://api.example.com' })).toBe('http://api.example.com/v1');
+        expect(oasWithServerOrigin.url(0, { server: 'api.example.com' })).toBe('https://api.example.com/v1');
+      });
     });
   });
 
@@ -326,6 +336,27 @@ describe('Oas', () => {
       ).toStrictEqual([
         { key: 'https://example.com/-0', type: 'text', value: 'https://example.com/' },
         { key: 'path-1', type: 'variable', value: 'path', description: undefined, enum: undefined },
+      ]);
+    });
+
+    it('should infer protocols from server variable defaults', () => {
+      expect(
+        Oas.init({
+          servers: [{ url: '{server}/v1', variables: { server: { default: 'https://api.example.com' } } }],
+        }).splitUrl(),
+      ).toStrictEqual([
+        { key: 'server-0', type: 'variable', value: 'server', description: undefined, enum: undefined },
+        { key: '/v1-1', type: 'text', value: '/v1' },
+      ]);
+
+      expect(
+        Oas.init({
+          servers: [{ url: '{host}/v1', variables: { host: { default: 'api.example.com' } } }],
+        }).splitUrl(),
+      ).toStrictEqual([
+        { key: 'https://-0', type: 'text', value: 'https://' },
+        { key: 'host-1', type: 'variable', value: 'host', description: undefined, enum: undefined },
+        { key: '/v1-2', type: 'text', value: '/v1' },
       ]);
     });
 

--- a/packages/oas/test/operation/index.test.ts
+++ b/packages/oas/test/operation/index.test.ts
@@ -153,6 +153,26 @@ describe('server helpers', () => {
     expect(operation.defaultVariables()).toStrictEqual({ version: 'v3' });
   });
 
+  it('should normalize a URL supplied by an operation server variable', () => {
+    const oas = Oas.init({
+      openapi: '3.0.0',
+      info: { title: 'server variables', version: '1.0.0' },
+      paths: {
+        '/pets': {
+          get: {
+            responses: { 200: { description: 'OK' } },
+            servers: [{ url: '{server}/v1', variables: { server: { default: 'https://api.example.com' } } }],
+          },
+        },
+      },
+    });
+    const operation = oas.operation('/pets', 'get');
+
+    expect(operation.url()).toBe('https://api.example.com/v1');
+    expect(operation.url(0, { server: 'http://api.example.com' })).toBe('http://api.example.com/v1');
+    expect(operation.url(0, { server: 'api.example.com' })).toBe('https://api.example.com/v1');
+  });
+
   it('should resolve path-item refs when retrieving path-item servers', () => {
     const oas = Oas.init(serverPathLevelSpec);
     const operation = oas.operation('/path-item-ref-server', 'get');


### PR DESCRIPTION
Fixes [CX-3748](https://linear.app/readme-io/issue/CX-3748/api-explorer-automatically-prepends-a-protocol-to-the-base-url-causing).

## Changes

- Normalize server URLs after substituting their selected variable values.
- Keep `splitUrl()` templates unresolved while using variable defaults to determine whether they supply the protocol.
- Cover root and operation server variables with and without protocols.

## QA & Testing

- A `{server}/v1` template with an `https://api.example.com` value resolves without duplicating the protocol.
- A variable value without a protocol defaults to `https://`.
- Existing protocol-relative, relative-path, and host-only server URLs keep their current normalization behavior.
