### PR TITLE
fix: resolve nested property examples and defaults by their full path first

### DIFF
--- a/.changeset/nested-example-pointers.md
+++ b/.changeset/nested-example-pointers.md
@@ -1,0 +1,5 @@
+---
+'oas': patch
+---
+
+Resolve property examples and defaults from the most specific JSON pointer first, so a nested property no longer picks up the value of a shallower property that shares its name.

--- a/packages/oas/src/lib/openapi-to-json-schema.ts
+++ b/packages/oas/src/lib/openapi-to-json-schema.ts
@@ -616,12 +616,12 @@ function isRequestBodySchema(schema: unknown): schema is RequestBodyObject {
  *  ]
  * ```
  *
- * As with most things however, this is not without its quirks! If a deeply nested property shares
- * the same name as an example that's further up the stack (like `tags.id` and an example for `id`),
- * there's a chance that it'll be misidentified as having an example and receive the wrong value.
- *
- * That said, any example is usually better than no example though, so while it's quirky behavior
- * it shouldn't raise immediate cause for alarm.
+ * Within each example the most specific pointer is tried first, so `tags.id` picks up the example's
+ * own `tags.id` rather than an `id` further up the stack. If the example has nothing at `tags.id`,
+ * the trailing segments of the path (`/id`) are tried next, since that's how an example declared on
+ * a nested schema reaches its own properties. This fallback behaviour means a property without an
+ * example can inadvertently pick up the value of a shallower property that shares its name - which
+ * is okay as any example is usually better than no example regardless.
  *
  * @see {@link https://tools.ietf.org/html/rfc6901}
  * @param property Specific type of schema property to look for a value for.
@@ -649,25 +649,25 @@ function searchForValueByPropAndPointer(
   let foundValue: any;
   const rev = [...schemas].toReversed();
 
-  for (let i = 0; i < pointers.length; i += 1) {
-    for (let ii = 0; ii < rev.length; ii += 1) {
-      let schema = rev[ii];
+  for (let ii = 0; ii < rev.length; ii += 1) {
+    let schema = rev[ii];
 
-      if (property === 'example') {
-        if ('example' in schema) {
-          schema = schema.example;
-        } else {
-          if (!Array.isArray(schema.examples) || !schema.examples.length) {
-            continue;
-          }
-
-          // Prevent us from crashing if `examples` is a completely empty object.
-          schema = [...schema.examples].shift();
-        }
+    if (property === 'example') {
+      if ('example' in schema) {
+        schema = schema.example;
       } else {
-        schema = schema.default;
-      }
+        if (!Array.isArray(schema.examples) || !schema.examples.length) {
+          continue;
+        }
 
+        // Prevent us from crashing if `examples` is a completely empty object.
+        schema = [...schema.examples].shift();
+      }
+    } else {
+      schema = schema.default;
+    }
+
+    for (let i = pointers.length - 1; i >= 0; i -= 1) {
       try {
         foundValue = jsonpointer.get(schema, pointers[i]);
       } catch {

--- a/packages/oas/test/lib/openapi-to-json-schema.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema.test.ts
@@ -1644,11 +1644,7 @@ describe('toJSONSchema()', () => {
               properties: {
                 id: {
                   type: 'integer',
-
-                  // Quirk: This is getting picked up as `100` as `id` exists in the root example and
-                  // with the reverse search, is getting picked up over `tags.id`. This example
-                  // should actually be 50.
-                  examples: [100],
+                  examples: [50],
                 },
                 name: {
                   type: 'object',
@@ -1749,6 +1745,69 @@ describe('toJSONSchema()', () => {
             properties: {
               id: { type: 'integer', examples: [7] },
               count: { type: 'integer', examples: [0] },
+            },
+          },
+        },
+      });
+    });
+
+    it('should resolve an array item example from its full path, not a shallower property with the same name', () => {
+      const schema: SchemaObject = toJSONSchema({
+        type: 'object',
+        example: { name: 'John Doe', pets: [{ name: 'Buster' }] },
+        properties: {
+          name: { type: 'string' },
+          pets: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+              },
+            },
+          },
+        },
+      });
+
+      expect(schema).toStrictEqual({
+        type: 'object',
+        properties: {
+          name: { type: 'string', examples: ['John Doe'] },
+          pets: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', examples: ['Buster'] },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should prefer a nested schema example over a parent example for the same property', () => {
+      const schema: SchemaObject = toJSONSchema({
+        type: 'object',
+        example: { owner: { name: 'from-parent' } },
+        properties: {
+          owner: {
+            type: 'object',
+            example: { name: 'from-owner' },
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        },
+      });
+
+      expect(schema).toStrictEqual({
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', examples: ['from-owner'] },
             },
           },
         },

--- a/packages/oas/test/lib/openapi-to-json-schema/default.test.ts
+++ b/packages/oas/test/lib/openapi-to-json-schema/default.test.ts
@@ -162,10 +162,7 @@ describe('`default` support in `openapi-to-json-schema`', () => {
             type: 'object',
             properties: {
               id: expect.objectContaining({
-                // This should be `4` but our parent `default` determination has the same problem as
-                // `example` determination where if a matching key name exists upwards it'll pick
-                // that.
-                default: 5678,
+                default: 4,
               }),
               name: {
                 type: 'string',

--- a/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
+++ b/packages/oas/test/operation/transformers/get-parameters-as-json-schema.test.ts
@@ -1570,6 +1570,59 @@ describe('.getParametersAsJSONSchema()', () => {
         await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
       });
     });
+
+    describe('request bodies', () => {
+      it('should not give a nested property the example of a shallower property with the same name', async () => {
+        const oas = createOasForOperation({
+          requestBody: {
+            content: {
+              'application/json': {
+                examples: {
+                  example1: {
+                    value: { name: 'John Doe', age: { name: 'test' } },
+                  },
+                },
+                schema: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string' },
+                    age: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'OK',
+            },
+          },
+        });
+
+        const schemas = oas.operation('/', 'get').getParametersAsJSONSchema();
+
+        expect(schemas?.[0].schema).toStrictEqual({
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          type: 'object',
+          properties: {
+            name: { type: 'string', examples: ['John Doe'] },
+            age: {
+              type: 'object',
+              properties: {
+                name: { type: 'string', examples: ['test'] },
+              },
+            },
+          },
+        });
+
+        await expect(schemas?.map(s => s.schema)).toBeValidJSONSchemas();
+      });
+    });
   });
 
   describe('deprecated', () => {


### PR DESCRIPTION
| 🚥 Resolves CX-3897 |
| :------------------- |

## 🧰 Changes

- Previously, a nested property that shared a name with a shallower one took the shallower property's example, so with a request body example of `{ "name": "John Doe", "age": { "name": "test" } }`, `age.name` showed `John Doe`.
- Each property now takes its example from its own path, so `age.name` shows `test`, and `default` values are fixed the same way.

## 🧬 QA & Testing

- Added regression tests
- Tested e2e by npm linking to the monorepo
- Fix also corroborates with existing failing tests that were given temporary values