### PR TITLE
feat(oas): add apply-tag-changes extension

### DIFF
--- a/.changeset/apply-tag-changes-extension.md
+++ b/.changeset/apply-tag-changes-extension.md
@@ -1,0 +1,5 @@
+---
+"oas": minor
+---
+
+Add support for the `apply-tag-changes` ReadMe extension (`x-readme.apply-tag-changes`) for opting in to moving existing API operation pages to match their tags within the current API category.

--- a/packages/oas/src/extensions.ts
+++ b/packages/oas/src/extensions.ts
@@ -206,6 +206,24 @@ export const SAMPLES_LANGUAGES = 'samples-languages';
 export const SIMPLE_MODE = 'simple-mode';
 
 /**
+ * Moves existing API operation pages within their current API category to match their tags when
+ * the API definition is updated. Operations that have been moved to another category are not
+ * affected.
+ *
+ * This extension may only be placed at the API definition root level.
+ *
+ * @defaultValue false
+ * @see {@link https://docs.readme.com/main/docs/openapi-extensions}
+ * @example
+ * {
+ *  "x-readme": {
+ *    "apply-tag-changes": true
+ *  }
+ * }
+ */
+export const APPLY_TAG_CHANGES = 'apply-tag-changes';
+
+/**
  * If `true`, tags are generated from the file top-down. If `false`, we sort the tags
  * based off the `tags` array in the OAS file.
  *
@@ -236,6 +254,7 @@ export const DISABLE_TAG_SORTING = 'disable-tag-sorting';
 export const STATUS_URL = 'status-url';
 
 export interface Extensions {
+  [APPLY_TAG_CHANGES]: boolean;
   [CODE_SAMPLES]:
     | {
         /**
@@ -317,6 +336,7 @@ export interface Extensions {
 }
 
 export const extensionDefaults: Extensions = {
+  [APPLY_TAG_CHANGES]: false,
   [CODE_SAMPLES]: undefined,
   [DISABLE_TAG_SORTING]: false,
   [EXPLORER_ENABLED]: true,

--- a/packages/oas/test/extensions.test.ts
+++ b/packages/oas/test/extensions.test.ts
@@ -6,6 +6,7 @@ import Oas from '../src/index.js';
 
 describe('extension defaults', () => {
   it.each([
+    ['APPLY_TAG_CHANGES'],
     ['CODE_SAMPLES'],
     ['EXPLORER_ENABLED'],
     ['HEADERS'],
@@ -38,6 +39,12 @@ describe('#getExtension', () => {
   });
 
   describe('oas-level extensions', () => {
+    it('should default `apply-tag-changes` to false', () => {
+      const oas = Oas.init(petstore);
+
+      expect(oas.getExtension(extensions.APPLY_TAG_CHANGES)).toBe(false);
+    });
+
     it('should use the default extension value if the extension is not present', () => {
       const oas = Oas.init(petstore);
 
@@ -249,6 +256,7 @@ describe('#validateExtension', () => {
   });
 
   describe.each([
+    ['APPLY_TAG_CHANGES', true, 'yes', 'Boolean'],
     [
       'CODE_SAMPLES',
       [


### PR DESCRIPTION
## What changed

Adds `apply-tag-changes` as a supported ReadMe OAS extension with a default of `false` and boolean validation. This provides a canonical extension for opting in to moving existing API operation pages to match their tags within the current API category.

Consumed by https://github.com/readmeio/gitto/pull/2675.

## QA

- Confirm the extension resolves to `false` when it is absent.
- Confirm boolean values are accepted under `x-readme.apply-tag-changes` and `x-apply-tag-changes`.
- Confirm non-boolean values fail extension validation.