### PR TITLE
fix: populate property examples from a schema-level examples array

### DIFF
--- a/.changeset/object-level-examples.md
+++ b/.changeset/object-level-examples.md
@@ -1,0 +1,5 @@
+---
+"oas": patch
+---
+
+Populate property examples from a schema-level `examples` array of objects

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -1343,7 +1343,7 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
     // we're dealing with a primitive schema.
     if (!hasSchemaType(schema, 'array') && !hasSchemaType(schema, 'object') && !schema.examples) {
       const foundExample = searchForValueByPropAndPointer('example', currentLocation, prevExampleSchemas);
-      if (foundExample) {
+      if (foundExample !== undefined) {
         // We can only really deal with primitives, so only promote those as the found example if
         // it is.
         if (isPrimitive(foundExample) || (Array.isArray(foundExample) && isPrimitive(foundExample[0]))) {

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -823,6 +823,8 @@ export function toJSONSchema(data: SchemaObject | boolean, opts?: toJSONSchemaOp
         }
       } else if (Array.isArray(obj.examples) && isPrimitive((obj.examples as unknown[])[0])) {
         reshapedExamples = true;
+      } else if (Array.isArray(obj.examples) && isObject((obj.examples as unknown[])[0])) {
+        prevExampleSchemas.push({ example: (obj.examples as unknown[])[0] });
       }
 
       if (!reshapedExamples) {

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -1725,13 +1725,15 @@ describe('toJSONSchema()', () => {
     it('should inherit an object example from a schema-level `examples` array', () => {
       const schema: SchemaObject = toJSONSchema({
         type: 'object',
-        examples: [{ name: 'example1', tags: { id: 7 } }],
+        examples: [{ name: 'example1', archived: false, tags: { id: 7, count: 0 } }],
         properties: {
           name: { type: 'string' },
+          archived: { type: 'boolean' },
           tags: {
             type: 'object',
             properties: {
               id: { type: 'integer' },
+              count: { type: 'integer' },
             },
           },
         },
@@ -1741,10 +1743,12 @@ describe('toJSONSchema()', () => {
         type: 'object',
         properties: {
           name: { type: 'string', examples: ['example1'] },
+          archived: { type: 'boolean', examples: [false] },
           tags: {
             type: 'object',
             properties: {
               id: { type: 'integer', examples: [7] },
+              count: { type: 'integer', examples: [0] },
             },
           },
         },

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -1722,6 +1722,35 @@ describe('toJSONSchema()', () => {
       expect(schema.examples).toStrictEqual(['dog', 'cat']);
     });
 
+    it('should inherit an object example from a schema-level `examples` array', () => {
+      const schema: SchemaObject = toJSONSchema({
+        type: 'object',
+        examples: [{ name: 'example1', tags: { id: 7 } }],
+        properties: {
+          name: { type: 'string' },
+          tags: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+            },
+          },
+        },
+      });
+
+      expect(schema).toStrictEqual({
+        type: 'object',
+        properties: {
+          name: { type: 'string', examples: ['example1'] },
+          tags: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer', examples: [7] },
+            },
+          },
+        },
+      });
+    });
+
     it('if multiple examples are present in `examples` it should always use the first in the list', () => {
       const oas = Oas.init(structuredClone(requestbodyExampleQuirksSpec));
       const operation = oas.operation('/anything', 'post');


### PR DESCRIPTION
| 🚥 Resolves CX-3896 |
| :------------------- |

## 🧰 Changes

When an OpenAPI 3.1 schema declares `examples` as an array whose first entry is an object, `toJSONSchema()` now feeds that object into the per-property example lookup, the same way it already does for a singular `example` object and for the keyed `examples` map. Nested properties pick up their values by JSON pointer, so `tags.colour` resolves from `examples: [{ tags: { colour: "blue" } }]`.

## Why

`convertExamples()` only kept a schema-level `examples` array when its first entry was a primitive. An array of objects fell through every branch and was deleted before the walk descended into the properties, so nothing downstream could inherit from it. 

The array form is a JSON Schema keyword that only became valid in 3.1, so this is a gap rather than a regression.

Only the first entry is used, matching how the keyed map and the singular `example` already behave.

## 🧬 QA & Testing

Added a `toJSONSchema()` test covering a top-level and a nested property. It fails before the fix and passes after.
<img width="531" height="313" alt="image" src="https://github.com/user-attachments/assets/a5022a24-e04c-4de5-9077-cd32763511d2" />

**Before**
<img width="610" height="243" alt="image" src="https://github.com/user-attachments/assets/27809bd5-892a-4171-90f5-0c30d8379b06" />

**After**
<img width="626" height="241" alt="image" src="https://github.com/user-attachments/assets/1a90aae7-72a3-4634-916c-aa1ccceaee17" />

