### PR TITLE
fix: honor a schema's own `description` alongside an `allOf` `$ref`

### DIFF
--- a/.changeset/big-cloths-read.md
+++ b/.changeset/big-cloths-read.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+Honor a schema's own `description` when it's declared alongside an `allOf` `$ref`, rather than inheriting the referenced schema's description

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -870,7 +870,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
     // If this is an `allOf` schema we should make an attempt to merge so as to ease the burden on
     // the tooling that ingests these schemas.
     if ('allOf' in schema && Array.isArray(schema.allOf)) {
-      // A `description` alongside `allOf` overrides the desciption resolved 
+      // A `description` alongside `allOf` overrides the desciption resolved
       // by `json-schema-merge-allof` (last-wins).
       //
       // Using allOf + description is a widely adopted workaround for the oas 3.0 limitation

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -870,6 +870,14 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
     // If this is an `allOf` schema we should make an attempt to merge so as to ease the burden on
     // the tooling that ingests these schemas.
     if ('allOf' in schema && Array.isArray(schema.allOf)) {
+      // A `description` alongside `allOf` overrides the desciption resolved 
+      // by `json-schema-merge-allof` (last-wins).
+      //
+      // Using allOf + description is a widely adopted workaround for the oas 3.0 limitation
+      // that $ref cannot have sibling properties. Swagger, for example, resolves it exactly this way.
+      const siblingDescription =
+        typeof schema.description === 'string' && schema.description.length > 0 ? schema.description : undefined;
+
       // `json-schema-merge-allof` does not resolve `$ref` pointers so if this schema has sibling
       // `properties` whose internal schemas _also_ contain an `allOf` with multiple `$ref`
       // pointers, merging the parent `allOf` first can drop those pointers. We should instead
@@ -1001,6 +1009,12 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
 
       try {
         schema = mergeJSONSchemaAllOf(schema as JSONSchema, mergeAllOfSchemasOptions) as SchemaObject;
+
+        // Reinstate the schema's own sibling `description` so it always wins over any `description`
+        // merged in from json-schema-merge-allof.
+        if (siblingDescription !== undefined && isObject(schema) && !isRef(schema)) {
+          schema.description = siblingDescription;
+        }
       } catch {
         // The merge can throw on irreconcilable conflicts (eg. `properties.foo.type` being `array`
         // in one branch and `object` in another). Dropping the entire `allOf` here would leave the

--- a/packages/oas/test/__datasets__/issues/CX-3769.json
+++ b/packages/oas/test/__datasets__/issues/CX-3769.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "CX-3769: `description` as a sibling of an `allOf` `$ref`",
+    "version": "1.0.0",
+    "description": "OpenAPI 3.0 ignores siblings of a `$ref`, so a common workaround wraps the `$ref` in an `allOf` and puts `description` alongside it. The schema's own sibling `description` should win over any `description` on the referenced schema."
+  },
+  "paths": {
+    "/single-ref": {
+      "post": {
+        "operationId": "singleRef",
+        "summary": "bug case: `allOf` with a single `$ref` plus a sibling `description`",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pet": { "$ref": "#/components/schemas/Pet" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/multi-branch": {
+      "post": {
+        "operationId": "multiBranch",
+        "summary": "`allOf` with multiple `$ref` branches plus a sibling `description`",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "combo": { "$ref": "#/components/schemas/Combo" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [{ "$ref": "#/components/schemas/Error" }],
+        "description": "A pet"
+      },
+      "Combo": {
+        "allOf": [{ "$ref": "#/components/schemas/Error" }, { "$ref": "#/components/schemas/Thing" }],
+        "description": "A combo"
+      },
+      "Error": {
+        "type": "object",
+        "description": "An error",
+        "properties": {
+          "code": { "type": "integer", "format": "int32" }
+        }
+      },
+      "Thing": {
+        "type": "object",
+        "description": "A thing",
+        "properties": {
+          "id": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
+++ b/packages/oas/test/lib/__snapshots__/openapi-to-json-schema.test.ts.snap
@@ -1037,7 +1037,7 @@ exports[`toJSONSchema() > \`description\` support > should support description i
 exports[`toJSONSchema() > polymorphism / inheritance > quirks > should perform default resolution for unrecognized properties 1`] = `
 {
   "additionalProperties": false,
-  "description": "Represents a namespace (one).",
+  "description": "Represents a namespace (two).",
   "properties": {
     "dataAccessPolicy": {
       "additionalProperties": false,

--- a/packages/oas/test/operation/transformers/__snapshots__/get-parameters-as-json-schema.test.ts.snap
+++ b/packages/oas/test/operation/transformers/__snapshots__/get-parameters-as-json-schema.test.ts.snap
@@ -180,7 +180,7 @@ exports[`.getParametersAsJSONSchema() > $ref quirks > should retain component sc
       },
       "properties": {
         "filterBinder": {
-          "description": "
+          "description": "Tells the query engine of the Filters should be applied as an And or an Or (the default is And)
 
 0 = And
 

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -2608,7 +2608,7 @@ describe('.getParametersAsJSONSchema()', () => {
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
 
-      it("should keep the sibling `description` over descriptions from multiple `allOf` branches", async () => {
+      it('should keep the sibling `description` over descriptions from multiple `allOf` branches', async () => {
         const oas = Oas.init(structuredClone(cx3769));
         const schemas = oas.operation('/multi-branch', 'post').getParametersAsJSONSchema();
         const combo = (schemas?.find(s => s.type === 'body')?.schema as any).components.schemas.Combo;

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -35,6 +35,7 @@ import cx3276 from '../../__datasets__/issues/CX-3276.json' with { type: 'json' 
 import cx3280 from '../../__datasets__/issues/CX-3280.json' with { type: 'json' };
 import cx3312 from '../../__datasets__/issues/CX-3312.json' with { type: 'json' };
 import cx3359 from '../../__datasets__/issues/CX-3359.json' with { type: 'json' };
+import cx3769 from '../../__datasets__/issues/CX-3769.json' with { type: 'json' };
 import deepSelfRefInItems from '../../__datasets__/issues/deep-self-ref-in-items.json' with { type: 'json' };
 import nonStandardComponentsSpec from '../../__datasets__/non-standard-components.json' with { type: 'json' };
 import petstoreServerVarsSpec from '../../__datasets__/petstore-server-vars.json' with { type: 'json' };
@@ -2593,6 +2594,26 @@ describe('.getParametersAsJSONSchema()', () => {
         expect(bodySchema.properties).not.toHaveProperty('serverGeneratedId');
         expect(bodySchema.properties).toHaveProperty('name');
         expect(bodySchema.properties).toHaveProperty('extraField');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+    });
+
+    describe('CX-3769: `description` alongside an `allOf` `$ref`', () => {
+      it("should keep the schema's own sibling `description` over a single `$ref` branch's", async () => {
+        const oas = Oas.init(structuredClone(cx3769));
+        const schemas = oas.operation('/single-ref', 'post').getParametersAsJSONSchema();
+        const pet = (schemas?.find(s => s.type === 'body')?.schema as any).components.schemas.Pet;
+
+        expect(pet.description).toBe('A pet');
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+
+      it("should keep the sibling `description` over descriptions from multiple `allOf` branches", async () => {
+        const oas = Oas.init(structuredClone(cx3769));
+        const schemas = oas.operation('/multi-branch', 'post').getParametersAsJSONSchema();
+        const combo = (schemas?.find(s => s.type === 'body')?.schema as any).components.schemas.Combo;
+
+        expect(combo.description).toBe('A combo');
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
     });


### PR DESCRIPTION
| 🚥 Resolves CX-3769 |
| :------------------- |

## 🧰 Changes

When a schema attaches its own `description` as a sibling of an `allOf`, that
description now takes precedence over any `description` merged in from a branch
(e.g. a `$ref` target).

## Why

OpenAPI 3.0 forbids a `$ref` from having sibling properties, so to give a shared
schema a context-specific description authors wrap the `$ref` in an `allOf` and
hang the new `description` off it:

  ```json
  {
    "Pet": {
      "allOf": [{ "$ref": "#/components/schemas/Error" }],
      "description": "A pet"
    }
  }
```

- This allOf + description pattern is a de facto standard (Swagger and others resolve it this way)

## 🧬 QA & Testing

Provide as much information as you can on how to test what you've done.
